### PR TITLE
add support with the new vec32

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Populate test graph
-        run: pip install falkordb && ./resources/populate_graph.py
+        run:  pip install falkordb && ./resources/populate_graph.py
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
       - name: Generate Code Coverage
-        run: cargo llvm-cov nextest --all --features tokio --codecov --output-path codecov.json
+        run:  cargo llvm-cov nextest --all --features tokio --codecov --output-path codecov.json
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +153,7 @@ dependencies = [
 name = "falkordb"
 version = "0.1.5"
 dependencies = [
+ "approx",
  "parking_lot",
  "redis",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ thiserror = "1.0.63"
 tokio = { version = "1.39.2", default-features = false, features = ["macros", "sync", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"], optional = true }
 
+[dev-dependencies]
+approx = "0.5.1"
+
 [features]
 default = []
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let nodes = graph.query("UNWIND range(0, 100) AS i CREATE (n { v:1 }) RETURN n L
 .with_timeout(5000).execute().expect("Failed executing query");
 
 // Can also be collected, like any other iterator
-while let Some(node) = nodes.next() {
+while let Some(node) = nodes.data.next() {
 println ! ("{:?}", node);
 }
 ```
@@ -94,7 +94,7 @@ let nodes = graph.query("UNWIND range(0, 100) AS i CREATE (n { v:1 }) RETURN n L
 .with_timeout(5000).execute().await.expect("Failed executing query");
 
 // Graph operations are asynchronous, but parsing is still concurrent:
-while let Some(node) = nodes.next() {
+while let Some(node) = nodes.data.next() {
 println ! ("{:?}", node);
 }
 ```

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -300,13 +300,13 @@ mod tests {
         graph
             .query("CREATE (p:Document {embedding: vecf32([2.1, 0.82, 1.3]), id: '1'})")
             .execute()
-            .expect("Could create document with embedding");
+            .expect("Could not create document with embedding");
         let mut res: QueryResult<LazyResultSet> = graph
             .query("MATCH (p:Document) RETURN p")
             .execute()
             .expect("Could not get document");
         while let Some(falkor_value) = res.data.next() {
-            // iterate on value that is a node
+            // iterate on a node value
             for value in falkor_value {
                 if let Node(node) = value {
                     if let FalkorValue::Vec32(embedding) = &node.properties["embedding"] {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -76,6 +76,12 @@ pub enum FalkorDBError {
     /// Element was not of type F64.
     #[error("Element was not of type F64")]
     ParsingF64,
+    /// Element was not of type F32.
+    #[error("Element was not of type F32")]
+    ParsingF32,
+    /// Element was not of type Vec32.
+    #[error("Element was not of type Vec32")]
+    ParsingVec32,
     /// Element was not of type Array.
     #[error("Element was not of type Array")]
     ParsingArray,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -80,8 +80,8 @@ pub enum FalkorDBError {
     #[error("Element was not of type F32")]
     ParsingF32,
     /// Element was not of type Vec32.
-    #[error("Element was not of type Vec32")]
-    ParsingVec32,
+    #[error("Element was not of type Vec32: {0}")]
+    ParsingVec32(String),
     /// Element was not of type Array.
     #[error("Element was not of type Array")]
     ParsingArray,

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -435,6 +435,9 @@ mod tests {
             vec![IndexType::Fulltext]
         );
 
+        assert_eq!(indices.data[0].fields.len(), 1);
+        assert_eq!(indices.data[0].fields[0], "Hello");
+
         graph
             .inner
             .drop_index(IndexType::Fulltext, EntityType::Node, "actor", &["Hello"])

--- a/src/response/index.rs
+++ b/src/response/index.rs
@@ -96,6 +96,8 @@ pub struct FalkorIndex {
     pub status: IndexStatus,
     /// What is this index's label
     pub index_label: String,
+    /// What fields to index by
+    pub fields: Vec<String>,
     /// Whether each field is a text field, range, etc.
     pub field_types: HashMap<String, Vec<IndexType>>,
     /// Which language is the text used to index in
@@ -117,9 +119,7 @@ impl SchemaParsable for FalkorIndex {
         value: redis::Value,
         graph_schema: &mut GraphSchema,
     ) -> Result<Self, FalkorDBError> {
-        // properties are ignored because we deliver then in field_types and the keys of the map
-        // where the value is the index type
-        let [label, _properties, field_types, options, language, stopwords, entity_type, status, info] =
+        let [label, fields, field_types, options, language, stopwords, entity_type, status, info] =
             redis_value_as_vec(value).and_then(|as_vec| {
                 as_vec.try_into().map_err(|_| {
                     FalkorDBError::ParsingArrayToStructElementCount(
@@ -132,6 +132,7 @@ impl SchemaParsable for FalkorIndex {
             entity_type: parse_falkor_enum(entity_type)?,
             status: parse_falkor_enum(status)?,
             index_label: redis_value_as_typed_string(label)?,
+            fields: parse_string_array(fields, graph_schema)?,
             field_types: parse_types_map(field_types)?,
             language: redis_value_as_typed_string(language)?,
             stopwords: parse_string_array(stopwords, graph_schema)?,

--- a/src/response/index.rs
+++ b/src/response/index.rs
@@ -123,7 +123,7 @@ impl SchemaParsable for FalkorIndex {
             redis_value_as_vec(value).and_then(|as_vec| {
                 as_vec.try_into().map_err(|_| {
                     FalkorDBError::ParsingArrayToStructElementCount(
-                        "Expected exactly 8 elements in index object",
+                        "Expected exactly 9 elements in index object",
                     )
                 })
             })?;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -8,11 +8,13 @@ use graph_entities::{Edge, Node};
 use path::Path;
 use point::Point;
 use std::{collections::HashMap, fmt::Debug};
+use vec32::Vec32;
 
 pub(crate) mod config;
 pub(crate) mod graph_entities;
 pub(crate) mod path;
 pub(crate) mod point;
+pub(crate) mod vec32;
 
 /// An enum of all the supported Falkor types
 #[derive(Clone, Debug, PartialEq)]
@@ -25,6 +27,8 @@ pub enum FalkorValue {
     Array(Vec<FalkorValue>),
     /// A [`HashMap`] of [`String`] as keys, and other [`FalkorValue`] as values
     Map(HashMap<String, FalkorValue>),
+    /// A vector of float values used for vector search see [`Vec32`]
+    Vec32(Vec32),
     /// Plain old string
     String(String),
     /// A boolean value

--- a/src/value/vec32.rs
+++ b/src/value/vec32.rs
@@ -77,4 +77,12 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), FalkorDBError::ParsingF32);
     }
+
+    #[test]
+    fn test_parse_empty_vec32() {
+        let value = redis::Value::Array(vec![]);
+        let result = Vec32::parse(value);
+        assert!(result.is_ok());
+        assert!(result.unwrap().values.is_empty());
+    }
 }

--- a/src/value/vec32.rs
+++ b/src/value/vec32.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+use crate::{
+    parser::{redis_value_as_float, redis_value_as_vec},
+    FalkorDBError::ParsingVec32,
+    FalkorResult,
+};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Vec32 {
+    /// The values of the vector
+    pub values: Vec<f32>,
+}
+
+impl Vec32 {
+    /// Parses a Vec32 from a redis::Value::Array,
+    /// # Arguments
+    /// * `value`: The value to parse
+    ///
+    /// # Returns
+    /// Self, if successful
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Parse Vec32", skip_all, level = "trace")
+    )]
+    pub fn parse(value: redis::Value) -> FalkorResult<Vec32> {
+        let values: Vec<redis::Value> = redis_value_as_vec(value).map_err(|_| ParsingVec32)?;
+
+        let mut vec32 = Vec32 {
+            values: Vec::with_capacity(values.len()),
+        };
+
+        for val in values {
+            vec32.values.push(redis_value_as_float(val)?);
+        }
+
+        Ok(vec32)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FalkorDBError;
+
+    #[test]
+    fn test_parse_valid_vec32() {
+        let value = redis::Value::Array(vec![
+            redis::Value::SimpleString("45.0".to_string()),
+            redis::Value::SimpleString("90.0".to_string()),
+        ]);
+        let result = Vec32::parse(value);
+        assert!(result.is_ok());
+        let vec = result.unwrap().values;
+        assert_eq!(vec.len(), 2);
+        assert_eq!(vec[0], 45.0);
+        assert_eq!(vec[1], 90.0);
+    }
+
+    #[test]
+    fn test_parse_invalid_vec32_not_an_array() {
+        let value = redis::Value::SimpleString("not an array".to_string());
+        let result = Vec32::parse(value);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), FalkorDBError::ParsingVec32);
+    }
+
+    #[test]
+    fn test_parse_invalid_vec32_invalid_elements() {
+        let value = redis::Value::Array(vec![
+            redis::Value::SimpleString("45.0".to_string()),
+            redis::Value::SimpleString("not a number".to_string()),
+        ]);
+        let result = Vec32::parse(value);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), FalkorDBError::ParsingF32);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new `Vec32` struct for handling vectors of 32-bit floating-point values.
  - Added support for new error handling variants: `ParsingF32` and `ParsingVec32`.
  - Enhanced parsing capabilities with the addition of `redis_value_as_float` and updates to the `ParserTypeMarker` enum.
  - Added a new function to parse string arrays from Redis values.
  - Enhanced index and constraint management functionalities within the graph API.

- **Documentation**
  - Updated code examples in the README to reflect changes in method calls and data handling.

- **Tests**
  - Expanded test suite with new tests for vector data handling and parsing functionalities.
  - Added tests to validate index creation, constraint management, and slowlog functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->