### PR TITLE
build(deps): combine cargo-deny-action 2.0.20 and redis 1.2.2 updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check bans licenses sources
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
         with:
           command: check bans licenses sources
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
+checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
 dependencies = [
  "arcstr",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 
 [dependencies]
 parking_lot = { version = "0.12.5", default-features = false }
-redis = { version = "1.2.1", default-features = false, features = ["sentinel"] }
+redis = { version = "1.2.2", default-features = false, features = ["sentinel"] }
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
 strum = { version = "0.28.0", default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.18"


### PR DESCRIPTION
Combines two Dependabot dependency updates into a single PR.

## Updates
- **EmbarkStudios/cargo-deny-action**: 2.0.19 → 2.0.20 (SHA-pinned, `# v2`) — supersedes #205
- **redis**: 1.2.1 → 1.2.2 — supersedes #196

## Verification
- SHA `bb137d7af7e4fb67e5f82a49c4fce4fad40782fe` corresponds to upstream tag `v2.0.20`.
- `redis 1.2.2` lockfile checksum matches the crates.io index entry (not yanked).
- Local checks pass: `cargo build`, `cargo fmt --check`, `cargo clippy --all`, `cargo doc --all`, `cargo deny check bans licenses sources`.

Closes #205
Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis dependency to version 1.2.2
  * Updated CI/CD workflow action versions to latest pinned revisions for improved reliability and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->