### PR TITLE
LazyResultSet implemenation, allowing one-by-one parsing

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -38,5 +38,9 @@ fn main() -> FalkorResult<()> {
 
     cloned_graph.delete()?;
 
+    let res_again = graph.query("MATCH (a:actor) return a").execute()?;
+    let as_vec = res_again.data.collect::<Vec<_>>();
+    assert_eq!(as_vec.len(), 1317);
+
     Ok(())
 }

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -4,6 +4,7 @@
  */
 
 use falkordb::{FalkorClientBuilder, FalkorResult};
+use std::time::Instant;
 
 fn main() -> FalkorResult<()> {
     let client = FalkorClientBuilder::new()
@@ -39,7 +40,9 @@ fn main() -> FalkorResult<()> {
     cloned_graph.delete()?;
 
     let res_again = graph.query("MATCH (a:actor) return a").execute()?;
+    let time = Instant::now();
     let as_vec = res_again.data.collect::<Vec<_>>();
+    println!("{}", time.elapsed().as_micros());
     assert_eq!(as_vec.len(), 1317);
 
     Ok(())

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -4,7 +4,6 @@
  */
 
 use falkordb::{FalkorClientBuilder, FalkorResult};
-use std::time::Instant;
 
 fn main() -> FalkorResult<()> {
     let client = FalkorClientBuilder::new()
@@ -40,9 +39,7 @@ fn main() -> FalkorResult<()> {
     cloned_graph.delete()?;
 
     let res_again = graph.query("MATCH (a:actor) return a").execute()?;
-    let time = Instant::now();
     let as_vec = res_again.data.collect::<Vec<_>>();
-    println!("{}", time.elapsed().as_micros());
     assert_eq!(as_vec.len(), 1317);
 
     Ok(())

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+use falkordb::{FalkorClientBuilder, FalkorResult};
+
+fn main() -> FalkorResult<()> {
+    let client = FalkorClientBuilder::new()
+        .with_connection_info("falkor://127.0.0.1:6379".try_into()?)
+        .build()?;
+
+    // Dataset is available in the 'resources' directory
+    let mut graph = client.select_graph("imdb");
+
+    let mut cloned_graph = client.copy_graph("imdb", "imdb_clone")?;
+
+    let mut res = graph.query("MATCH (a:actor) return a").execute()?;
+    let mut clone_graph_res = cloned_graph.query("MATCH (a:actor) return a").execute()?;
+
+    // Parses them one by one, to avoid unneeded performance hits
+    assert_eq!(res.data.len(), 1317);
+    assert_eq!(clone_graph_res.data.len(), 1317);
+    if let (Some(orig), Some(cloned)) = (res.data.next(), clone_graph_res.data.next()) {
+        println!("Original one: {orig:?}, Cloned one: {cloned:?}");
+        assert_eq!(orig, cloned);
+    }
+
+    // We have already parsed one result
+    assert_eq!(res.data.len(), 1316);
+    assert_eq!(clone_graph_res.data.len(), 1316);
+
+    // more iterator usage:
+    for (orig, cloned) in res.data.zip(clone_graph_res.data) {
+        println!("Original one: {orig:?}, Cloned one: {cloned:?}");
+        assert_eq!(orig, cloned);
+    }
+
+    cloned_graph.delete()?;
+
+    Ok(())
+}

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -350,7 +350,7 @@ mod tests {
             .execute()
             .expect("Could not get actors from unmodified graph");
 
-        assert_eq!(res.data.len(), 1317);
+        assert_eq!(res.data.collect::<Vec<_>>().len(), 1317);
     }
 
     #[test]
@@ -374,12 +374,14 @@ mod tests {
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
                 .expect("Could not get actors from unmodified graph")
-                .data,
+                .data
+                .collect::<Vec<_>>(),
             original_graph
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
                 .expect("Could not get actors from unmodified graph")
                 .data
+                .collect::<Vec<_>>()
         )
     }
 

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -78,7 +78,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`QueryBuilder`] for this graph, in an attempt to profile a specific query
-    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     ///
     /// # Arguments
     /// * `query_string`: The query to profile
@@ -93,7 +93,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`QueryBuilder`] for this graph, in an attempt to explain a specific query
-    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     ///
     /// # Arguments
     /// * `query_string`: The query to explain the process for
@@ -108,7 +108,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`QueryBuilder`] for this graph
-    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     ///
     /// # Arguments
     /// * `query_string`: The query to run
@@ -123,7 +123,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`QueryBuilder`] for this graph, for a readonly query
-    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`QueryBuilder`] has to be dropped or ran using [`QueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     /// Read-only queries are more limited with the operations they are allowed to perform.
     ///
     /// # Arguments
@@ -139,7 +139,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph
-    /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     /// Read-only queries are more limited with the operations they are allowed to perform.
     ///
     /// # Arguments
@@ -155,7 +155,7 @@ impl SyncGraph {
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph, for a readonly procedure
-    /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::perform`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
+    /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     /// Read-only procedures are more limited with the operations they are allowed to perform.
     ///
     /// # Arguments

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -5,8 +5,8 @@
 
 use crate::{
     client::blocking::FalkorSyncClientInner, Constraint, ConstraintType, EntityType, ExecutionPlan,
-    FalkorIndex, FalkorResponse, FalkorResult, FalkorValue, GraphSchema, IndexType,
-    ProcedureQueryBuilder, QueryBuilder, ResultSet, SlowlogEntry,
+    FalkorIndex, FalkorResponse, FalkorResult, FalkorValue, GraphSchema, IndexType, LazyResultSet,
+    ProcedureQueryBuilder, QueryBuilder, SlowlogEntry,
 };
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
@@ -88,7 +88,7 @@ impl SyncGraph {
     pub fn profile<'a>(
         &'a mut self,
         query_string: &'a str,
-    ) -> QueryBuilder<ExecutionPlan> {
+    ) -> QueryBuilder<ExecutionPlan, &str> {
         QueryBuilder::<'a>::new(self, "GRAPH.PROFILE", query_string)
     }
 
@@ -103,7 +103,7 @@ impl SyncGraph {
     pub fn explain<'a>(
         &'a mut self,
         query_string: &'a str,
-    ) -> QueryBuilder<ExecutionPlan> {
+    ) -> QueryBuilder<ExecutionPlan, &str> {
         QueryBuilder::new(self, "GRAPH.EXPLAIN", query_string)
     }
 
@@ -115,10 +115,10 @@ impl SyncGraph {
     ///
     /// # Returns
     /// A [`QueryBuilder`] object, which when performed will return a [`FalkorResponse<FalkorResultSet>`]
-    pub fn query<'a>(
-        &'a mut self,
-        query_string: &'a str,
-    ) -> QueryBuilder<FalkorResponse<ResultSet>> {
+    pub fn query<T: Display>(
+        &mut self,
+        query_string: T,
+    ) -> QueryBuilder<FalkorResponse<LazyResultSet>, T> {
         QueryBuilder::new(self, "GRAPH.QUERY", query_string)
     }
 
@@ -134,7 +134,7 @@ impl SyncGraph {
     pub fn ro_query<'a>(
         &'a mut self,
         query_string: &'a str,
-    ) -> QueryBuilder<FalkorResponse<ResultSet>> {
+    ) -> QueryBuilder<FalkorResponse<LazyResultSet>, &str> {
         QueryBuilder::new(self, "GRAPH.QUERY_RO", query_string)
     }
 
@@ -188,7 +188,7 @@ impl SyncGraph {
     /// * `options`:
     ///
     /// # Returns
-    /// A [`ResultSet`] containing information on the created index
+    /// A [`LazyResultSet`] containing information on the created index
     pub fn create_index<P: Display>(
         &mut self,
         index_field_type: IndexType,
@@ -196,7 +196,7 @@ impl SyncGraph {
         label: &str,
         properties: &[P],
         options: Option<&HashMap<String, String>>,
-    ) -> FalkorResult<FalkorResponse<ResultSet>> {
+    ) -> FalkorResult<FalkorResponse<LazyResultSet>> {
         // Create index from these properties
         let properties_string = properties
             .iter()
@@ -226,14 +226,12 @@ impl SyncGraph {
             .map(|options_string| format!(" OPTIONS {{ {} }}", options_string))
             .unwrap_or_default();
 
-        self.query(
-            format!(
-                "CREATE {idx_type}INDEX FOR {pattern} ON ({}){}",
-                properties_string, options_string
-            )
-            .as_str(),
-        )
-        .execute()
+        let query_str = format!(
+            "CREATE {idx_type}INDEX FOR {pattern} ON ({}){}",
+            properties_string, options_string
+        );
+        QueryBuilder::<FalkorResponse<LazyResultSet>, String>::new(self, "GRAPH.QUERY", query_str)
+            .execute()
     }
 
     /// Drop an existing index, by specifying its type, entity, label and specific properties
@@ -246,7 +244,7 @@ impl SyncGraph {
         entity_type: EntityType,
         label: L,
         properties: &[P],
-    ) -> FalkorResult<FalkorResponse<ResultSet>> {
+    ) -> FalkorResult<FalkorResponse<LazyResultSet>> {
         let properties_string = properties
             .iter()
             .map(|element| format!("e.{}", element.to_string()))
@@ -265,14 +263,11 @@ impl SyncGraph {
         }
         .to_string();
 
-        self.query(
-            format!(
-                "DROP {idx_type} INDEX for {pattern} ON ({})",
-                properties_string
-            )
-            .as_str(),
-        )
-        .execute()
+        let query_str = format!(
+            "DROP {idx_type} INDEX for {pattern} ON ({})",
+            properties_string
+        );
+        self.query(query_str).execute()
     }
 
     /// Calls the DB.CONSTRAINTS procedure on the graph, returning an array of the graph's constraints

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -120,7 +120,7 @@ impl<'a, T: Display> QueryBuilder<'a, FalkorResponse<LazyResultSet<'a>>, T> {
 
                 FalkorResponse::from_response(
                     None,
-                    LazyResultSet::new(Default::default(), self.graph),
+                    LazyResultSet::new(Default::default(), &mut self.graph.graph_schema),
                     stats,
                 )
             }
@@ -133,7 +133,7 @@ impl<'a, T: Display> QueryBuilder<'a, FalkorResponse<LazyResultSet<'a>>, T> {
 
                 FalkorResponse::from_response(
                     Some(header),
-                    LazyResultSet::new(Default::default(), self.graph),
+                    LazyResultSet::new(Default::default(), &mut self.graph.graph_schema),
                     stats,
                 )
             }
@@ -146,7 +146,7 @@ impl<'a, T: Display> QueryBuilder<'a, FalkorResponse<LazyResultSet<'a>>, T> {
 
                 FalkorResponse::from_response(
                     Some(header),
-                    LazyResultSet::new(data.into_vec()?, self.graph),
+                    LazyResultSet::new(data.into_vec()?, &mut self.graph.graph_schema),
                     stats,
                 )
             }
@@ -281,7 +281,7 @@ impl<'a, Output> ProcedureQueryBuilder<'a, Output> {
 
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
-        let query = construct_query(&query_string, params.as_ref());
+        let query = construct_query(query_string, params.as_ref());
 
         conn.execute_command(
             Some(self.graph.graph_name()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use response::{
     execution_plan::ExecutionPlan,
     index::{FalkorIndex, IndexStatus, IndexType},
     slowlog_entry::SlowlogEntry,
-    FalkorResponse, ResultSet,
+    FalkorResponse, LazyResultSet,
 };
 pub use value::{
     config::ConfigValue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
  */
 
 #![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(not(feature = "redis"))]
@@ -38,8 +39,9 @@ pub use response::{
     constraint::{Constraint, ConstraintStatus, ConstraintType},
     execution_plan::ExecutionPlan,
     index::{FalkorIndex, IndexStatus, IndexType},
+    lazy_result_set::LazyResultSet,
     slowlog_entry::SlowlogEntry,
-    FalkorResponse, LazyResultSet,
+    FalkorResponse,
 };
 pub use value::{
     config::ConfigValue,

--- a/src/parser/utils.rs
+++ b/src/parser/utils.rs
@@ -3,9 +3,7 @@
  * Licensed under the Server Side Public License v1 (SSPLv1).
  */
 
-use crate::{
-    value::utils::parse_type, FalkorDBError, FalkorResult, FalkorValue, GraphSchema, ResultSet,
-};
+use crate::{FalkorDBError, FalkorResult, FalkorValue};
 
 pub(crate) fn string_vec_from_val(value: FalkorValue) -> FalkorResult<Vec<String>> {
     value.into_vec().map(|value_as_vec| {
@@ -41,20 +39,6 @@ pub(crate) fn parse_header(header: FalkorValue) -> FalkorResult<Vec<String>> {
             }
             .into_string()?,
         )
-    }
-
-    Ok(out_vec)
-}
-
-pub(crate) fn parse_result_set(
-    data: FalkorValue,
-    graph_schema: &mut GraphSchema,
-) -> FalkorResult<ResultSet> {
-    let data_vec = data.into_vec()?;
-
-    let mut out_vec = Vec::with_capacity(data_vec.len());
-    for column in data_vec {
-        out_vec.push(parse_type(6, column, graph_schema)?.into_vec()?);
     }
 
     Ok(out_vec)

--- a/src/response/lazy_result_set.rs
+++ b/src/response/lazy_result_set.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the Server Side Public License v1 (SSPLv1).
+ */
+
+use crate::{value::utils::parse_type, FalkorValue, GraphSchema};
+use std::collections::VecDeque;
+
+/// A wrapper around the returned raw data, allowing parsing on demand of each result
+/// This implements Iterator, so can simply be collect()'ed into any desired container
+pub struct LazyResultSet<'a> {
+    data: VecDeque<FalkorValue>,
+    graph_schema: &'a mut GraphSchema,
+}
+
+impl<'a> LazyResultSet<'a> {
+    pub(crate) fn new(
+        data: Vec<FalkorValue>,
+        graph_schema: &'a mut GraphSchema,
+    ) -> Self {
+        Self {
+            data: data.into(),
+            graph_schema,
+        }
+    }
+
+    /// Returns the remaining rows in the result set.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns whether this result set is empty or depleted
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl<'a> Iterator for LazyResultSet<'a> {
+    type Item = Vec<FalkorValue>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.data.pop_front().map(|current_result| {
+            parse_type(6, current_result, self.graph_schema)
+                .and_then(|parsed_result| parsed_result.into_vec())
+                .unwrap_or(vec![FalkorValue::Unparseable])
+        })
+    }
+}

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -5,56 +5,14 @@
 
 use crate::{
     parser::utils::{parse_header, string_vec_from_val},
-    value::utils::parse_type,
-    FalkorDBError, FalkorParsable, FalkorResult, FalkorValue, GraphSchema, SyncGraph,
+    FalkorDBError, FalkorParsable, FalkorResult, FalkorValue, GraphSchema,
 };
-use std::collections::VecDeque;
 
 pub(crate) mod constraint;
 pub(crate) mod execution_plan;
 pub(crate) mod index;
+pub(crate) mod lazy_result_set;
 pub(crate) mod slowlog_entry;
-
-/// A wrapper around the returned raw data, allowing parsing on demand of each result
-/// This implements Iterator, so can simply be collect()'ed into any desired container
-pub struct LazyResultSet<'a> {
-    data: VecDeque<FalkorValue>,
-    graph: &'a mut SyncGraph,
-}
-
-impl<'a> LazyResultSet<'a> {
-    pub(crate) fn new(
-        data: Vec<FalkorValue>,
-        graph: &'a mut SyncGraph,
-    ) -> Self {
-        Self {
-            data: data.into(),
-            graph,
-        }
-    }
-
-    /// Returns the remaining rows in the result set.
-    pub fn len(&self) -> usize {
-        self.data.len()
-    }
-
-    /// Returns whether this result set is empty or depleted
-    pub fn is_empty(&self) -> bool {
-        self.data.is_empty()
-    }
-}
-
-impl<'a> Iterator for LazyResultSet<'a> {
-    type Item = Vec<FalkorValue>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.data.pop_front().map(|current_result| {
-            parse_type(6, current_result, &mut self.graph.graph_schema)
-                .and_then(|parsed_result| parsed_result.into_vec())
-                .unwrap_or(vec![FalkorValue::Unparseable])
-        })
-    }
-}
 
 /// A response struct which also contains the returned header and stats data
 #[derive(Clone, Debug, Default)]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -41,6 +41,8 @@ pub enum FalkorValue {
     Path(Path),
     /// A NULL type
     None,
+    /// Failed parsing this value
+    Unparseable,
 }
 
 macro_rules! impl_to_falkordb_value {


### PR DESCRIPTION
This allows the user to choose their method, either using a collect() on the iterator, or just getting the next element every time until the user has their data.
Also, during benching some functions, moved some of them to closures to optimize in debug builds.

* Added a more in depth example the user can run, showing the capabilities of the LazyResultSet