### PR TITLE
fix read only query builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,18 +1048,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = { version = "0.12.3", default-features = false, features = ["deadl
 redis = { version = "0.27.6", default-features = false, features = ["sentinel"] }
 regex = { version = "1.11.1", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
 strum = { version = "0.26.3", default-features = false, features = ["std", "derive"] }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", default-features = false, features = ["macros", "sync", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.41", default-features = false, features = ["std", "attributes"], optional = true }
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Just add it to your `Cargo.toml`, like so:
 
 ```toml
-falkordb = { version = "0.1.9" }
+falkordb = { version = "0.1.10" }
 ```
 
 ### Run FalkorDB instance
@@ -69,7 +69,7 @@ This client supports nonblocking API using the [`tokio`](https://tokio.rs/) runt
 It can be enabled like so:
 
 ```toml
-falkordb = { version = "0.1.9", features = ["tokio"] }
+falkordb = { version = "0.1.10", features = ["tokio"] }
 ```
 
 Currently, this API requires running within a [
@@ -123,21 +123,21 @@ when using tokio: `"tokio-rustls"`/`"tokio-native-tls"`).
 For Rustls:
 
 ```toml
-falkordb = { version = "0.1.9", features = ["rustls"] }
+falkordb = { version = "0.1.10", features = ["rustls"] }
 ```
 
 ```toml
-falkordb = { version = "0.1.9", features = ["tokio-rustls"] }
+falkordb = { version = "0.1.10", features = ["tokio-rustls"] }
 ```
 
 For Native TLS:
 
 ```toml
-falkordb = { version = "0.1.9", features = ["native-tls"] }
+falkordb = { version = "0.1.10", features = ["native-tls"] }
 ```
 
 ```toml
-falkordb = { version = "0.1.9", features = ["tokio-native-tls"] }
+falkordb = { version = "0.1.10", features = ["tokio-native-tls"] }
 ```
 
 ### Tracing
@@ -146,7 +146,7 @@ This crate fully supports instrumentation using the [`tracing`](https://docs.rs/
 it, simply, enable the `tracing` feature:
 
 ```toml
-falkordb = { version = "0.1.9", features = ["tracing"] }
+falkordb = { version = "0.1.10", features = ["tracing"] }
 ```
 
 Note that different functions use different filtration levels, to avoid spamming your tests, be sure to enable the

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -111,7 +111,7 @@ impl FalkorSyncClient {
         })
     }
 
-    ///
+
     ///  Get the max number of connections in the client's connection pool
     pub fn connection_pool_size(&self) -> u8 {
         self.inner.connection_pool_size

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -302,19 +302,21 @@ mod tests {
             .query("CREATE (n:Person {name: 'John Doe', age: 30})")
             .execute()
             .expect("Could not create John");
+
+        // test ro_query with a read query
         graph
             .ro_query("MATCH (n:Person {name: 'John Doe', age: 30}) RETURN n")
             .execute()
             .expect("Could not read John");
+
+        // test ro_query with a write query
         let result = graph
             .ro_query("CREATE (n:Person {name: 'John Doe', age: 30})")
             .execute();
-
         assert!(
             result.is_err(),
             "Expected an error for write operation in read-only query"
         );
-
         if let Err(e) = result {
             assert!(
                 e.to_string()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -111,7 +111,8 @@ impl FalkorSyncClient {
         })
     }
 
-    /// Get the max number of connections in the client's connection pool
+    ///
+    ///  Get the max number of connections in the client's connection pool
     pub fn connection_pool_size(&self) -> u8 {
         self.inner.connection_pool_size
     }
@@ -138,7 +139,7 @@ impl FalkorSyncClient {
     ///
     /// # Arguments
     /// * `config_Key`: A [`String`] representation of a configuration's key.
-    /// The config key can also be "*", which will return ALL the configuration options.
+    ///    The config key can also be "*", which will return ALL the configuration options.
     ///
     /// # Returns
     /// A [`HashMap`] comprised of [`String`] keys, and [`ConfigValue`] values.
@@ -161,7 +162,7 @@ impl FalkorSyncClient {
     ///
     /// # Arguments
     /// * `config_Key`: A [`String`] representation of a configuration's key.
-    /// The config key can also be "*", which will return ALL the configuration options.
+    ///    The config key can also be "*", which will return ALL the configuration options.
     /// * `value`: The new value to set, which is anything that can be converted into a [`ConfigValue`], namely string types and i64.
     #[cfg_attr(
         feature = "tracing",

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -163,7 +163,7 @@ impl AsyncGraph {
         &'a mut self,
         query_string: &'a str,
     ) -> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, &'a str, Self> {
-        QueryBuilder::new(self, "GRAPH.QUERY_RO", query_string)
+        QueryBuilder::new(self, "GRAPH.RO_QUERY", query_string)
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -157,7 +157,7 @@ impl SyncGraph {
         &'a mut self,
         query_string: &'a str,
     ) -> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, &'a str, Self> {
-        QueryBuilder::new(self, "GRAPH.QUERY_RO", query_string)
+        QueryBuilder::new(self, "GRAPH.RO_QUERY", query_string)
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph

--- a/src/response/index.rs
+++ b/src/response/index.rs
@@ -50,7 +50,6 @@ fn parse_string_array(
         vector
             .into_iter()
             .map(FalkorValue::into_string)
-            .into_iter()
             .collect::<Result<Vec<String>, FalkorDBError>>()
     })
 }

--- a/src/response/lazy_result_set.rs
+++ b/src/response/lazy_result_set.rs
@@ -36,7 +36,7 @@ impl<'a> LazyResultSet<'a> {
     }
 }
 
-impl<'a> Iterator for LazyResultSet<'a> {
+impl Iterator for LazyResultSet<'_> {
     type Item = Vec<FalkorValue>;
 
     #[cfg_attr(


### PR DESCRIPTION
Fix clippy warnings
Update version on readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version number for `falkordb` crate to `0.1.10` in documentation.

- **Documentation**
	- Improved clarity and formatting of documentation comments across various methods.
	- Expanded documentation for the `with_timeout` method in `QueryBuilder`.

- **Bug Fixes**
	- Simplified control flow in the `parse_string_array` function by removing unnecessary iterations.

- **Refactor**
	- Adjusted lifetime parameters in `LazyResultSet` for improved flexibility.
	- Updated command strings for read-only queries to align with new naming conventions in multiple components.
	- Simplified implementation of `QueryBuilder` and `ProcedureQueryBuilder` by removing explicit lifetime annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->