### PR TITLE
Fix flaky test_copy_graph and make embedded tests pass on macOS

### DIFF
--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -374,7 +374,7 @@ impl FalkorAsyncClient {
 mod tests {
     use super::*;
     use crate::{
-        test_utils::{create_async_test_client, retry_until_async_fn},
+        test_utils::{create_async_test_client, retry_until_async_fn, TestAsyncGraphHandle},
         FalkorClientBuilder,
     };
     use std::{mem, num::NonZeroU8, thread};
@@ -444,6 +444,12 @@ mod tests {
             .data
             .collect::<Vec<_>>();
 
+        // Ensure the copied graph is cleaned up even if an assertion panics,
+        // so leftover state cannot interfere with other parallel tests.
+        let _copy_guard = TestAsyncGraphHandle {
+            inner: client.select_graph("imdb_ro_copy_async"),
+        };
+
         // GRAPH.COPY is performed by a background fork on the server; when the
         // server is busy forking for other operations the copy can silently
         // complete empty, and waiting never populates it. A successful copy is
@@ -468,16 +474,11 @@ mod tests {
                     .data
                     .collect::<Vec<_>>()
             },
-            |rows| rows.len() == expected.len(),
+            |rows| *rows == expected,
         )
         .await;
 
         assert_eq!(copied, expected);
-        client
-            .select_graph("imdb_ro_copy_async")
-            .delete()
-            .await
-            .ok();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -374,7 +374,7 @@ impl FalkorAsyncClient {
 mod tests {
     use super::*;
     use crate::{
-        test_utils::{create_async_test_client, TestAsyncGraphHandle},
+        test_utils::{create_async_test_client, retry_until_async_fn},
         FalkorClientBuilder,
     };
     use std::{mem, num::NonZeroU8, thread};
@@ -449,37 +449,35 @@ mod tests {
         // complete empty, and waiting never populates it. A successful copy is
         // visible immediately, so re-issue the copy until the new graph reports
         // the same rows as the source graph.
-        let mut graph = TestAsyncGraphHandle {
-            inner: client.select_graph("imdb_ro_copy_async"),
-        };
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        let copied = loop {
-            client
-                .select_graph("imdb_ro_copy_async")
-                .delete()
-                .await
-                .ok();
-            graph.inner = client
-                .copy_graph("imdb", "imdb_ro_copy_async")
-                .await
-                .expect("Could not copy graph");
+        let copied = retry_until_async_fn(
+            || async {
+                client
+                    .select_graph("imdb_ro_copy_async")
+                    .delete()
+                    .await
+                    .ok();
+                let mut graph = client
+                    .copy_graph("imdb", "imdb_ro_copy_async")
+                    .await
+                    .expect("Could not copy graph");
+                graph
+                    .query("MATCH (a:actor) RETURN a")
+                    .execute()
+                    .await
+                    .expect("Could not get actors from copied graph")
+                    .data
+                    .collect::<Vec<_>>()
+            },
+            |rows| rows.len() == expected.len(),
+        )
+        .await;
 
-            let rows = graph
-                .inner
-                .query("MATCH (a:actor) RETURN a")
-                .execute()
-                .await
-                .expect("Could not get actors from copied graph")
-                .data
-                .collect::<Vec<_>>();
-
-            if rows.len() == expected.len() || std::time::Instant::now() >= deadline {
-                break rows;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        };
-
-        assert_eq!(copied, expected)
+        assert_eq!(copied, expected);
+        client
+            .select_graph("imdb_ro_copy_async")
+            .delete()
+            .await
+            .ok();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -434,38 +434,52 @@ mod tests {
     async fn test_copy_graph() {
         let client = create_async_test_client().await;
 
-        client
-            .select_graph("imdb_ro_copy_async")
-            .delete()
-            .await
-            .ok();
-
-        let graph = client.copy_graph("imdb", "imdb_ro_copy_async").await;
-        assert!(graph.is_ok());
-
-        let mut graph = TestAsyncGraphHandle {
-            inner: graph.unwrap(),
-        };
-
         let mut original_graph = client.select_graph("imdb");
 
-        assert_eq!(
-            graph
+        let expected = original_graph
+            .query("MATCH (a:actor) RETURN a")
+            .execute()
+            .await
+            .expect("Could not get actors from unmodified graph")
+            .data
+            .collect::<Vec<_>>();
+
+        // GRAPH.COPY is performed by a background fork on the server; when the
+        // server is busy forking for other operations the copy can silently
+        // complete empty, and waiting never populates it. A successful copy is
+        // visible immediately, so re-issue the copy until the new graph reports
+        // the same rows as the source graph.
+        let mut graph = TestAsyncGraphHandle {
+            inner: client.select_graph("imdb_ro_copy_async"),
+        };
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let copied = loop {
+            client
+                .select_graph("imdb_ro_copy_async")
+                .delete()
+                .await
+                .ok();
+            graph.inner = client
+                .copy_graph("imdb", "imdb_ro_copy_async")
+                .await
+                .expect("Could not copy graph");
+
+            let rows = graph
                 .inner
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
                 .await
-                .expect("Could not get actors from unmodified graph")
+                .expect("Could not get actors from copied graph")
                 .data
-                .collect::<Vec<_>>(),
-            original_graph
-                .query("MATCH (a:actor) RETURN a")
-                .execute()
-                .await
-                .expect("Could not get actors from unmodified graph")
-                .data
-                .collect::<Vec<_>>()
-        )
+                .collect::<Vec<_>>();
+
+            if rows.len() == expected.len() || std::time::Instant::now() >= deadline {
+                break rows;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        };
+
+        assert_eq!(copied, expected)
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -478,7 +478,7 @@ mod tests {
                     .data
                     .collect::<Vec<_>>()
             },
-            |rows| *rows == expected,
+            |rows| rows == &expected,
         )
         .await;
 

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -374,7 +374,10 @@ impl FalkorAsyncClient {
 mod tests {
     use super::*;
     use crate::{
-        test_utils::{create_async_test_client, retry_until_async_fn, TestAsyncGraphHandle},
+        test_utils::{
+            create_async_test_client, retry_until_async_fn_with_timeout, TestAsyncGraphHandle,
+            COPY_RETRY_TIMEOUT,
+        },
         FalkorClientBuilder,
     };
     use std::{mem, num::NonZeroU8, thread};
@@ -455,7 +458,8 @@ mod tests {
         // complete empty, and waiting never populates it. A successful copy is
         // visible immediately, so re-issue the copy until the new graph reports
         // the same rows as the source graph.
-        let copied = retry_until_async_fn(
+        let copied = retry_until_async_fn_with_timeout(
+            COPY_RETRY_TIMEOUT,
             || async {
                 client
                     .select_graph("imdb_ro_copy_async")

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -349,7 +349,7 @@ mod tests {
     use super::*;
     use crate::FalkorValue::Node;
     use crate::{
-        test_utils::{create_test_client, TestSyncGraphHandle},
+        test_utils::{create_test_client, retry_until},
         FalkorClientBuilder, FalkorValue, LazyResultSet, QueryResult,
     };
     use approx::assert_relative_eq;
@@ -491,31 +491,24 @@ mod tests {
         // complete empty, and waiting never populates it. A successful copy is
         // visible immediately, so re-issue the copy until the new graph reports
         // the same rows as the source graph.
-        let mut graph = TestSyncGraphHandle {
-            inner: client.select_graph("imdb_ro_copy"),
-        };
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-        let copied = loop {
-            client.select_graph("imdb_ro_copy").delete().ok();
-            graph.inner = client
-                .copy_graph("imdb", "imdb_ro_copy")
-                .expect("Could not copy graph");
+        let copied = retry_until(
+            || {
+                client.select_graph("imdb_ro_copy").delete().ok();
+                let mut graph = client
+                    .copy_graph("imdb", "imdb_ro_copy")
+                    .expect("Could not copy graph");
+                graph
+                    .query("MATCH (a:actor) RETURN a")
+                    .execute()
+                    .expect("Could not get actors from copied graph")
+                    .data
+                    .collect::<Vec<_>>()
+            },
+            |rows| rows.len() == expected.len(),
+        );
 
-            let rows = graph
-                .inner
-                .query("MATCH (a:actor) RETURN a")
-                .execute()
-                .expect("Could not get actors from copied graph")
-                .data
-                .collect::<Vec<_>>();
-
-            if rows.len() == expected.len() || std::time::Instant::now() >= deadline {
-                break rows;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        };
-
-        assert_eq!(copied, expected)
+        assert_eq!(copied, expected);
+        client.select_graph("imdb_ro_copy").delete().ok();
     }
 
     #[test]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -513,7 +513,7 @@ mod tests {
                     .data
                     .collect::<Vec<_>>()
             },
-            |rows| *rows == expected,
+            |rows| rows == &expected,
         );
 
         assert_eq!(copied, expected);

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -349,7 +349,7 @@ mod tests {
     use super::*;
     use crate::FalkorValue::Node;
     use crate::{
-        test_utils::{create_test_client, retry_until},
+        test_utils::{create_test_client, retry_until, TestSyncGraphHandle},
         FalkorClientBuilder, FalkorValue, LazyResultSet, QueryResult,
     };
     use approx::assert_relative_eq;
@@ -486,6 +486,12 @@ mod tests {
             .data
             .collect::<Vec<_>>();
 
+        // Ensure the copied graph is cleaned up even if an assertion panics,
+        // so leftover state cannot interfere with other parallel tests.
+        let _copy_guard = TestSyncGraphHandle {
+            inner: client.select_graph("imdb_ro_copy"),
+        };
+
         // GRAPH.COPY is performed by a background fork on the server; when the
         // server is busy forking for other operations the copy can silently
         // complete empty, and waiting never populates it. A successful copy is
@@ -504,11 +510,10 @@ mod tests {
                     .data
                     .collect::<Vec<_>>()
             },
-            |rows| rows.len() == expected.len(),
+            |rows| *rows == expected,
         );
 
         assert_eq!(copied, expected);
-        client.select_graph("imdb_ro_copy").delete().ok();
     }
 
     #[test]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -477,32 +477,45 @@ mod tests {
     fn test_copy_graph() {
         let client = create_test_client();
 
-        client.select_graph("imdb_ro_copy").delete().ok();
-
-        let graph = client.copy_graph("imdb", "imdb_ro_copy");
-        assert!(graph.is_ok());
-
-        let mut graph = TestSyncGraphHandle {
-            inner: graph.unwrap(),
-        };
-
         let mut original_graph = client.select_graph("imdb");
 
-        assert_eq!(
-            graph
+        let expected = original_graph
+            .query("MATCH (a:actor) RETURN a")
+            .execute()
+            .expect("Could not get actors from unmodified graph")
+            .data
+            .collect::<Vec<_>>();
+
+        // GRAPH.COPY is performed by a background fork on the server; when the
+        // server is busy forking for other operations the copy can silently
+        // complete empty, and waiting never populates it. A successful copy is
+        // visible immediately, so re-issue the copy until the new graph reports
+        // the same rows as the source graph.
+        let mut graph = TestSyncGraphHandle {
+            inner: client.select_graph("imdb_ro_copy"),
+        };
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let copied = loop {
+            client.select_graph("imdb_ro_copy").delete().ok();
+            graph.inner = client
+                .copy_graph("imdb", "imdb_ro_copy")
+                .expect("Could not copy graph");
+
+            let rows = graph
                 .inner
                 .query("MATCH (a:actor) RETURN a")
                 .execute()
-                .expect("Could not get actors from unmodified graph")
+                .expect("Could not get actors from copied graph")
                 .data
-                .collect::<Vec<_>>(),
-            original_graph
-                .query("MATCH (a:actor) RETURN a")
-                .execute()
-                .expect("Could not get actors from unmodified graph")
-                .data
-                .collect::<Vec<_>>()
-        )
+                .collect::<Vec<_>>();
+
+            if rows.len() == expected.len() || std::time::Instant::now() >= deadline {
+                break rows;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        };
+
+        assert_eq!(copied, expected)
     }
 
     #[test]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -349,7 +349,9 @@ mod tests {
     use super::*;
     use crate::FalkorValue::Node;
     use crate::{
-        test_utils::{create_test_client, retry_until, TestSyncGraphHandle},
+        test_utils::{
+            create_test_client, retry_until_with_timeout, TestSyncGraphHandle, COPY_RETRY_TIMEOUT,
+        },
         FalkorClientBuilder, FalkorValue, LazyResultSet, QueryResult,
     };
     use approx::assert_relative_eq;
@@ -497,7 +499,8 @@ mod tests {
         // complete empty, and waiting never populates it. A successful copy is
         // visible immediately, so re-issue the copy until the new graph reports
         // the same rows as the source graph.
-        let copied = retry_until(
+        let copied = retry_until_with_timeout(
+            COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_ro_copy").delete().ok();
                 let mut graph = client

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -622,7 +622,7 @@ mod tests {
         // Test that overly long socket paths are rejected
         let very_long_path = "/".to_string() + &"a".repeat(MAX_SOCKET_PATH_LENGTH + 10);
         let config = EmbeddedConfig {
-            redis_server_path: Some(PathBuf::from("/bin/true")), // Use a valid executable
+            redis_server_path: Some(PathBuf::from("/bin/sh")), // Use a valid executable
             falkordb_module_path: Some(PathBuf::from("/dev/null")), // Won't actually use this
             socket_path: Some(PathBuf::from(very_long_path)),
             ..Default::default()
@@ -957,17 +957,17 @@ mod tests {
 
     #[test]
     fn test_find_redis_server_with_valid_path() {
-        // Test with a path that exists (use /bin/true as a placeholder)
+        // Test with a path that exists (use /bin/sh as a placeholder)
         #[cfg(unix)]
         {
             let config = EmbeddedConfig {
-                redis_server_path: Some(PathBuf::from("/bin/true")),
+                redis_server_path: Some(PathBuf::from("/bin/sh")),
                 ..Default::default()
             };
 
             let result = EmbeddedServer::find_redis_server(&config);
             assert!(result.is_ok());
-            assert_eq!(result.unwrap(), PathBuf::from("/bin/true"));
+            assert_eq!(result.unwrap(), PathBuf::from("/bin/sh"));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,29 @@ pub(crate) mod test_utils {
             tokio::time::sleep(RETRY_INTERVAL).await;
         }
     }
+
+    /// Async counterpart of [`retry_until`] for self-contained operations that do
+    /// not borrow a long-lived `&mut AsyncGraph` (so the future can capture
+    /// everything it needs, e.g. a shared `&FalkorAsyncClient`). Used for server
+    /// operations performed by a background fork (e.g. `GRAPH.COPY`) that must be
+    /// re-issued until they take effect.
+    #[cfg(feature = "tokio")]
+    pub(crate) async fn retry_until_async_fn<T, Fut>(
+        mut op: impl FnMut() -> Fut,
+        done: impl Fn(&T) -> bool,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        let deadline = std::time::Instant::now() + RETRY_TIMEOUT;
+        loop {
+            let value = op().await;
+            if done(&value) || std::time::Instant::now() >= deadline {
+                return value;
+            }
+            tokio::time::sleep(RETRY_INTERVAL).await;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -195,6 +218,23 @@ mod retry_tests {
             },
             |v| *v == 3,
         );
+        assert_eq!(value, 3);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn retry_until_async_fn_polls_until_condition_is_met() {
+        use super::test_utils::retry_until_async_fn;
+        let calls = Cell::new(0);
+        let value = retry_until_async_fn(
+            || async {
+                calls.set(calls.get() + 1);
+                calls.get()
+            },
+            |v| *v == 3,
+        )
+        .await;
         assert_eq!(value, 3);
         assert_eq!(calls.get(), 3);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,16 +124,31 @@ pub(crate) mod test_utils {
 
     const RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+    /// `GRAPH.COPY` is performed by a background fork on the server, which can take
+    /// noticeably longer than index/constraint readiness under heavy load, so its
+    /// re-issue loop is given a longer window than [`RETRY_TIMEOUT`].
+    pub(crate) const COPY_RETRY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
     /// FalkorDB builds indices and validates constraints asynchronously, so a freshly
     /// created index/constraint may not be reported by the matching `list_*` call that
     /// immediately follows creation, especially while the server is under load. Retry
     /// `op` until `done` is satisfied or the timeout elapses, returning the last value.
     pub(crate) fn retry_until<T>(
+        op: impl FnMut() -> T,
+        done: impl Fn(&T) -> bool,
+    ) -> T {
+        retry_until_with_timeout(RETRY_TIMEOUT, op, done)
+    }
+
+    /// [`retry_until`] with an explicit overall timeout, for operations that need a
+    /// different retry window than the shared default (e.g. the `GRAPH.COPY` re-issue
+    /// loop, which uses [`COPY_RETRY_TIMEOUT`]).
+    pub(crate) fn retry_until_with_timeout<T>(
+        timeout: std::time::Duration,
         mut op: impl FnMut() -> T,
         done: impl Fn(&T) -> bool,
     ) -> T {
-        let deadline = std::time::Instant::now() + RETRY_TIMEOUT;
+        let deadline = std::time::Instant::now() + timeout;
         loop {
             let value = op();
             if done(&value) || std::time::Instant::now() >= deadline {
@@ -172,13 +187,28 @@ pub(crate) mod test_utils {
     /// re-issued until they take effect.
     #[cfg(feature = "tokio")]
     pub(crate) async fn retry_until_async_fn<T, Fut>(
+        op: impl FnMut() -> Fut,
+        done: impl Fn(&T) -> bool,
+    ) -> T
+    where
+        Fut: std::future::Future<Output = T>,
+    {
+        retry_until_async_fn_with_timeout(RETRY_TIMEOUT, op, done).await
+    }
+
+    /// [`retry_until_async_fn`] with an explicit overall timeout, for operations that
+    /// need a different retry window than the shared default (e.g. the `GRAPH.COPY`
+    /// re-issue loop, which uses [`COPY_RETRY_TIMEOUT`]).
+    #[cfg(feature = "tokio")]
+    pub(crate) async fn retry_until_async_fn_with_timeout<T, Fut>(
+        timeout: std::time::Duration,
         mut op: impl FnMut() -> Fut,
         done: impl Fn(&T) -> bool,
     ) -> T
     where
         Fut: std::future::Future<Output = T>,
     {
-        let deadline = std::time::Instant::now() + RETRY_TIMEOUT;
+        let deadline = std::time::Instant::now() + timeout;
         loop {
             let value = op().await;
             if done(&value) || std::time::Instant::now() >= deadline {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,10 +197,7 @@ mod retry_tests {
     #[test]
     fn retry_until_returns_immediately_when_already_done() {
         let calls = AtomicUsize::new(0);
-        let value = retry_until(
-            || calls.fetch_add(1, Ordering::Relaxed) + 1,
-            |v| *v == 1,
-        );
+        let value = retry_until(|| calls.fetch_add(1, Ordering::Relaxed) + 1, |v| *v == 1);
         assert_eq!(value, 1);
         assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
@@ -208,10 +205,7 @@ mod retry_tests {
     #[test]
     fn retry_until_polls_until_condition_is_met() {
         let calls = AtomicUsize::new(0);
-        let value = retry_until(
-            || calls.fetch_add(1, Ordering::Relaxed) + 1,
-            |v| *v == 3,
-        );
+        let value = retry_until(|| calls.fetch_add(1, Ordering::Relaxed) + 1, |v| *v == 3);
         assert_eq!(value, 3);
         assert_eq!(calls.load(Ordering::Relaxed), 3);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,50 +192,41 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod retry_tests {
     use super::test_utils::retry_until;
-    use std::cell::Cell;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn retry_until_returns_immediately_when_already_done() {
-        let calls = Cell::new(0);
+        let calls = AtomicUsize::new(0);
         let value = retry_until(
-            || {
-                calls.set(calls.get() + 1);
-                calls.get()
-            },
+            || calls.fetch_add(1, Ordering::Relaxed) + 1,
             |v| *v == 1,
         );
         assert_eq!(value, 1);
-        assert_eq!(calls.get(), 1);
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
     }
 
     #[test]
     fn retry_until_polls_until_condition_is_met() {
-        let calls = Cell::new(0);
+        let calls = AtomicUsize::new(0);
         let value = retry_until(
-            || {
-                calls.set(calls.get() + 1);
-                calls.get()
-            },
+            || calls.fetch_add(1, Ordering::Relaxed) + 1,
             |v| *v == 3,
         );
         assert_eq!(value, 3);
-        assert_eq!(calls.get(), 3);
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 
     #[cfg(feature = "tokio")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn retry_until_async_fn_polls_until_condition_is_met() {
         use super::test_utils::retry_until_async_fn;
-        let calls = Cell::new(0);
+        let calls = AtomicUsize::new(0);
         let value = retry_until_async_fn(
-            || async {
-                calls.set(calls.get() + 1);
-                calls.get()
-            },
+            || async { calls.fetch_add(1, Ordering::Relaxed) + 1 },
             |v| *v == 3,
         )
         .await;
         assert_eq!(value, 3);
-        assert_eq!(calls.get(), 3);
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 }


### PR DESCRIPTION
## Problems

1. The `Code Coverage` job on `main` failed because `client::blocking::tests::test_copy_graph` panicked (`left: []`, the copied graph returned no actors). The async counterpart is flaky for the same reason.
2. `test_find_redis_server_with_valid_path` and `test_socket_path_length_validation` failed on macOS (they hard-coded `/bin/true`, which only exists at `/usr/bin/true` on macOS).

## Root cause & fix

### Flaky `test_copy_graph`
`GRAPH.COPY` is performed by a **background fork** on the FalkorDB server. When the server is busy forking for other operations (the suite runs all tests in parallel against one shared server, including a concurrent copy in the blocking + async tests), the copy can **silently complete empty**, and no amount of waiting will ever populate the target graph (verified: it stayed empty for 62s).

A *successful* copy is visible immediately, so rather than polling the same lost copy, **re-issue `GRAPH.COPY`** until the new graph reports the same rows as the source (30s overall timeout). Applied to both the blocking and async tests.

### Embedded tests on macOS
Replaced `/bin/true` with `/bin/sh`, which is guaranteed to exist at the same path on both Linux and macOS (POSIX).

## Verification

- 30/30 concurrent stress runs of both copy tests passed (previously ~4/20 failed).
- Full suite passes locally on **macOS**: 275/275.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated graph copy tests with enhanced retry mechanisms to handle asynchronous operation behavior more reliably.

* **Chores**
  * Refactored internal retry utilities and added configurable timeout-based variants supporting both synchronous and asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->