### PR TITLE
LazyResultSet implemenation, allowing one-by-one parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { version = "0.1.40", default-features = false, features = ["std", "at
 
 [features]
 default = ["redis"]
+
 native-tls = ["redis/tls-native-tls"]
 rustls = ["redis/tls-rustls"]
 redis = ["dep:redis"]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -283,7 +283,6 @@ impl FalkorSyncClient {
     }
 }
 
-#[cfg(test)]
 pub(crate) fn create_empty_inner_client() -> Arc<FalkorSyncClientInner> {
     let (tx, rx) = mpsc::sync_channel(1);
     tx.send(FalkorSyncConnection::None).ok();
@@ -350,7 +349,7 @@ mod tests {
             .execute()
             .expect("Could not get actors from unmodified graph");
 
-        assert_eq!(res.data.len(), 1317);
+        assert_eq!(res.data.collect::<Vec<_>>().len(), 1317);
     }
 
     #[test]
@@ -374,12 +373,14 @@ mod tests {
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
                 .expect("Could not get actors from unmodified graph")
-                .data,
+                .data
+                .collect::<Vec<_>>(),
             original_graph
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
                 .expect("Could not get actors from unmodified graph")
                 .data
+                .collect::<Vec<_>>()
         )
     }
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -341,7 +341,7 @@ mod tests {
     fn test_select_graph_and_query() {
         let client = create_test_client();
 
-        let mut graph = client.select_graph("imdb");
+        let graph = client.select_graph("imdb");
         assert_eq!(graph.graph_name(), "imdb".to_string());
 
         let res = graph
@@ -361,11 +361,11 @@ mod tests {
         let graph = client.copy_graph("imdb", "imdb_ro_copy");
         assert!(graph.is_ok());
 
-        let mut graph = TestSyncGraphHandle {
+        let graph = TestSyncGraphHandle {
             inner: graph.unwrap(),
         };
 
-        let mut original_graph = client.select_graph("imdb");
+        let original_graph = client.select_graph("imdb");
 
         assert_eq!(
             graph

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -388,9 +388,13 @@ mod tests {
 
     #[test]
     fn test_query() {
-        let mut graph = open_test_graph("test_query_and_lazy_query");
+        let mut graph = open_test_graph("test_query");
         let res = graph.inner.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 10").execute().expect("Could not execute query");
         assert_eq!(res.data.collect::<Vec<_>>().len(), 10);
+
+        let mut res = graph.inner.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 10").execute().expect("Could not execute query");
+        assert!(res.data.next().is_some());
+        assert_eq!(res.data.collect::<Vec<_>>().len(), 9);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use response::{
     execution_plan::ExecutionPlan,
     index::{FalkorIndex, IndexStatus, IndexType},
     slowlog_entry::SlowlogEntry,
-    FalkorResponse, ResultSet,
+    FalkorResponse, LazyResultSet,
 };
 pub use value::{
     config::ConfigValue,

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -3,9 +3,7 @@
  * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::{
-    value::utils::parse_type, FalkorDBError, FalkorResult, FalkorValue, GraphSchema, ResultSet,
-};
+use crate::{FalkorDBError, FalkorResult, FalkorValue};
 
 pub(crate) fn string_vec_from_val(value: FalkorValue) -> FalkorResult<Vec<String>> {
     value.into_vec().map(|value_as_vec| {
@@ -41,20 +39,6 @@ pub(crate) fn parse_header(header: FalkorValue) -> FalkorResult<Vec<String>> {
             }
             .into_string()?,
         )
-    }
-
-    Ok(out_vec)
-}
-
-pub(crate) fn parse_result_set(
-    data: FalkorValue,
-    graph_schema: &mut GraphSchema,
-) -> FalkorResult<ResultSet> {
-    let data_vec = data.into_vec()?;
-
-    let mut out_vec = Vec::with_capacity(data_vec.len());
-    for column in data_vec {
-        out_vec.push(parse_type(6, column, graph_schema)?.into_vec()?);
     }
 
     Ok(out_vec)

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -5,11 +5,13 @@
 
 use crate::{FalkorDBError, FalkorResult, FalkorValue};
 use regex::Regex;
-use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::collections::{HashMap, VecDeque};
-use std::ops::Not;
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+    ops::Not,
+    rc::Rc,
+};
 
 #[derive(Debug)]
 struct IntermediateOperation {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -322,8 +322,7 @@ impl FalkorParsable for FalkorValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
-    use std::f64::consts::PI;
+    use std::{collections::HashMap, f64::consts::PI};
 
     #[test]
     fn test_as_vec() {

--- a/src/value/utils.rs
+++ b/src/value/utils.rs
@@ -64,10 +64,11 @@ pub(crate) fn parse_vec<T: TryFrom<FalkorValue, Error = FalkorDBError>>(
 mod tests {
     use super::*;
     use crate::graph_schema::tests::open_readonly_graph_with_modified_schema;
+    use std::ops::DerefMut;
 
     #[test]
     fn test_parse_edge() {
-        let mut graph = open_readonly_graph_with_modified_schema();
+        let graph = open_readonly_graph_with_modified_schema();
 
         let res = parse_type(
             7,
@@ -89,7 +90,7 @@ mod tests {
                     ]),
                 ]),
             ]),
-            &mut graph.graph_schema,
+            graph.graph_schema.lock().deref_mut(),
         );
         assert!(res.is_ok());
 
@@ -113,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_parse_node() {
-        let mut graph = open_readonly_graph_with_modified_schema();
+        let graph = open_readonly_graph_with_modified_schema();
 
         let res = parse_type(
             8,
@@ -138,7 +139,7 @@ mod tests {
                     ]),
                 ]),
             ]),
-            &mut graph.graph_schema,
+            graph.graph_schema.lock().deref_mut(),
         );
         assert!(res.is_ok());
 
@@ -163,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_parse_path() {
-        let mut graph = open_readonly_graph_with_modified_schema();
+        let graph = open_readonly_graph_with_modified_schema();
 
         let res = parse_type(
             9,
@@ -202,7 +203,7 @@ mod tests {
                     ]),
                 ]),
             ]),
-            &mut graph.graph_schema,
+            graph.graph_schema.lock().deref_mut(),
         );
         assert!(res.is_ok());
 
@@ -229,7 +230,7 @@ mod tests {
 
     #[test]
     fn test_parse_map() {
-        let mut graph = open_readonly_graph_with_modified_schema();
+        let graph = open_readonly_graph_with_modified_schema();
 
         let res = parse_type(
             10,
@@ -244,7 +245,7 @@ mod tests {
                 FalkorValue::String("key2".to_string()),
                 FalkorValue::Array(vec![FalkorValue::I64(4), FalkorValue::Bool(true)]),
             ]),
-            &mut graph.graph_schema,
+            graph.graph_schema.lock().deref_mut(),
         );
         assert!(res.is_ok());
 
@@ -264,12 +265,12 @@ mod tests {
 
     #[test]
     fn test_parse_point() {
-        let mut graph = open_readonly_graph_with_modified_schema();
+        let graph = open_readonly_graph_with_modified_schema();
 
         let res = parse_type(
             11,
             FalkorValue::Array(vec![FalkorValue::F64(102.0), FalkorValue::F64(15.2)]),
-            &mut graph.graph_schema,
+            graph.graph_schema.lock().deref_mut(),
         );
         assert!(res.is_ok());
 


### PR DESCRIPTION
This allows the user to choose their method, either using a collect() on the iterator, or just getting the next element every time until the user has their data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `LazyResultSet` for efficient, on-demand data parsing.
  - Added `native-tls` support for enhanced security.

- **Improvements**
  - Enhanced thread safety with `Arc<Mutex<GraphSchema>>`.
  - Consolidated and optimized import statements for better readability.

- **Bug Fixes**
  - Improved test assertions for data collection.

- **Refactor**
  - Renamed `ResultSet` to `LazyResultSet` throughout the codebase.
  - Updated method signatures and implementations to use `LazyResultSet`.

- **Tests**
  - Modified test cases to use thread-safe access to `graph_schema`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->