### PR TITLE
use debug assert

### DIFF
--- a/src/undo_log/undo_log.rs
+++ b/src/undo_log/undo_log.rs
@@ -267,7 +267,7 @@ impl UndoLog {
                             id: -1,
                         };
                         g.create_node(&mut node, labels.as_mut_ptr(), labels.len() as u32);
-                        assert!(*node_id >= node.id);
+                        debug_assert!(*node_id >= node.id);
                         node.attributes.write(*set);
                         gc.add_node_to_indices(&mut node);
                     }
@@ -283,7 +283,7 @@ impl UndoLog {
                             dest_id: *dest_id,
                         };
                         g.create_edge(edge.src_id, edge.dest_id, edge.relation_id, &mut edge);
-                        assert!(*edge_id >= edge.id);
+                        debug_assert!(*edge_id >= edge.id);
                         edge.attributes.write(*set);
                         gc.add_edge_to_indices(&mut edge);
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of internal checks in the undo log functionality by using debug assertions for node and edge ID validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->