### PR TITLE
build(deps): combine all Dependabot dependency updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: ${{ matrix.language }}
       env:
@@ -38,4 +38,4 @@ jobs:
         cargo build --all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
         with:
           command: check bans licenses sources
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2
         with:
           command: check bans licenses sources
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e41a79ae5cbb41257d84cf4cf0db0bb5a95b11bf05c62c351de4fe748620d"
+checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
 dependencies = [
  "arcstr",
  "async-lock",
@@ -975,18 +975,18 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "libc",
  "mio",
@@ -1081,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ all-features = true
 
 [dependencies]
 parking_lot = { version = "0.12.5", default-features = false }
-redis = { version = "1.0.3", default-features = false, features = ["sentinel"] }
+redis = { version = "1.2.0", default-features = false, features = ["sentinel"] }
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
-strum = { version = "0.27.2", default-features = false, features = ["std", "derive"] }
+strum = { version = "0.28.0", default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.45.1", default-features = false, features = ["macros", "sync", "rt-multi-thread"], optional = true }
+tokio = { version = "1.51.1", default-features = false, features = ["macros", "sync", "rt-multi-thread"], optional = true }
 tracing = { version = "0.1.44", default-features = false, features = ["std", "attributes"], optional = true }
 which = { version = "8.0", optional = true }
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -138,7 +138,7 @@ impl FalkorSyncClient {
     ///
     /// # Arguments
     /// * `config_Key`: A [`String`] representation of a configuration's key.
-    ///    The config key can also be "*", which will return ALL the configuration options.
+    ///   The config key can also be "*", which will return ALL the configuration options.
     ///
     /// # Returns
     /// A [`HashMap`] comprised of [`String`] keys, and [`ConfigValue`] values.
@@ -161,7 +161,7 @@ impl FalkorSyncClient {
     ///
     /// # Arguments
     /// * `config_Key`: A [`String`] representation of a configuration's key.
-    ///    The config key can also be "*", which will return ALL the configuration options.
+    ///   The config key can also be "*", which will return ALL the configuration options.
     /// * `value`: The new value to set, which is anything that can be converted into a [`ConfigValue`], namely string types and i64.
     #[cfg_attr(
         feature = "tracing",


### PR DESCRIPTION
## Combined Dependency Updates

Combines the following Dependabot PRs into a single update:

### Cargo dependency updates
- `redis`: 1.0.3 → 1.2.0 (closes #181)
- `strum`: 0.27.2 → 0.28.0 (closes #182)
- `tokio`: 1.45.1 → 1.51.1 (closes #185)
- `rand`: 0.9.2 → 0.9.4 (closes #186)

### GitHub Actions updates
- `actions/checkout`: v4 → v6 in codeql.yml (closes #179)
- `github/codeql-action`: v3 → v4 (closes #187)
- `EmbarkStudios/cargo-deny-action`: 2.0.15 → 2.0.17 (closes #188)

### Additional fixes
- Fix doc over-indentation clippy warnings in `src/client/blocking.rs`
- Update codeql-action version comment tag from v3 to v4

### Verification
- `cargo clippy --all-features` — 0 warnings
- `cargo build --all-features` — success
- `cargo fmt --all --check` — pass
- `cargo doc --all` — success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to latest versions for improved security and stability
  * Upgraded core dependencies including redis, strum, and tokio to their latest stable versions

* **Documentation**
  * Refined documentation formatting and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->