### PR TITLE
build(deps): combine dependabot bumps (codecov-action 7.0.0, which 8.0.3)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,7 +67,7 @@ jobs:
         run: cargo llvm-cov nextest --all --features tokio,embedded --codecov --output-path codecov.json
       
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: codecov.json
           fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "c789537cf2f7f55be8e6192f92e464174ee55f91af622777f7f1ceb0dbccd03e"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Combines the following dependabot PRs into one:

- #212 bump codecov/codecov-action from 6.0.1 to 7.0.0
- #210 bump which from 8.0.2 to 8.0.3

## Verification
- `cargo build --all-features` passes
- `cargo fmt --all --check` passes
- `cargo clippy` / `cargo clippy --all` pass (only a pre-existing unrelated warning)
- codecov-action SHA `fb8b3582c8e4def4969c97caa2f19720cb33a72f` verified as the official v7.0.0 tag
- `which` 8.0.3 checksum verified

Closes #212
Closes #210

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality assurance tooling to the latest version to enhance reporting accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->