### PR TITLE
feat: ergonomic builder API for waiting on background operations

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -51,6 +51,8 @@ cleans
 FalkorResult
 FalkorClientBuilder
 FalkorConnectionInfo
+EntityType
+IndexType
 EmbeddedServer
 Alice
 falkor

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ while let Some(node) = nodes.data.next() {
 
 ### Waiting for background operations
 
-Some FalkorDB operations finish **after** the command that starts them returns: creating or
-dropping an index or constraint is populated/enforced on a background worker thread, and
-`GRAPH.COPY` can fail transiently while the server is unable to `fork`. The eager methods
+Some FalkorDB operations finish **after** the command that starts them returns: when you create or
+drop an index or constraint, the request returns immediately while the index is populated (or the
+constraint is enforced) on a background worker thread, and `GRAPH.COPY` can fail transiently while
+the server is unable to `fork`. The eager methods
 (`create_index`, `create_unique_constraint`, `copy_graph`, …) stay fire-and-forget, but every
 one of them now has an additive `*_op` builder that adds explicit, opt-in waiting while keeping
 full backward compatibility.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ one of them now has an additive `*_op` builder that adds explicit, opt-in waitin
 full backward compatibility.
 
 Each builder offers `.execute()` (non-blocking, identical to the eager method) and `.wait()` /
-`.wait_with(WaitOptions)` terminals (block until the operation has actually taken effect, or
-return [`FalkorDBError::Timeout`]):
+`.wait_with(WaitOptions)` terminals. For index and constraint builders, `.wait()` blocks until the
+operation has actually taken effect (the index/constraint becomes operational or is dropped),
+returning [`FalkorDBError::Timeout`] if it does not happen in time. For the copy builder, `GRAPH.COPY`
+is already blocking on the server, so `.wait()` simply retries transient `could not fork` failures
+with backoff; it does **not** verify the copied contents (that remains the caller's responsibility).
 
 ```rust,no_run
 use falkordb::{EntityType, FalkorClientBuilder, FalkorConnectionInfo, IndexType, WaitOptions};

--- a/README.md
+++ b/README.md
@@ -63,6 +63,79 @@ while let Some(node) = nodes.data.next() {
 
 ## Features
 
+### Waiting for background operations
+
+Some FalkorDB operations finish **after** the command that starts them returns: creating or
+dropping an index or constraint is populated/enforced on a background worker thread, and
+`GRAPH.COPY` can fail transiently while the server is unable to `fork`. The eager methods
+(`create_index`, `create_unique_constraint`, `copy_graph`, …) stay fire-and-forget, but every
+one of them now has an additive `*_op` builder that adds explicit, opt-in waiting while keeping
+full backward compatibility.
+
+Each builder offers `.execute()` (non-blocking, identical to the eager method) and `.wait()` /
+`.wait_with(WaitOptions)` terminals (block until the operation has actually taken effect, or
+return [`FalkorDBError::Timeout`]):
+
+```rust,no_run
+use falkordb::{EntityType, FalkorClientBuilder, FalkorConnectionInfo, IndexType, WaitOptions};
+use std::time::Duration;
+
+let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()
+            .expect("Invalid connection info");
+let client = FalkorClientBuilder::new()
+           .with_connection_info(connection_info)
+           .build()
+           .expect("Failed to build client");
+let mut graph = client.select_graph("social");
+
+// Fire-and-forget, exactly like `create_index` (returns as soon as the server accepts it):
+graph.create_index_op(IndexType::Range, EntityType::Node, "Person", &["age"], None)
+     .execute()
+     .expect("Failed to request index creation");
+
+// Block until the index is actually operational (default 30s readiness timeout):
+graph.create_index_op(IndexType::Range, EntityType::Node, "Person", &["name"], None)
+     .wait()
+     .expect("Index did not become operational");
+
+// A unique constraint reports a *distinct* error if existing data violates it:
+match graph.create_unique_constraint_op(EntityType::Node, "Person", &["email"])
+           .wait_with(WaitOptions::with_timeout(Duration::from_secs(10)))
+{
+    Ok(()) => println!("constraint is enforced"),
+    Err(falkordb::FalkorDBError::ConstraintFailed { .. }) => println!("data violates the constraint"),
+    Err(other) => panic!("unexpected error: {other}"),
+}
+
+// Copy a graph, retrying transient `could not fork` failures:
+let _copy = client.copy_graph_op("social", "social_backup")
+                  .wait()
+                  .expect("Failed to copy graph");
+```
+
+The same builders exist on the async client/graph; just `await` the terminals:
+
+```rust,ignore
+use falkordb::{EntityType, FalkorClientBuilder, FalkorConnectionInfo, IndexType};
+
+let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()
+            .expect("Invalid connection info");
+let client = FalkorClientBuilder::new_async()
+           .with_connection_info(connection_info)
+           .build()
+           .await
+           .expect("Failed to build client");
+let mut graph = client.select_graph("social");
+
+graph.create_index_op(IndexType::Range, EntityType::Node, "Person", &["name"], None)
+     .wait()
+     .await
+     .expect("Index did not become operational");
+```
+
+[`FalkorDBError::Timeout`]: https://docs.rs/falkordb/latest/falkordb/enum.FalkorDBError.html
+
+
 ### `tokio` support
 
 This client supports nonblocking API using the [`tokio`](https://tokio.rs/) runtime.

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -486,6 +486,90 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_copy_graph_op_wait() {
+        let client = create_async_test_client().await;
+
+        let mut original_graph = client.select_graph("imdb");
+        let expected = original_graph
+            .query("MATCH (a:actor) RETURN a")
+            .execute()
+            .await
+            .expect("Could not get actors from unmodified graph")
+            .data
+            .collect::<Vec<_>>();
+
+        let _copy_guard = TestAsyncGraphHandle {
+            inner: client.select_graph("imdb_op_copy_async_wait"),
+        };
+
+        // `.wait()` retries only transient fork failures; the rare empty-but-OK copy is still
+        // possible, so the outer loop re-issues until the destination matches the source.
+        let copied = retry_until_async_fn_with_timeout(
+            COPY_RETRY_TIMEOUT,
+            || async {
+                client
+                    .select_graph("imdb_op_copy_async_wait")
+                    .delete()
+                    .await
+                    .ok();
+                let mut graph = client
+                    .copy_graph_op("imdb", "imdb_op_copy_async_wait")
+                    .wait()
+                    .await
+                    .expect("Could not copy graph");
+                graph
+                    .query("MATCH (a:actor) RETURN a")
+                    .execute()
+                    .await
+                    .expect("Could not get actors from copied graph")
+                    .data
+                    .collect::<Vec<_>>()
+            },
+            |rows| rows == &expected,
+        )
+        .await;
+
+        assert_eq!(copied, expected);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_copy_graph_op_execute() {
+        let client = create_async_test_client().await;
+
+        let _copy_guard = TestAsyncGraphHandle {
+            inner: client.select_graph("imdb_op_copy_async_execute"),
+        };
+
+        let copied = retry_until_async_fn_with_timeout(
+            COPY_RETRY_TIMEOUT,
+            || async {
+                client
+                    .select_graph("imdb_op_copy_async_execute")
+                    .delete()
+                    .await
+                    .ok();
+                match client
+                    .copy_graph_op("imdb", "imdb_op_copy_async_execute")
+                    .execute()
+                    .await
+                {
+                    Ok(mut graph) => Ok(graph
+                        .query("MATCH (a:actor) RETURN a")
+                        .execute()
+                        .await?
+                        .data
+                        .collect::<Vec<_>>()),
+                    Err(error) => Err(error),
+                }
+            },
+            |rows| matches!(rows, Ok(rows) if !rows.is_empty()),
+        )
+        .await;
+
+        assert!(!copied.expect("Could not copy graph").is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_config() {
         let client = create_async_test_client().await;
 

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -548,19 +548,18 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                match client
+                let mut graph = client
                     .copy_graph_op("imdb", "imdb_op_copy_async_execute")
                     .execute()
-                    .await
-                {
-                    Ok(mut graph) => Ok(graph
+                    .await?;
+                Ok::<_, crate::FalkorDBError>(
+                    graph
                         .query("MATCH (a:actor) RETURN a")
                         .execute()
                         .await?
                         .data
-                        .collect::<Vec<_>>()),
-                    Err(error) => Err(error),
-                }
+                        .collect::<Vec<_>>(),
+                )
             },
             |rows| matches!(rows, Ok(rows) if !rows.is_empty()),
         )

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -520,6 +520,74 @@ mod tests {
     }
 
     #[test]
+    fn test_copy_graph_op_wait() {
+        let client = create_test_client();
+
+        let mut original_graph = client.select_graph("imdb");
+        let expected = original_graph
+            .query("MATCH (a:actor) RETURN a")
+            .execute()
+            .expect("Could not get actors from unmodified graph")
+            .data
+            .collect::<Vec<_>>();
+
+        let _copy_guard = TestSyncGraphHandle {
+            inner: client.select_graph("imdb_op_copy_wait"),
+        };
+
+        // `.wait()` retries only transient fork failures; the rare empty-but-OK copy is still
+        // possible, so the outer loop re-issues until the destination matches the source.
+        let copied = retry_until_with_timeout(
+            COPY_RETRY_TIMEOUT,
+            || {
+                client.select_graph("imdb_op_copy_wait").delete().ok();
+                let mut graph = client
+                    .copy_graph_op("imdb", "imdb_op_copy_wait")
+                    .wait()
+                    .expect("Could not copy graph");
+                graph
+                    .query("MATCH (a:actor) RETURN a")
+                    .execute()
+                    .expect("Could not get actors from copied graph")
+                    .data
+                    .collect::<Vec<_>>()
+            },
+            |rows| rows == &expected,
+        );
+
+        assert_eq!(copied, expected);
+    }
+
+    #[test]
+    fn test_copy_graph_op_execute() {
+        let client = create_test_client();
+
+        let _copy_guard = TestSyncGraphHandle {
+            inner: client.select_graph("imdb_op_copy_execute"),
+        };
+
+        let copied = retry_until_with_timeout(
+            COPY_RETRY_TIMEOUT,
+            || {
+                client.select_graph("imdb_op_copy_execute").delete().ok();
+                client
+                    .copy_graph_op("imdb", "imdb_op_copy_execute")
+                    .execute()
+                    .and_then(|mut graph| {
+                        Ok(graph
+                            .query("MATCH (a:actor) RETURN a")
+                            .execute()?
+                            .data
+                            .collect::<Vec<_>>())
+                    })
+            },
+            |rows| matches!(rows, Ok(rows) if !rows.is_empty()),
+        );
+
+        assert!(!copied.expect("Could not copy graph").is_empty());
+    }
+
+    #[test]
     fn test_get_config() {
         let client = create_test_client();
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -8,6 +8,7 @@ use crate::SchemaType;
 /// A verbose error enum used throughout the client, messages are static string slices.
 /// this allows easy error integration using [`thiserror`]
 #[derive(thiserror::Error, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum FalkorDBError {
     /// A required ID for parsing was not found in the schema.
     #[error("A required Id for parsing was not found in the schema")]
@@ -127,6 +128,24 @@ pub enum FalkorDBError {
     /// An error occurred with the embedded FalkorDB server
     #[error("Embedded server error: {0}")]
     EmbeddedServerError(String),
+    /// A background operation did not reach its expected state before the wait timed out.
+    #[error("Timed out after {timeout:?} waiting for {operation}")]
+    Timeout {
+        /// Which background operation timed out.
+        operation: crate::WaitOperation,
+        /// The timeout that elapsed.
+        timeout: std::time::Duration,
+    },
+    /// A constraint reached the terminal `FAILED` state (e.g. existing data violates it).
+    #[error("Constraint on label '{label}' properties {properties:?} failed to be enforced")]
+    ConstraintFailed {
+        /// The label the constraint applies to.
+        label: String,
+        /// The properties the constraint applies to.
+        properties: Vec<String>,
+        /// Whether the failed constraint was unique or mandatory.
+        constraint_type: crate::ConstraintType,
+    },
 }
 
 impl From<strum::ParseError> for FalkorDBError {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -137,7 +137,9 @@ pub enum FalkorDBError {
         timeout: std::time::Duration,
     },
     /// A constraint reached the terminal `FAILED` state (e.g. existing data violates it).
-    #[error("Constraint on label '{label}' properties {properties:?} failed to be enforced")]
+    #[error(
+        "{constraint_type} constraint on label '{label}' properties {properties:?} failed to be enforced"
+    )]
     ConstraintFailed {
         /// The label the constraint applies to.
         label: String,

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -638,6 +638,25 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_constraint_op_execute_is_non_blocking() {
+        let mut graph = open_empty_async_test_graph("test_constraint_op_execute_async").await;
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .execute()
+            .await
+            .expect("Could not create constraint");
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .wait()
+            .await
+            .expect("Constraint did not become operational");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_unique_constraint_op_wait() {
         let mut graph = open_empty_async_test_graph("test_unique_constraint_op_wait_async").await;
 

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -607,9 +607,7 @@ mod tests {
             .await
             .expect("Could not list indices")
             .data;
-        assert!(!indices
-            .iter()
-            .any(|index| index.index_label == "person" && index.field_types.contains_key("age")));
+        assert!(!indices.iter().any(|index| index.index_label == "person"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -692,10 +690,14 @@ mod tests {
             )))
             .await;
 
-        assert!(matches!(
+        assert_eq!(
             result,
-            Err(FalkorDBError::ConstraintFailed { .. })
-        ));
+            Err(FalkorDBError::ConstraintFailed {
+                label: "person".to_string(),
+                properties: vec!["email".to_string()],
+                constraint_type: ConstraintType::Unique,
+            })
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -559,6 +559,31 @@ mod tests {
             .expect("Could not create index");
         assert_eq!(res.get_indices_created(), Some(1));
 
+        // `execute` is non-blocking, so the index may not be visible yet; wait for it
+        // to appear before dropping so the drop is deterministic.
+        retry_until_async(
+            &mut graph.inner,
+            |graph| {
+                Box::pin(async move {
+                    graph
+                        .list_indices()
+                        .await
+                        .expect("Could not list indices")
+                        .data
+                })
+            },
+            |indices| {
+                indices.iter().any(|index| {
+                    index.index_label == "actor"
+                        && index
+                            .field_types
+                            .get("name")
+                            .is_some_and(|types| types.contains(&IndexType::Fulltext))
+                })
+            },
+        )
+        .await;
+
         let res = graph
             .inner
             .drop_index_op(IndexType::Fulltext, EntityType::Node, "actor", &["name"])

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -647,20 +647,6 @@ mod tests {
             .execute()
             .await
             .expect("Could not create constraint");
-
-        let res = retry_until_async(
-            &mut graph.inner,
-            |g| {
-                Box::pin(async move {
-                    g.list_constraints()
-                        .await
-                        .expect("Could not list constraints")
-                })
-            },
-            |res| res.data.iter().any(|c| c.label == "person"),
-        )
-        .await;
-        assert!(res.data.iter().any(|c| c.label == "person"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -607,7 +607,7 @@ mod tests {
             .await
             .expect("Could not list indices")
             .data;
-        assert!(!indices.iter().any(|index| index.index_label == "person"));
+        assert!(indices.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -645,6 +645,18 @@ mod tests {
             .execute()
             .await
             .expect("Could not create constraint");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_drop_index_op_wait_errors_when_missing() {
+        let mut graph = open_empty_async_test_graph("test_drop_index_op_missing_async").await;
+
+        let result = graph
+            .inner
+            .drop_index_op(IndexType::Range, EntityType::Node, "person", &["age"])
+            .wait()
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -404,7 +404,7 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{create_async_test_client, open_empty_async_test_graph, retry_until_async},
-        IndexType,
+        ConstraintType, FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
 
     #[tokio::test(flavor = "multi_thread")]
@@ -539,6 +539,151 @@ mod tests {
         )
         .await;
         assert_eq!(res.data.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_index_op_execute_is_non_blocking() {
+        let mut graph = open_empty_async_test_graph("test_create_index_op_execute_async").await;
+
+        let res = graph
+            .inner
+            .create_index_op(
+                IndexType::Fulltext,
+                EntityType::Node,
+                "actor",
+                &["name"],
+                None,
+            )
+            .execute()
+            .await
+            .expect("Could not create index");
+        assert_eq!(res.get_indices_created(), Some(1));
+
+        let res = graph
+            .inner
+            .drop_index_op(IndexType::Fulltext, EntityType::Node, "actor", &["name"])
+            .execute()
+            .await
+            .expect("Could not drop index");
+        assert_eq!(res.get_indices_deleted(), Some(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_drop_index_op_wait() {
+        let mut graph = open_empty_async_test_graph("test_create_index_op_wait_async").await;
+
+        graph
+            .inner
+            .create_index_op(IndexType::Range, EntityType::Node, "person", &["age"], None)
+            .wait()
+            .await
+            .expect("Index did not become operational");
+
+        let indices = graph
+            .inner
+            .list_indices()
+            .await
+            .expect("Could not list indices")
+            .data;
+        assert!(indices.iter().any(|index| {
+            index.index_label == "person"
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("age")
+                    .is_some_and(|types| types.contains(&IndexType::Range))
+        }));
+
+        graph
+            .inner
+            .drop_index_op(IndexType::Range, EntityType::Node, "person", &["age"])
+            .wait()
+            .await
+            .expect("Index was not dropped");
+
+        let indices = graph
+            .inner
+            .list_indices()
+            .await
+            .expect("Could not list indices")
+            .data;
+        assert!(!indices
+            .iter()
+            .any(|index| index.index_label == "person" && index.field_types.contains_key("age")));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mandatory_constraint_op_wait() {
+        let mut graph =
+            open_empty_async_test_graph("test_mandatory_constraint_op_wait_async").await;
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .wait()
+            .await
+            .expect("Constraint did not become operational");
+
+        graph
+            .inner
+            .drop_constraint_op(
+                ConstraintType::Mandatory,
+                EntityType::Node,
+                "person",
+                &["name"],
+            )
+            .wait()
+            .await
+            .expect("Constraint was not dropped");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unique_constraint_op_wait() {
+        let mut graph = open_empty_async_test_graph("test_unique_constraint_op_wait_async").await;
+
+        graph
+            .inner
+            .create_unique_constraint_op(EntityType::Node, "person", &["email"])
+            .wait()
+            .await
+            .expect("Constraint did not become operational");
+
+        graph
+            .inner
+            .drop_constraint_op(
+                ConstraintType::Unique,
+                EntityType::Node,
+                "person",
+                &["email"],
+            )
+            .wait()
+            .await
+            .expect("Constraint was not dropped");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unique_constraint_op_wait_reports_failure() {
+        let mut graph = open_empty_async_test_graph("test_unique_constraint_op_failed_async").await;
+
+        graph
+            .inner
+            .query("CREATE (:person {email: 'dup'}), (:person {email: 'dup'})")
+            .execute()
+            .await
+            .expect("Could not seed conflicting data");
+
+        let result = graph
+            .inner
+            .create_unique_constraint_op(EntityType::Node, "person", &["email"])
+            .wait_with(WaitOptions::with_timeout(std::time::Duration::from_secs(
+                10,
+            )))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(FalkorDBError::ConstraintFailed { .. })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -648,12 +648,19 @@ mod tests {
             .await
             .expect("Could not create constraint");
 
-        graph
-            .inner
-            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
-            .wait()
-            .await
-            .expect("Constraint did not become operational");
+        let res = retry_until_async(
+            &mut graph.inner,
+            |g| {
+                Box::pin(async move {
+                    g.list_constraints()
+                        .await
+                        .expect("Could not list constraints")
+                })
+            },
+            |res| res.data.iter().any(|c| c.label == "person"),
+        )
+        .await;
+        assert!(res.data.iter().any(|c| c.label == "person"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -392,7 +392,7 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{create_test_client, open_empty_test_graph, retry_until},
-        FalkorDBError, IndexType,
+        FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
 
     #[test]
@@ -519,6 +519,138 @@ mod tests {
             |res| res.data.len() == 1,
         );
         assert_eq!(res.data.len(), 1);
+    }
+
+    #[test]
+    fn test_create_index_op_execute_is_non_blocking() {
+        let mut graph = open_empty_test_graph("test_create_index_op_execute");
+
+        let res = graph
+            .inner
+            .create_index_op(
+                IndexType::Fulltext,
+                EntityType::Node,
+                "actor",
+                &["name"],
+                None,
+            )
+            .execute()
+            .expect("Could not create index");
+        assert_eq!(res.get_indices_created(), Some(1));
+
+        let res = graph
+            .inner
+            .drop_index_op(IndexType::Fulltext, EntityType::Node, "actor", &["name"])
+            .execute()
+            .expect("Could not drop index");
+        assert_eq!(res.get_indices_deleted(), Some(1));
+    }
+
+    #[test]
+    fn test_create_drop_index_op_wait() {
+        let mut graph = open_empty_test_graph("test_create_index_op_wait");
+
+        graph
+            .inner
+            .create_index_op(IndexType::Range, EntityType::Node, "person", &["age"], None)
+            .wait()
+            .expect("Index did not become operational");
+
+        let indices = graph
+            .inner
+            .list_indices()
+            .expect("Could not list indices")
+            .data;
+        assert!(indices.iter().any(|index| {
+            index.index_label == "person"
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("age")
+                    .is_some_and(|types| types.contains(&IndexType::Range))
+        }));
+
+        graph
+            .inner
+            .drop_index_op(IndexType::Range, EntityType::Node, "person", &["age"])
+            .wait()
+            .expect("Index was not dropped");
+
+        let indices = graph
+            .inner
+            .list_indices()
+            .expect("Could not list indices")
+            .data;
+        assert!(!indices
+            .iter()
+            .any(|index| index.index_label == "person" && index.field_types.contains_key("age")));
+    }
+
+    #[test]
+    fn test_mandatory_constraint_op_wait() {
+        let mut graph = open_empty_test_graph("test_mandatory_constraint_op_wait");
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .wait()
+            .expect("Constraint did not become operational");
+
+        graph
+            .inner
+            .drop_constraint_op(
+                ConstraintType::Mandatory,
+                EntityType::Node,
+                "person",
+                &["name"],
+            )
+            .wait()
+            .expect("Constraint was not dropped");
+    }
+
+    #[test]
+    fn test_unique_constraint_op_wait() {
+        let mut graph = open_empty_test_graph("test_unique_constraint_op_wait");
+
+        graph
+            .inner
+            .create_unique_constraint_op(EntityType::Node, "person", &["email"])
+            .wait()
+            .expect("Constraint did not become operational");
+
+        graph
+            .inner
+            .drop_constraint_op(
+                ConstraintType::Unique,
+                EntityType::Node,
+                "person",
+                &["email"],
+            )
+            .wait()
+            .expect("Constraint was not dropped");
+    }
+
+    #[test]
+    fn test_unique_constraint_op_wait_reports_failure() {
+        let mut graph = open_empty_test_graph("test_unique_constraint_op_failed");
+
+        graph
+            .inner
+            .query("CREATE (:person {email: 'dup'}), (:person {email: 'dup'})")
+            .execute()
+            .expect("Could not seed conflicting data");
+
+        let result = graph
+            .inner
+            .create_unique_constraint_op(EntityType::Node, "person", &["email"])
+            .wait_with(WaitOptions::with_timeout(std::time::Duration::from_secs(
+                10,
+            )));
+
+        assert!(matches!(
+            result,
+            Err(FalkorDBError::ConstraintFailed { .. })
+        ));
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -581,9 +581,7 @@ mod tests {
             .list_indices()
             .expect("Could not list indices")
             .data;
-        assert!(!indices
-            .iter()
-            .any(|index| index.index_label == "person" && index.field_types.contains_key("age")));
+        assert!(!indices.iter().any(|index| index.index_label == "person"));
     }
 
     #[test]
@@ -658,10 +656,14 @@ mod tests {
                 10,
             )));
 
-        assert!(matches!(
+        assert_eq!(
             result,
-            Err(FalkorDBError::ConstraintFailed { .. })
-        ));
+            Err(FalkorDBError::ConstraintFailed {
+                label: "person".to_string(),
+                properties: vec!["email".to_string()],
+                constraint_type: ConstraintType::Unique,
+            })
+        );
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -617,17 +617,6 @@ mod tests {
             .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
             .execute()
             .expect("Could not create constraint");
-
-        let res = retry_until(
-            || {
-                graph
-                    .inner
-                    .list_constraints()
-                    .expect("Could not list constraints")
-            },
-            |res| res.data.iter().any(|c| c.label == "person"),
-        );
-        assert!(res.data.iter().any(|c| c.label == "person"));
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -618,11 +618,16 @@ mod tests {
             .execute()
             .expect("Could not create constraint");
 
-        graph
-            .inner
-            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
-            .wait()
-            .expect("Constraint did not become operational");
+        let res = retry_until(
+            || {
+                graph
+                    .inner
+                    .list_constraints()
+                    .expect("Could not list constraints")
+            },
+            |res| res.data.iter().any(|c| c.label == "person"),
+        );
+        assert!(res.data.iter().any(|c| c.label == "person"));
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -609,6 +609,23 @@ mod tests {
     }
 
     #[test]
+    fn test_constraint_op_execute_is_non_blocking() {
+        let mut graph = open_empty_test_graph("test_constraint_op_execute");
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .execute()
+            .expect("Could not create constraint");
+
+        graph
+            .inner
+            .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
+            .wait()
+            .expect("Constraint did not become operational");
+    }
+
+    #[test]
     fn test_unique_constraint_op_wait() {
         let mut graph = open_empty_test_graph("test_unique_constraint_op_wait");
 

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -581,7 +581,7 @@ mod tests {
             .list_indices()
             .expect("Could not list indices")
             .data;
-        assert!(!indices.iter().any(|index| index.index_label == "person"));
+        assert!(indices.is_empty());
     }
 
     #[test]
@@ -615,6 +615,17 @@ mod tests {
             .create_mandatory_constraint_op(EntityType::Node, "person", &["name"])
             .execute()
             .expect("Could not create constraint");
+    }
+
+    #[test]
+    fn test_drop_index_op_wait_errors_when_missing() {
+        let mut graph = open_empty_test_graph("test_drop_index_op_missing");
+
+        let result = graph
+            .inner
+            .drop_index_op(IndexType::Range, EntityType::Node, "person", &["age"])
+            .wait();
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -538,6 +538,27 @@ mod tests {
             .expect("Could not create index");
         assert_eq!(res.get_indices_created(), Some(1));
 
+        // `execute` is non-blocking, so the index may not be visible yet; wait for it
+        // to appear before dropping so the drop is deterministic.
+        retry_until(
+            || {
+                graph
+                    .inner
+                    .list_indices()
+                    .expect("Could not list indices")
+                    .data
+            },
+            |indices| {
+                indices.iter().any(|index| {
+                    index.index_label == "actor"
+                        && index
+                            .field_types
+                            .get("name")
+                            .is_some_and(|types| types.contains(&IndexType::Fulltext))
+                })
+            },
+        );
+
         let res = graph
             .inner
             .drop_index_op(IndexType::Fulltext, EntityType::Node, "actor", &["name"])

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -9,6 +9,8 @@ use std::{collections::HashMap, fmt::Display};
 pub(crate) mod blocking;
 pub(crate) mod query_builder;
 
+pub(crate) mod ops;
+
 #[cfg(feature = "tokio")]
 pub(crate) mod asynchronous;
 

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -207,6 +207,37 @@ pub(crate) fn poll_sync<T>(
     }
 }
 
+/// Asynchronously polls `attempt` until it is [`Step::Done`]/[`Step::Fail`] or the timeout
+/// elapses. This is the async counterpart of [`poll_sync`] and shares the exact same backoff and
+/// deadline logic; it is generic over an async closure so the index/constraint wait (which needs
+/// `&mut AsyncGraph`) and the graph-copy wait (which needs `&FalkorAsyncClient`) can both reuse it.
+#[cfg(feature = "tokio")]
+pub(crate) async fn poll_async<T>(
+    options: &WaitOptions,
+    operation: WaitOperation,
+    mut attempt: impl AsyncFnMut() -> crate::FalkorResult<Step<T>>,
+) -> crate::FalkorResult<T> {
+    let deadline = Instant::now() + options.timeout;
+    let mut attempts = 0u32;
+    loop {
+        match attempt().await? {
+            Step::Done(value) => return Ok(value),
+            Step::Fail(error) => return Err(error),
+            Step::Retry => {}
+        }
+        match next_wakeup(options, deadline, attempts) {
+            Wakeup::TimedOut => {
+                return Err(crate::FalkorDBError::Timeout {
+                    operation,
+                    timeout: options.timeout,
+                })
+            }
+            Wakeup::Sleep(delay) => tokio::time::sleep(delay).await,
+        }
+        attempts += 1;
+    }
+}
+
 /// `true` if `error` is a transient `GRAPH.COPY` failure that should be retried (the server was
 /// temporarily unable to `fork`). FalkorDB's own tests retry copies on this condition.
 pub(crate) fn is_transient_copy_error(error: &crate::FalkorDBError) -> bool {
@@ -216,6 +247,17 @@ pub(crate) fn is_transient_copy_error(error: &crate::FalkorDBError) -> bool {
             message.to_lowercase().contains("could not fork")
         }
         _ => false,
+    }
+}
+
+/// Maps the result of a single `GRAPH.COPY` attempt into a [`Step`]: success completes the wait,
+/// a transient `could not fork` failure retries, and any other error fails immediately. Shared by
+/// the sync and async copy builders.
+pub(crate) fn classify_copy_result<T>(result: crate::FalkorResult<T>) -> Step<T> {
+    match result {
+        Ok(value) => Step::Done(value),
+        Err(error) if is_transient_copy_error(&error) => Step::Retry,
+        Err(error) => Step::Fail(error),
     }
 }
 
@@ -351,6 +393,13 @@ impl IndexWait {
                 self.index_type,
             )
         }
+    }
+
+    fn step(
+        &self,
+        indices: &[FalkorIndex],
+    ) -> Step<()> {
+        bool_step(self.satisfied(indices))
     }
 }
 
@@ -747,13 +796,13 @@ mod tests {
         let options = WaitOptions::with_timeout(Duration::ZERO);
         let result: crate::FalkorResult<()> =
             poll_sync(&options, WaitOperation::GraphCopy, || Ok(Step::Retry));
-        match result {
-            Err(crate::FalkorDBError::Timeout { operation, timeout }) => {
-                assert_eq!(operation, WaitOperation::GraphCopy);
-                assert_eq!(timeout, Duration::ZERO);
-            }
-            other => panic!("expected timeout, got {other:?}"),
-        }
+        assert!(matches!(
+            result,
+            Err(crate::FalkorDBError::Timeout {
+                operation: WaitOperation::GraphCopy,
+                timeout,
+            }) if timeout == Duration::ZERO
+        ));
     }
 
     #[test]
@@ -1005,6 +1054,36 @@ mod tests {
         };
         assert!(!drop.satisfied(std::slice::from_ref(&ready)));
         assert!(drop.satisfied(&[]));
+
+        // `step` maps the boolean readiness into a `Step` for both branches.
+        assert!(matches!(
+            create.step(std::slice::from_ref(&ready)),
+            Step::Done(())
+        ));
+        assert!(matches!(create.step(&[]), Step::Retry));
+    }
+
+    #[test]
+    fn bool_step_maps_both_branches() {
+        assert!(matches!(bool_step(true), Step::Done(())));
+        assert!(matches!(bool_step(false), Step::Retry));
+    }
+
+    #[test]
+    fn classify_copy_result_maps_each_outcome() {
+        assert!(matches!(classify_copy_result::<u8>(Ok(7)), Step::Done(7)));
+        assert!(matches!(
+            classify_copy_result::<u8>(Err(crate::FalkorDBError::RedisError(
+                "MISCONF could not fork".to_string()
+            ))),
+            Step::Retry
+        ));
+        assert!(matches!(
+            classify_copy_result::<u8>(Err(crate::FalkorDBError::RedisError(
+                "some other failure".to_string()
+            ))),
+            Step::Fail(_)
+        ));
     }
 
     #[test]
@@ -1088,5 +1167,84 @@ mod tests {
             properties: vec![],
         });
         assert_eq!(constraint_drop.operation(), WaitOperation::ConstraintDrop);
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn poll_async_returns_first_done() {
+        let value = poll_async(
+            &WaitOptions::new(),
+            WaitOperation::IndexCreation,
+            async || Ok::<_, crate::FalkorDBError>(Step::Done(7)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(value, 7);
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn poll_async_retries_until_done() {
+        let options = WaitOptions::new().poll_interval(Duration::from_millis(1));
+        let mut calls = 0u32;
+        let value = poll_async(&options, WaitOperation::IndexCreation, async || {
+            calls += 1;
+            Ok::<_, crate::FalkorDBError>(if calls < 3 {
+                Step::Retry
+            } else {
+                Step::Done(calls)
+            })
+        })
+        .await
+        .unwrap();
+        assert_eq!(value, 3);
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn poll_async_propagates_fail() {
+        let result: crate::FalkorResult<()> = poll_async(
+            &WaitOptions::new(),
+            WaitOperation::ConstraintCreation,
+            async || {
+                Ok(Step::Fail(crate::FalkorDBError::ConstraintFailed {
+                    label: "P".to_string(),
+                    properties: vec!["id".to_string()],
+                    constraint_type: ConstraintType::Unique,
+                }))
+            },
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(crate::FalkorDBError::ConstraintFailed { .. })
+        ));
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn poll_async_propagates_attempt_error() {
+        let result: crate::FalkorResult<()> = poll_async(
+            &WaitOptions::new(),
+            WaitOperation::IndexCreation,
+            async || Err(crate::FalkorDBError::ParsingArray),
+        )
+        .await;
+        assert!(matches!(result, Err(crate::FalkorDBError::ParsingArray)));
+    }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn poll_async_times_out() {
+        let options = WaitOptions::new().timeout(Duration::ZERO);
+        let result: crate::FalkorResult<()> =
+            poll_async(&options, WaitOperation::GraphCopy, async || Ok(Step::Retry)).await;
+        assert!(matches!(
+            result,
+            Err(crate::FalkorDBError::Timeout {
+                operation: WaitOperation::GraphCopy,
+                timeout,
+            }) if timeout == Duration::ZERO
+        ));
     }
 }

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -143,7 +143,8 @@ impl WaitOptions {
         &self,
         attempt: u32,
     ) -> Duration {
-        let scaled = self.poll_interval.as_secs_f64() * self.backoff_factor.powi(attempt as i32);
+        let exponent = i32::try_from(attempt).unwrap_or(i32::MAX);
+        let scaled = self.poll_interval.as_secs_f64() * self.backoff_factor.powi(exponent);
         Duration::from_secs_f64(scaled.min(self.max_interval.as_secs_f64()))
     }
 }
@@ -658,6 +659,11 @@ mod tests {
         // capped at max_interval
         assert_eq!(options.delay_for_attempt(3), Duration::from_millis(500));
         assert_eq!(options.delay_for_attempt(1000), Duration::from_millis(500));
+        // a huge attempt count must not overflow the i32 exponent and shrink the delay
+        assert_eq!(
+            options.delay_for_attempt(u32::MAX),
+            Duration::from_millis(500)
+        );
     }
 
     #[test]

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -167,16 +167,29 @@ enum Wakeup {
     TimedOut,
 }
 
+/// Computes the deadline for a wait. Returns `None` when `timeout` is so large that the deadline
+/// is not representable as an [`Instant`]; callers treat `None` as "never time out" rather than
+/// panicking on the overflowing `Instant` addition.
+fn deadline_for(timeout: Duration) -> Option<Instant> {
+    Instant::now().checked_add(timeout)
+}
+
 fn next_wakeup(
     options: &WaitOptions,
-    deadline: Instant,
+    deadline: Option<Instant>,
     attempt: u32,
 ) -> Wakeup {
-    let now = Instant::now();
-    if now >= deadline {
-        Wakeup::TimedOut
-    } else {
-        Wakeup::Sleep(options.delay_for_attempt(attempt).min(deadline - now))
+    let delay = options.delay_for_attempt(attempt);
+    match deadline {
+        None => Wakeup::Sleep(delay),
+        Some(deadline) => {
+            let now = Instant::now();
+            if now >= deadline {
+                Wakeup::TimedOut
+            } else {
+                Wakeup::Sleep(delay.min(deadline - now))
+            }
+        }
     }
 }
 
@@ -186,7 +199,7 @@ pub(crate) fn poll_sync<T>(
     operation: WaitOperation,
     mut attempt: impl FnMut() -> crate::FalkorResult<Step<T>>,
 ) -> crate::FalkorResult<T> {
-    let deadline = Instant::now() + options.timeout;
+    let deadline = deadline_for(options.timeout);
     let mut attempts = 0u32;
     loop {
         match attempt()? {
@@ -217,7 +230,7 @@ pub(crate) async fn poll_async<T>(
     operation: WaitOperation,
     mut attempt: impl AsyncFnMut() -> crate::FalkorResult<Step<T>>,
 ) -> crate::FalkorResult<T> {
-    let deadline = Instant::now() + options.timeout;
+    let deadline = deadline_for(options.timeout);
     let mut attempts = 0u32;
     loop {
         match attempt().await? {
@@ -719,9 +732,23 @@ mod tests {
     fn next_wakeup_sleeps_then_times_out() {
         let options = WaitOptions::new();
         let future = Instant::now() + Duration::from_secs(60);
-        assert!(matches!(next_wakeup(&options, future, 0), Wakeup::Sleep(_)));
+        assert!(matches!(
+            next_wakeup(&options, Some(future), 0),
+            Wakeup::Sleep(_)
+        ));
         let past = Instant::now() - Duration::from_secs(1);
-        assert!(matches!(next_wakeup(&options, past, 0), Wakeup::TimedOut));
+        assert!(matches!(
+            next_wakeup(&options, Some(past), 0),
+            Wakeup::TimedOut
+        ));
+        // No deadline (overflowing timeout) never times out.
+        assert!(matches!(next_wakeup(&options, None, 0), Wakeup::Sleep(_)));
+    }
+
+    #[test]
+    fn deadline_for_saturates_on_overflow() {
+        assert!(deadline_for(Duration::from_secs(1)).is_some());
+        assert!(deadline_for(Duration::MAX).is_none());
     }
 
     #[test]

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -1,0 +1,1086 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Ergonomic, opt-in helpers for FalkorDB operations that complete in the **background** on
+//! the server.
+//!
+//! Creating or dropping an index or a constraint returns as soon as the server *accepts* the
+//! request; the work itself (populating the index, enforcing the constraint) then happens on a
+//! background worker thread. `GRAPH.COPY` blocks until the copy finishes but can fail
+//! transiently while the server is unable to `fork`.
+//!
+//! The builders in this module make waiting for these operations explicit and intuitive while
+//! staying fully backward compatible: the existing eager methods (`create_index`, `copy_graph`,
+//! …) are untouched, and every builder exposes a non-blocking [`execute`](IndexOpBuilder::execute)
+//! terminal next to the waiting [`wait`](IndexOpBuilder::wait) terminal.
+
+use crate::{
+    Constraint, ConstraintStatus, ConstraintType, EntityType, FalkorIndex, IndexStatus, IndexType,
+};
+use std::time::{Duration, Instant};
+
+/// Identifies which background operation a [`crate::FalkorDBError::Timeout`] refers to.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, strum::Display)]
+pub enum WaitOperation {
+    /// Waiting for an index to become operational.
+    #[strum(serialize = "index creation")]
+    IndexCreation,
+    /// Waiting for an index to be removed.
+    #[strum(serialize = "index drop")]
+    IndexDrop,
+    /// Waiting for a constraint to become operational.
+    #[strum(serialize = "constraint creation")]
+    ConstraintCreation,
+    /// Waiting for a constraint to be removed.
+    #[strum(serialize = "constraint drop")]
+    ConstraintDrop,
+    /// Re-issuing a graph copy until it succeeds.
+    #[strum(serialize = "graph copy")]
+    GraphCopy,
+}
+
+const DEFAULT_READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_COPY_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const DEFAULT_MAX_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_BACKOFF_FACTOR: f64 = 1.5;
+const MIN_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Tunables for how a `wait` terminal polls/retries a background operation.
+///
+/// The defaults are sensible for readiness polling (30s timeout, 50ms initial interval growing
+/// by 1.5x up to 1s). All setters normalize their input so a [`WaitOptions`] can never busy-spin
+/// or sleep with a degenerate interval.
+///
+/// # Example
+/// ```
+/// use falkordb::WaitOptions;
+/// use std::time::Duration;
+///
+/// let options = WaitOptions::with_timeout(Duration::from_secs(5))
+///     .poll_interval(Duration::from_millis(100))
+///     .backoff_factor(2.0)
+///     .max_interval(Duration::from_secs(2));
+/// # let _ = options;
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct WaitOptions {
+    timeout: Duration,
+    poll_interval: Duration,
+    backoff_factor: f64,
+    max_interval: Duration,
+}
+
+impl Default for WaitOptions {
+    fn default() -> Self {
+        Self {
+            timeout: DEFAULT_READINESS_TIMEOUT,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            backoff_factor: DEFAULT_BACKOFF_FACTOR,
+            max_interval: DEFAULT_MAX_INTERVAL,
+        }
+    }
+}
+
+impl WaitOptions {
+    /// A [`WaitOptions`] with the default readiness settings (30s timeout).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The default settings used for graph copy retries (60s timeout).
+    pub(crate) fn for_copy() -> Self {
+        Self::default().timeout(DEFAULT_COPY_TIMEOUT)
+    }
+
+    /// A [`WaitOptions`] with the default settings but the provided overall `timeout`.
+    pub fn with_timeout(timeout: Duration) -> Self {
+        Self::default().timeout(timeout)
+    }
+
+    /// Sets the overall timeout, after which a `wait` terminal returns
+    /// [`crate::FalkorDBError::Timeout`].
+    pub fn timeout(
+        mut self,
+        timeout: Duration,
+    ) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Sets the initial poll interval (floored to 1ms, never larger than `max_interval`).
+    pub fn poll_interval(
+        mut self,
+        poll_interval: Duration,
+    ) -> Self {
+        self.poll_interval = poll_interval.max(MIN_POLL_INTERVAL);
+        self.max_interval = self.max_interval.max(self.poll_interval);
+        self
+    }
+
+    /// Sets the exponential backoff multiplier applied between polls (floored to 1.0).
+    pub fn backoff_factor(
+        mut self,
+        backoff_factor: f64,
+    ) -> Self {
+        self.backoff_factor = backoff_factor.max(1.0);
+        self
+    }
+
+    /// Sets the maximum interval between polls (never smaller than `poll_interval`).
+    pub fn max_interval(
+        mut self,
+        max_interval: Duration,
+    ) -> Self {
+        self.max_interval = max_interval.max(self.poll_interval);
+        self
+    }
+
+    /// The delay to wait before the poll following `attempt` (0-based), capped at `max_interval`.
+    pub(crate) fn delay_for_attempt(
+        &self,
+        attempt: u32,
+    ) -> Duration {
+        let scaled = self.poll_interval.as_secs_f64() * self.backoff_factor.powi(attempt as i32);
+        Duration::from_secs_f64(scaled.min(self.max_interval.as_secs_f64()))
+    }
+}
+
+/// The outcome of a single poll attempt.
+pub(crate) enum Step<T> {
+    /// The operation finished; return this value.
+    Done(T),
+    /// The operation is still pending; poll again after a delay.
+    Retry,
+    /// The operation reached a terminal failure; return this error without retrying.
+    Fail(crate::FalkorDBError),
+}
+
+/// What to do after a [`Step::Retry`], computed against the deadline.
+enum Wakeup {
+    /// Sleep for this long, then poll again.
+    Sleep(Duration),
+    /// The deadline has passed; time out.
+    TimedOut,
+}
+
+fn next_wakeup(
+    options: &WaitOptions,
+    deadline: Instant,
+    attempt: u32,
+) -> Wakeup {
+    let now = Instant::now();
+    if now >= deadline {
+        Wakeup::TimedOut
+    } else {
+        Wakeup::Sleep(options.delay_for_attempt(attempt).min(deadline - now))
+    }
+}
+
+/// Synchronously polls `attempt` until it is [`Step::Done`]/[`Step::Fail`] or the timeout elapses.
+pub(crate) fn poll_sync<T>(
+    options: &WaitOptions,
+    operation: WaitOperation,
+    mut attempt: impl FnMut() -> crate::FalkorResult<Step<T>>,
+) -> crate::FalkorResult<T> {
+    let deadline = Instant::now() + options.timeout;
+    let mut attempts = 0u32;
+    loop {
+        match attempt()? {
+            Step::Done(value) => return Ok(value),
+            Step::Fail(error) => return Err(error),
+            Step::Retry => {}
+        }
+        match next_wakeup(options, deadline, attempts) {
+            Wakeup::TimedOut => {
+                return Err(crate::FalkorDBError::Timeout {
+                    operation,
+                    timeout: options.timeout,
+                })
+            }
+            Wakeup::Sleep(delay) => std::thread::sleep(delay),
+        }
+        attempts += 1;
+    }
+}
+
+/// `true` if `error` is a transient `GRAPH.COPY` failure that should be retried (the server was
+/// temporarily unable to `fork`). FalkorDB's own tests retry copies on this condition.
+pub(crate) fn is_transient_copy_error(error: &crate::FalkorDBError) -> bool {
+    match error {
+        crate::FalkorDBError::RedisError(message)
+        | crate::FalkorDBError::RedisParsingError(message) => {
+            message.to_lowercase().contains("could not fork")
+        }
+        _ => false,
+    }
+}
+
+/// `true` if `properties` describe the same set of property names (order-insensitive).
+fn same_property_set(
+    left: &[String],
+    right: &[String],
+) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut left = left.to_vec();
+    let mut right = right.to_vec();
+    left.sort();
+    right.sort();
+    left == right
+}
+
+/// `true` once an index of `index_type` covering every property in `properties` is operational.
+fn index_is_ready(
+    indices: &[FalkorIndex],
+    entity_type: EntityType,
+    label: &str,
+    properties: &[String],
+    index_type: IndexType,
+) -> bool {
+    indices.iter().any(|index| {
+        index.entity_type == entity_type
+            && index.index_label == label
+            && index.status == IndexStatus::Active
+            && properties.iter().all(|property| {
+                index
+                    .field_types
+                    .get(property)
+                    .is_some_and(|types| types.contains(&index_type))
+            })
+    })
+}
+
+/// `true` once no property in `properties` is still indexed with `index_type`.
+fn index_is_dropped(
+    indices: &[FalkorIndex],
+    entity_type: EntityType,
+    label: &str,
+    properties: &[String],
+    index_type: IndexType,
+) -> bool {
+    !indices.iter().any(|index| {
+        index.entity_type == entity_type
+            && index.index_label == label
+            && properties.iter().any(|property| {
+                index
+                    .field_types
+                    .get(property)
+                    .is_some_and(|types| types.contains(&index_type))
+            })
+    })
+}
+
+/// The readiness of a constraint, or [`ConstraintReadiness::Pending`] if it is not visible yet.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ConstraintReadiness {
+    Ready,
+    Pending,
+    Failed,
+}
+
+fn constraint_readiness(
+    constraints: &[Constraint],
+    constraint_type: ConstraintType,
+    entity_type: EntityType,
+    label: &str,
+    properties: &[String],
+) -> ConstraintReadiness {
+    match constraints.iter().find(|constraint| {
+        constraint.constraint_type == constraint_type
+            && constraint.entity_type == entity_type
+            && constraint.label == label
+            && same_property_set(&constraint.properties, properties)
+    }) {
+        Some(constraint) => match constraint.status {
+            ConstraintStatus::Active => ConstraintReadiness::Ready,
+            ConstraintStatus::Pending => ConstraintReadiness::Pending,
+            ConstraintStatus::Failed => ConstraintReadiness::Failed,
+        },
+        None => ConstraintReadiness::Pending,
+    }
+}
+
+fn constraint_is_dropped(
+    constraints: &[Constraint],
+    constraint_type: ConstraintType,
+    entity_type: EntityType,
+    label: &str,
+    properties: &[String],
+) -> bool {
+    !constraints.iter().any(|constraint| {
+        constraint.constraint_type == constraint_type
+            && constraint.entity_type == entity_type
+            && constraint.label == label
+            && same_property_set(&constraint.properties, properties)
+    })
+}
+
+/// A pending index readiness check shared by the sync and async wait loops.
+struct IndexWait {
+    drop: bool,
+    index_type: IndexType,
+    entity_type: EntityType,
+    label: String,
+    properties: Vec<String>,
+}
+
+impl IndexWait {
+    fn satisfied(
+        &self,
+        indices: &[FalkorIndex],
+    ) -> bool {
+        if self.drop {
+            index_is_dropped(
+                indices,
+                self.entity_type,
+                &self.label,
+                &self.properties,
+                self.index_type,
+            )
+        } else {
+            index_is_ready(
+                indices,
+                self.entity_type,
+                &self.label,
+                &self.properties,
+                self.index_type,
+            )
+        }
+    }
+}
+
+/// A pending constraint readiness check shared by the sync and async wait loops.
+struct ConstraintWait {
+    drop: bool,
+    constraint_type: ConstraintType,
+    entity_type: EntityType,
+    label: String,
+    properties: Vec<String>,
+}
+
+impl ConstraintWait {
+    fn step(
+        &self,
+        constraints: &[Constraint],
+    ) -> Step<()> {
+        if self.drop {
+            return bool_step(constraint_is_dropped(
+                constraints,
+                self.constraint_type,
+                self.entity_type,
+                &self.label,
+                &self.properties,
+            ));
+        }
+        match constraint_readiness(
+            constraints,
+            self.constraint_type,
+            self.entity_type,
+            &self.label,
+            &self.properties,
+        ) {
+            ConstraintReadiness::Ready => Step::Done(()),
+            ConstraintReadiness::Pending => Step::Retry,
+            ConstraintReadiness::Failed => Step::Fail(crate::FalkorDBError::ConstraintFailed {
+                label: self.label.clone(),
+                properties: self.properties.clone(),
+                constraint_type: self.constraint_type,
+            }),
+        }
+    }
+}
+
+fn bool_step(done: bool) -> Step<()> {
+    if done {
+        Step::Done(())
+    } else {
+        Step::Retry
+    }
+}
+
+/// A readiness check against either the index list or the constraint list.
+enum Wait {
+    Index(IndexWait),
+    Constraint(ConstraintWait),
+}
+
+impl Wait {
+    fn operation(&self) -> WaitOperation {
+        match self {
+            Wait::Index(wait) if wait.drop => WaitOperation::IndexDrop,
+            Wait::Index(_) => WaitOperation::IndexCreation,
+            Wait::Constraint(wait) if wait.drop => WaitOperation::ConstraintDrop,
+            Wait::Constraint(_) => WaitOperation::ConstraintCreation,
+        }
+    }
+}
+
+/// The index operation a builder represents, independent of sync/async execution.
+pub(crate) enum IndexOp {
+    Create {
+        index_type: IndexType,
+        entity_type: EntityType,
+        label: String,
+        properties: Vec<String>,
+        options: Option<std::collections::HashMap<String, String>>,
+    },
+    Drop {
+        index_type: IndexType,
+        entity_type: EntityType,
+        label: String,
+        properties: Vec<String>,
+    },
+}
+
+impl IndexOp {
+    fn to_wait(&self) -> Wait {
+        let (drop, index_type, entity_type, label, properties) = match self {
+            IndexOp::Create {
+                index_type,
+                entity_type,
+                label,
+                properties,
+                ..
+            } => (
+                false,
+                *index_type,
+                *entity_type,
+                label.clone(),
+                properties.clone(),
+            ),
+            IndexOp::Drop {
+                index_type,
+                entity_type,
+                label,
+                properties,
+            } => (
+                true,
+                *index_type,
+                *entity_type,
+                label.clone(),
+                properties.clone(),
+            ),
+        };
+        Wait::Index(IndexWait {
+            drop,
+            index_type,
+            entity_type,
+            label,
+            properties,
+        })
+    }
+}
+
+/// The constraint operation a builder represents, independent of sync/async execution.
+pub(crate) enum ConstraintOp {
+    CreateUnique {
+        entity_type: EntityType,
+        label: String,
+        properties: Vec<String>,
+    },
+    CreateMandatory {
+        entity_type: EntityType,
+        label: String,
+        properties: Vec<String>,
+    },
+    Drop {
+        constraint_type: ConstraintType,
+        entity_type: EntityType,
+        label: String,
+        properties: Vec<String>,
+    },
+}
+
+impl ConstraintOp {
+    fn to_wait(&self) -> Wait {
+        let (drop, constraint_type, entity_type, label, properties) = match self {
+            ConstraintOp::CreateUnique {
+                entity_type,
+                label,
+                properties,
+            } => (
+                false,
+                ConstraintType::Unique,
+                *entity_type,
+                label.clone(),
+                properties.clone(),
+            ),
+            ConstraintOp::CreateMandatory {
+                entity_type,
+                label,
+                properties,
+            } => (
+                false,
+                ConstraintType::Mandatory,
+                *entity_type,
+                label.clone(),
+                properties.clone(),
+            ),
+            ConstraintOp::Drop {
+                constraint_type,
+                entity_type,
+                label,
+                properties,
+            } => (
+                true,
+                *constraint_type,
+                *entity_type,
+                label.clone(),
+                properties.clone(),
+            ),
+        };
+        Wait::Constraint(ConstraintWait {
+            drop,
+            constraint_type,
+            entity_type,
+            label,
+            properties,
+        })
+    }
+}
+
+/// Converts a slice of `Display` properties into owned strings for storage in a builder.
+pub(crate) fn owned_properties<P: std::fmt::Display>(properties: &[P]) -> Vec<String> {
+    properties
+        .iter()
+        .map(|property| property.to_string())
+        .collect()
+}
+
+/// Converts owned property strings back into `&str` slices for the constraint commands.
+pub(crate) fn property_refs(properties: &[String]) -> Vec<&str> {
+    properties.iter().map(String::as_str).collect()
+}
+
+#[cfg(feature = "tokio")]
+mod async_ops;
+mod blocking_ops;
+
+#[cfg(feature = "tokio")]
+pub use async_ops::{AsyncConstraintOpBuilder, AsyncCopyGraphBuilder, AsyncIndexOpBuilder};
+pub use blocking_ops::{ConstraintOpBuilder, CopyGraphBuilder, IndexOpBuilder};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn index(
+        entity_type: EntityType,
+        label: &str,
+        status: IndexStatus,
+        field: &str,
+        index_type: IndexType,
+    ) -> FalkorIndex {
+        let mut field_types = HashMap::new();
+        field_types.insert(field.to_string(), vec![index_type]);
+        FalkorIndex {
+            entity_type,
+            status,
+            index_label: label.to_string(),
+            fields: vec![field.to_string()],
+            field_types,
+            language: String::new(),
+            stopwords: vec![],
+            info: HashMap::new(),
+            options: HashMap::new(),
+        }
+    }
+
+    fn constraint(
+        constraint_type: ConstraintType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+        status: ConstraintStatus,
+    ) -> Constraint {
+        Constraint {
+            constraint_type,
+            label: label.to_string(),
+            properties: properties.iter().map(|p| p.to_string()).collect(),
+            entity_type,
+            status,
+        }
+    }
+
+    #[test]
+    fn wait_options_defaults() {
+        let options = WaitOptions::new();
+        assert_eq!(options.timeout, DEFAULT_READINESS_TIMEOUT);
+        assert_eq!(options.poll_interval, DEFAULT_POLL_INTERVAL);
+        assert_eq!(options.backoff_factor, DEFAULT_BACKOFF_FACTOR);
+        assert_eq!(options.max_interval, DEFAULT_MAX_INTERVAL);
+    }
+
+    #[test]
+    fn wait_options_for_copy_uses_longer_timeout() {
+        assert_eq!(WaitOptions::for_copy().timeout, DEFAULT_COPY_TIMEOUT);
+    }
+
+    #[test]
+    fn wait_options_with_timeout() {
+        let options = WaitOptions::with_timeout(Duration::from_secs(7));
+        assert_eq!(options.timeout, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn wait_options_normalize_inputs() {
+        let options = WaitOptions::new()
+            .poll_interval(Duration::ZERO)
+            .backoff_factor(0.1)
+            .max_interval(Duration::ZERO);
+        assert_eq!(options.poll_interval, MIN_POLL_INTERVAL);
+        assert_eq!(options.backoff_factor, 1.0);
+        // max_interval can never drop below poll_interval.
+        assert_eq!(options.max_interval, MIN_POLL_INTERVAL);
+    }
+
+    #[test]
+    fn wait_options_poll_interval_raises_max_interval() {
+        let options = WaitOptions::new().poll_interval(Duration::from_secs(5));
+        assert_eq!(options.poll_interval, Duration::from_secs(5));
+        assert_eq!(options.max_interval, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn delay_for_attempt_grows_and_caps() {
+        let options = WaitOptions::new()
+            .poll_interval(Duration::from_millis(100))
+            .backoff_factor(2.0)
+            .max_interval(Duration::from_millis(500));
+        assert_eq!(options.delay_for_attempt(0), Duration::from_millis(100));
+        assert_eq!(options.delay_for_attempt(1), Duration::from_millis(200));
+        assert_eq!(options.delay_for_attempt(2), Duration::from_millis(400));
+        // capped at max_interval
+        assert_eq!(options.delay_for_attempt(3), Duration::from_millis(500));
+        assert_eq!(options.delay_for_attempt(1000), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn next_wakeup_sleeps_then_times_out() {
+        let options = WaitOptions::new();
+        let future = Instant::now() + Duration::from_secs(60);
+        assert!(matches!(next_wakeup(&options, future, 0), Wakeup::Sleep(_)));
+        let past = Instant::now() - Duration::from_secs(1);
+        assert!(matches!(next_wakeup(&options, past, 0), Wakeup::TimedOut));
+    }
+
+    #[test]
+    fn wait_operation_display() {
+        assert_eq!(WaitOperation::IndexCreation.to_string(), "index creation");
+        assert_eq!(WaitOperation::IndexDrop.to_string(), "index drop");
+        assert_eq!(
+            WaitOperation::ConstraintCreation.to_string(),
+            "constraint creation"
+        );
+        assert_eq!(WaitOperation::ConstraintDrop.to_string(), "constraint drop");
+        assert_eq!(WaitOperation::GraphCopy.to_string(), "graph copy");
+    }
+
+    #[test]
+    fn poll_sync_returns_first_done() {
+        let mut calls = 0;
+        let value = poll_sync(&WaitOptions::new(), WaitOperation::IndexCreation, || {
+            calls += 1;
+            Ok(Step::Done(calls))
+        })
+        .unwrap();
+        assert_eq!(value, 1);
+    }
+
+    #[test]
+    fn poll_sync_retries_until_done() {
+        let options = WaitOptions::new().poll_interval(Duration::from_millis(1));
+        let mut calls = 0;
+        let value = poll_sync(&options, WaitOperation::IndexCreation, || {
+            calls += 1;
+            Ok(if calls >= 3 {
+                Step::Done(calls)
+            } else {
+                Step::Retry
+            })
+        })
+        .unwrap();
+        assert_eq!(value, 3);
+    }
+
+    #[test]
+    fn poll_sync_propagates_fail() {
+        let result: crate::FalkorResult<()> = poll_sync(
+            &WaitOptions::new(),
+            WaitOperation::ConstraintCreation,
+            || {
+                Ok(Step::Fail(crate::FalkorDBError::ConstraintFailed {
+                    label: "L".to_string(),
+                    properties: vec!["p".to_string()],
+                    constraint_type: ConstraintType::Unique,
+                }))
+            },
+        );
+        assert!(matches!(
+            result,
+            Err(crate::FalkorDBError::ConstraintFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn poll_sync_propagates_attempt_error() {
+        let result: crate::FalkorResult<()> =
+            poll_sync(&WaitOptions::new(), WaitOperation::IndexCreation, || {
+                Err(crate::FalkorDBError::ConnectionDown)
+            });
+        assert!(matches!(result, Err(crate::FalkorDBError::ConnectionDown)));
+    }
+
+    #[test]
+    fn poll_sync_times_out() {
+        let options = WaitOptions::with_timeout(Duration::ZERO);
+        let result: crate::FalkorResult<()> =
+            poll_sync(&options, WaitOperation::GraphCopy, || Ok(Step::Retry));
+        match result {
+            Err(crate::FalkorDBError::Timeout { operation, timeout }) => {
+                assert_eq!(operation, WaitOperation::GraphCopy);
+                assert_eq!(timeout, Duration::ZERO);
+            }
+            other => panic!("expected timeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transient_copy_error_detection() {
+        assert!(is_transient_copy_error(&crate::FalkorDBError::RedisError(
+            "GRAPH.COPY failed, could not fork".to_string()
+        )));
+        assert!(is_transient_copy_error(
+            &crate::FalkorDBError::RedisParsingError("Could Not Fork".to_string())
+        ));
+        assert!(!is_transient_copy_error(&crate::FalkorDBError::RedisError(
+            "destination key already exists".to_string()
+        )));
+        assert!(!is_transient_copy_error(
+            &crate::FalkorDBError::ConnectionDown
+        ));
+    }
+
+    #[test]
+    fn same_property_set_is_order_insensitive() {
+        assert!(same_property_set(
+            &["a".to_string(), "b".to_string()],
+            &["b".to_string(), "a".to_string()]
+        ));
+        assert!(!same_property_set(
+            &["a".to_string()],
+            &["a".to_string(), "b".to_string()]
+        ));
+        assert!(!same_property_set(&["a".to_string()], &["b".to_string()]));
+    }
+
+    #[test]
+    fn index_ready_requires_active_and_all_properties() {
+        let mut multi = index(
+            EntityType::Node,
+            "P",
+            IndexStatus::Active,
+            "name",
+            IndexType::Range,
+        );
+        multi
+            .field_types
+            .insert("age".to_string(), vec![IndexType::Range]);
+        multi.fields.push("age".to_string());
+
+        let props = vec!["name".to_string(), "age".to_string()];
+        assert!(index_is_ready(
+            std::slice::from_ref(&multi),
+            EntityType::Node,
+            "P",
+            &props,
+            IndexType::Range
+        ));
+
+        let pending = index(
+            EntityType::Node,
+            "P",
+            IndexStatus::Pending,
+            "name",
+            IndexType::Range,
+        );
+        assert!(!index_is_ready(
+            &[pending],
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Range
+        ));
+
+        // Wrong index type / wrong label / missing property all read as not ready.
+        let range = index(
+            EntityType::Node,
+            "P",
+            IndexStatus::Active,
+            "name",
+            IndexType::Range,
+        );
+        assert!(!index_is_ready(
+            std::slice::from_ref(&range),
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Vector
+        ));
+        assert!(!index_is_ready(
+            std::slice::from_ref(&range),
+            EntityType::Node,
+            "Other",
+            &["name".to_string()],
+            IndexType::Range
+        ));
+        assert!(!index_is_ready(
+            &[],
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Range
+        ));
+    }
+
+    #[test]
+    fn index_dropped_when_type_absent() {
+        let range = index(
+            EntityType::Node,
+            "P",
+            IndexStatus::Active,
+            "name",
+            IndexType::Range,
+        );
+        // Same property still indexed with this type -> not dropped.
+        assert!(!index_is_dropped(
+            std::slice::from_ref(&range),
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Range
+        ));
+        // A different index type was dropped even though the range index remains.
+        assert!(index_is_dropped(
+            std::slice::from_ref(&range),
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Vector
+        ));
+        assert!(index_is_dropped(
+            &[],
+            EntityType::Node,
+            "P",
+            &["name".to_string()],
+            IndexType::Range
+        ));
+    }
+
+    #[test]
+    fn constraint_readiness_states() {
+        let props = ["id"];
+        let active = constraint(
+            ConstraintType::Unique,
+            EntityType::Node,
+            "P",
+            &props,
+            ConstraintStatus::Active,
+        );
+        let pending = constraint(
+            ConstraintType::Unique,
+            EntityType::Node,
+            "P",
+            &props,
+            ConstraintStatus::Pending,
+        );
+        let failed = constraint(
+            ConstraintType::Unique,
+            EntityType::Node,
+            "P",
+            &props,
+            ConstraintStatus::Failed,
+        );
+        let needle = vec!["id".to_string()];
+
+        assert_eq!(
+            constraint_readiness(
+                &[active],
+                ConstraintType::Unique,
+                EntityType::Node,
+                "P",
+                &needle
+            ),
+            ConstraintReadiness::Ready
+        );
+        assert_eq!(
+            constraint_readiness(
+                &[pending],
+                ConstraintType::Unique,
+                EntityType::Node,
+                "P",
+                &needle
+            ),
+            ConstraintReadiness::Pending
+        );
+        assert_eq!(
+            constraint_readiness(
+                &[failed],
+                ConstraintType::Unique,
+                EntityType::Node,
+                "P",
+                &needle
+            ),
+            ConstraintReadiness::Failed
+        );
+        // Not visible yet reads as pending.
+        assert_eq!(
+            constraint_readiness(&[], ConstraintType::Unique, EntityType::Node, "P", &needle),
+            ConstraintReadiness::Pending
+        );
+    }
+
+    #[test]
+    fn constraint_dropped_detection() {
+        let props = ["id"];
+        let existing = constraint(
+            ConstraintType::Mandatory,
+            EntityType::Node,
+            "P",
+            &props,
+            ConstraintStatus::Active,
+        );
+        let needle = vec!["id".to_string()];
+        assert!(!constraint_is_dropped(
+            std::slice::from_ref(&existing),
+            ConstraintType::Mandatory,
+            EntityType::Node,
+            "P",
+            &needle
+        ));
+        assert!(constraint_is_dropped(
+            &[],
+            ConstraintType::Mandatory,
+            EntityType::Node,
+            "P",
+            &needle
+        ));
+    }
+
+    #[test]
+    fn index_wait_satisfied_dispatch() {
+        let ready = index(
+            EntityType::Node,
+            "P",
+            IndexStatus::Active,
+            "name",
+            IndexType::Range,
+        );
+        let create = IndexWait {
+            drop: false,
+            index_type: IndexType::Range,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec!["name".to_string()],
+        };
+        assert!(create.satisfied(std::slice::from_ref(&ready)));
+
+        let drop = IndexWait {
+            drop: true,
+            index_type: IndexType::Range,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec!["name".to_string()],
+        };
+        assert!(!drop.satisfied(std::slice::from_ref(&ready)));
+        assert!(drop.satisfied(&[]));
+    }
+
+    #[test]
+    fn constraint_wait_step_dispatch() {
+        let failed = constraint(
+            ConstraintType::Unique,
+            EntityType::Node,
+            "P",
+            &["id"],
+            ConstraintStatus::Failed,
+        );
+        let create = ConstraintWait {
+            drop: false,
+            constraint_type: ConstraintType::Unique,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec!["id".to_string()],
+        };
+        assert!(matches!(
+            create.step(std::slice::from_ref(&failed)),
+            Step::Fail(crate::FalkorDBError::ConstraintFailed { .. })
+        ));
+        assert!(matches!(create.step(&[]), Step::Retry));
+
+        let active = constraint(
+            ConstraintType::Unique,
+            EntityType::Node,
+            "P",
+            &["id"],
+            ConstraintStatus::Active,
+        );
+        assert!(matches!(create.step(&[active]), Step::Done(())));
+
+        let drop = ConstraintWait {
+            drop: true,
+            constraint_type: ConstraintType::Unique,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec!["id".to_string()],
+        };
+        assert!(matches!(drop.step(&[]), Step::Done(())));
+    }
+
+    #[test]
+    fn wait_operation_mapping() {
+        let index_create = Wait::Index(IndexWait {
+            drop: false,
+            index_type: IndexType::Range,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec![],
+        });
+        assert_eq!(index_create.operation(), WaitOperation::IndexCreation);
+
+        let index_drop = Wait::Index(IndexWait {
+            drop: true,
+            index_type: IndexType::Range,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec![],
+        });
+        assert_eq!(index_drop.operation(), WaitOperation::IndexDrop);
+
+        let constraint_create = Wait::Constraint(ConstraintWait {
+            drop: false,
+            constraint_type: ConstraintType::Unique,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec![],
+        });
+        assert_eq!(
+            constraint_create.operation(),
+            WaitOperation::ConstraintCreation
+        );
+
+        let constraint_drop = Wait::Constraint(ConstraintWait {
+            drop: true,
+            constraint_type: ConstraintType::Unique,
+            entity_type: EntityType::Node,
+            label: "P".to_string(),
+            properties: vec![],
+        });
+        assert_eq!(constraint_drop.operation(), WaitOperation::ConstraintDrop);
+    }
+}

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -244,7 +244,7 @@ pub(crate) async fn poll_async<S, T>(
     mut attempt: impl for<'s> FnMut(
         &'s mut S,
     ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = crate::FalkorResult<Step<T>>> + 's>,
+        Box<dyn std::future::Future<Output = crate::FalkorResult<Step<T>>> + Send + 's>,
     >,
 ) -> crate::FalkorResult<T> {
     let deadline = deadline_for(options.timeout);

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -145,7 +145,13 @@ impl WaitOptions {
     ) -> Duration {
         let exponent = i32::try_from(attempt).unwrap_or(i32::MAX);
         let scaled = self.poll_interval.as_secs_f64() * self.backoff_factor.powi(exponent);
-        Duration::from_secs_f64(scaled.min(self.max_interval.as_secs_f64()))
+        let capped = self.max_interval.as_secs_f64();
+        // Guard against non-finite (`NaN`/`inf`) or out-of-range values that would make
+        // `Duration::from_secs_f64` panic: fall back to the (already finite) `max_interval`.
+        if !scaled.is_finite() || scaled >= capped {
+            return self.max_interval;
+        }
+        Duration::try_from_secs_f64(scaled).unwrap_or(self.max_interval)
     }
 }
 
@@ -222,18 +228,29 @@ pub(crate) fn poll_sync<T>(
 
 /// Asynchronously polls `attempt` until it is [`Step::Done`]/[`Step::Fail`] or the timeout
 /// elapses. This is the async counterpart of [`poll_sync`] and shares the exact same backoff and
-/// deadline logic; it is generic over an async closure so the index/constraint wait (which needs
-/// `&mut AsyncGraph`) and the graph-copy wait (which needs `&FalkorAsyncClient`) can both reuse it.
+/// deadline logic.
+///
+/// `attempt` receives `&mut state` on every poll and returns a boxed future. This explicit
+/// `FnMut(&mut S) -> Pin<Box<dyn Future>>` shape (rather than an async closure / `AsyncFnMut`)
+/// mirrors `crate::test_utils::retry_until_async` so the crate keeps compiling on all stable
+/// toolchains. Threading the polled value through `&mut state` lets both the index/constraint
+/// wait (`state = &mut AsyncGraph`) and the graph-copy wait (`state` carrying the client and graph
+/// names) reuse this single loop.
 #[cfg(feature = "tokio")]
-pub(crate) async fn poll_async<T>(
+pub(crate) async fn poll_async<S, T>(
+    state: &mut S,
     options: &WaitOptions,
     operation: WaitOperation,
-    mut attempt: impl AsyncFnMut() -> crate::FalkorResult<Step<T>>,
+    mut attempt: impl for<'s> FnMut(
+        &'s mut S,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = crate::FalkorResult<Step<T>>> + 's>,
+    >,
 ) -> crate::FalkorResult<T> {
     let deadline = deadline_for(options.timeout);
     let mut attempts = 0u32;
     loop {
-        match attempt().await? {
+        match attempt(state).await? {
             Step::Done(value) => return Ok(value),
             Step::Fail(error) => return Err(error),
             Step::Retry => {}
@@ -729,6 +746,23 @@ mod tests {
     }
 
     #[test]
+    fn delay_for_attempt_handles_non_finite_and_overflow() {
+        // A very large `max_interval` combined with a growing backoff must never panic in
+        // `Duration::from_secs_f64`; it falls back to `max_interval`.
+        let huge = WaitOptions::new()
+            .poll_interval(Duration::from_secs(1))
+            .backoff_factor(10.0)
+            .max_interval(Duration::MAX);
+        assert_eq!(huge.delay_for_attempt(u32::MAX), Duration::MAX);
+        // An infinite backoff factor saturates to `max_interval` rather than panicking.
+        let infinite = WaitOptions::new()
+            .poll_interval(Duration::from_millis(10))
+            .backoff_factor(f64::INFINITY)
+            .max_interval(Duration::from_millis(500));
+        assert_eq!(infinite.delay_for_attempt(1), Duration::from_millis(500));
+    }
+
+    #[test]
     fn next_wakeup_sleeps_then_times_out() {
         let options = WaitOptions::new();
         let future = Instant::now() + Duration::from_secs(60);
@@ -1200,9 +1234,10 @@ mod tests {
     #[tokio::test]
     async fn poll_async_returns_first_done() {
         let value = poll_async(
+            &mut (),
             &WaitOptions::new(),
             WaitOperation::IndexCreation,
-            async || Ok::<_, crate::FalkorDBError>(Step::Done(7)),
+            |()| Box::pin(async { Ok::<_, crate::FalkorDBError>(Step::Done(7)) }),
         )
         .await
         .unwrap();
@@ -1214,14 +1249,21 @@ mod tests {
     async fn poll_async_retries_until_done() {
         let options = WaitOptions::new().poll_interval(Duration::from_millis(1));
         let mut calls = 0u32;
-        let value = poll_async(&options, WaitOperation::IndexCreation, async || {
-            calls += 1;
-            Ok::<_, crate::FalkorDBError>(if calls < 3 {
-                Step::Retry
-            } else {
-                Step::Done(calls)
-            })
-        })
+        let value = poll_async(
+            &mut calls,
+            &options,
+            WaitOperation::IndexCreation,
+            |calls| {
+                Box::pin(async move {
+                    *calls += 1;
+                    Ok::<_, crate::FalkorDBError>(if *calls < 3 {
+                        Step::Retry
+                    } else {
+                        Step::Done(*calls)
+                    })
+                })
+            },
+        )
         .await
         .unwrap();
         assert_eq!(value, 3);
@@ -1231,14 +1273,17 @@ mod tests {
     #[tokio::test]
     async fn poll_async_propagates_fail() {
         let result: crate::FalkorResult<()> = poll_async(
+            &mut (),
             &WaitOptions::new(),
             WaitOperation::ConstraintCreation,
-            async || {
-                Ok(Step::Fail(crate::FalkorDBError::ConstraintFailed {
-                    label: "P".to_string(),
-                    properties: vec!["id".to_string()],
-                    constraint_type: ConstraintType::Unique,
-                }))
+            |()| {
+                Box::pin(async {
+                    Ok(Step::Fail(crate::FalkorDBError::ConstraintFailed {
+                        label: "P".to_string(),
+                        properties: vec!["id".to_string()],
+                        constraint_type: ConstraintType::Unique,
+                    }))
+                })
             },
         )
         .await;
@@ -1252,9 +1297,10 @@ mod tests {
     #[tokio::test]
     async fn poll_async_propagates_attempt_error() {
         let result: crate::FalkorResult<()> = poll_async(
+            &mut (),
             &WaitOptions::new(),
             WaitOperation::IndexCreation,
-            async || Err(crate::FalkorDBError::ParsingArray),
+            |()| Box::pin(async { Err(crate::FalkorDBError::ParsingArray) }),
         )
         .await;
         assert!(matches!(result, Err(crate::FalkorDBError::ParsingArray)));
@@ -1265,7 +1311,10 @@ mod tests {
     async fn poll_async_times_out() {
         let options = WaitOptions::new().timeout(Duration::ZERO);
         let result: crate::FalkorResult<()> =
-            poll_async(&options, WaitOperation::GraphCopy, async || Ok(Step::Retry)).await;
+            poll_async(&mut (), &options, WaitOperation::GraphCopy, |()| {
+                Box::pin(async { Ok(Step::Retry) })
+            })
+            .await;
         assert!(matches!(
             result,
             Err(crate::FalkorDBError::Timeout {

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -156,6 +156,7 @@ impl WaitOptions {
 }
 
 /// The outcome of a single poll attempt.
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub(crate) enum Step<T> {
     /// The operation finished; return this value.
     Done(T),
@@ -166,6 +167,7 @@ pub(crate) enum Step<T> {
 }
 
 /// What to do after a [`Step::Retry`], computed against the deadline.
+#[cfg_attr(test, derive(Debug, PartialEq))]
 enum Wakeup {
     /// Sleep for this long, then poll again.
     Sleep(Duration),
@@ -766,17 +768,17 @@ mod tests {
     fn next_wakeup_sleeps_then_times_out() {
         let options = WaitOptions::new();
         let future = Instant::now() + Duration::from_secs(60);
-        assert!(matches!(
+        assert_eq!(
             next_wakeup(&options, Some(future), 0),
-            Wakeup::Sleep(_)
-        ));
+            Wakeup::Sleep(Duration::from_millis(50))
+        );
         let past = Instant::now() - Duration::from_secs(1);
-        assert!(matches!(
-            next_wakeup(&options, Some(past), 0),
-            Wakeup::TimedOut
-        ));
+        assert_eq!(next_wakeup(&options, Some(past), 0), Wakeup::TimedOut);
         // No deadline (overflowing timeout) never times out.
-        assert!(matches!(next_wakeup(&options, None, 0), Wakeup::Sleep(_)));
+        assert_eq!(
+            next_wakeup(&options, None, 0),
+            Wakeup::Sleep(Duration::from_millis(50))
+        );
     }
 
     #[test]
@@ -837,10 +839,14 @@ mod tests {
                 }))
             },
         );
-        assert!(matches!(
+        assert_eq!(
             result,
-            Err(crate::FalkorDBError::ConstraintFailed { .. })
-        ));
+            Err(crate::FalkorDBError::ConstraintFailed {
+                label: "L".to_string(),
+                properties: vec!["p".to_string()],
+                constraint_type: ConstraintType::Unique,
+            })
+        );
     }
 
     #[test]
@@ -849,7 +855,7 @@ mod tests {
             poll_sync(&WaitOptions::new(), WaitOperation::IndexCreation, || {
                 Err(crate::FalkorDBError::ConnectionDown)
             });
-        assert!(matches!(result, Err(crate::FalkorDBError::ConnectionDown)));
+        assert_eq!(result, Err(crate::FalkorDBError::ConnectionDown));
     }
 
     #[test]
@@ -1117,34 +1123,33 @@ mod tests {
         assert!(drop.satisfied(&[]));
 
         // `step` maps the boolean readiness into a `Step` for both branches.
-        assert!(matches!(
-            create.step(std::slice::from_ref(&ready)),
-            Step::Done(())
-        ));
-        assert!(matches!(create.step(&[]), Step::Retry));
+        assert_eq!(create.step(std::slice::from_ref(&ready)), Step::Done(()));
+        assert_eq!(create.step(&[]), Step::Retry);
     }
 
     #[test]
     fn bool_step_maps_both_branches() {
-        assert!(matches!(bool_step(true), Step::Done(())));
-        assert!(matches!(bool_step(false), Step::Retry));
+        assert_eq!(bool_step(true), Step::Done(()));
+        assert_eq!(bool_step(false), Step::Retry);
     }
 
     #[test]
     fn classify_copy_result_maps_each_outcome() {
-        assert!(matches!(classify_copy_result::<u8>(Ok(7)), Step::Done(7)));
-        assert!(matches!(
+        assert_eq!(classify_copy_result::<u8>(Ok(7)), Step::Done(7));
+        assert_eq!(
             classify_copy_result::<u8>(Err(crate::FalkorDBError::RedisError(
                 "MISCONF could not fork".to_string()
             ))),
             Step::Retry
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             classify_copy_result::<u8>(Err(crate::FalkorDBError::RedisError(
                 "some other failure".to_string()
             ))),
-            Step::Fail(_)
-        ));
+            Step::Fail(crate::FalkorDBError::RedisError(
+                "some other failure".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -1163,11 +1168,15 @@ mod tests {
             label: "P".to_string(),
             properties: vec!["id".to_string()],
         };
-        assert!(matches!(
+        assert_eq!(
             create.step(std::slice::from_ref(&failed)),
-            Step::Fail(crate::FalkorDBError::ConstraintFailed { .. })
-        ));
-        assert!(matches!(create.step(&[]), Step::Retry));
+            Step::Fail(crate::FalkorDBError::ConstraintFailed {
+                label: "P".to_string(),
+                properties: vec!["id".to_string()],
+                constraint_type: ConstraintType::Unique,
+            })
+        );
+        assert_eq!(create.step(&[]), Step::Retry);
 
         let active = constraint(
             ConstraintType::Unique,
@@ -1176,7 +1185,7 @@ mod tests {
             &["id"],
             ConstraintStatus::Active,
         );
-        assert!(matches!(create.step(&[active]), Step::Done(())));
+        assert_eq!(create.step(&[active]), Step::Done(()));
 
         let drop = ConstraintWait {
             drop: true,
@@ -1185,7 +1194,7 @@ mod tests {
             label: "P".to_string(),
             properties: vec!["id".to_string()],
         };
-        assert!(matches!(drop.step(&[]), Step::Done(())));
+        assert_eq!(drop.step(&[]), Step::Done(()));
     }
 
     #[test]
@@ -1287,10 +1296,14 @@ mod tests {
             },
         )
         .await;
-        assert!(matches!(
+        assert_eq!(
             result,
-            Err(crate::FalkorDBError::ConstraintFailed { .. })
-        ));
+            Err(crate::FalkorDBError::ConstraintFailed {
+                label: "P".to_string(),
+                properties: vec!["id".to_string()],
+                constraint_type: ConstraintType::Unique,
+            })
+        );
     }
 
     #[cfg(feature = "tokio")]
@@ -1303,7 +1316,7 @@ mod tests {
             |()| Box::pin(async { Err(crate::FalkorDBError::ParsingArray) }),
         )
         .await;
-        assert!(matches!(result, Err(crate::FalkorDBError::ParsingArray)));
+        assert_eq!(result, Err(crate::FalkorDBError::ParsingArray));
     }
 
     #[cfg(feature = "tokio")]

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -55,7 +55,7 @@ impl<'a> AsyncIndexOpBuilder<'a> {
     ) -> FalkorResult<()> {
         let wait = self.op.to_wait();
         run_index_command(self.graph, &self.op).await?;
-        wait_async(self.graph, &options, &wait).await
+        wait_async(self.graph, &options, wait).await
     }
 }
 
@@ -101,7 +101,7 @@ impl<'a> AsyncConstraintOpBuilder<'a> {
     ) -> FalkorResult<()> {
         let wait = self.op.to_wait();
         run_constraint_command(self.graph, &self.op).await?;
-        wait_async(self.graph, &options, &wait).await
+        wait_async(self.graph, &options, wait).await
     }
 }
 
@@ -149,12 +149,15 @@ impl<'a> AsyncCopyGraphBuilder<'a> {
         self,
         options: WaitOptions,
     ) -> FalkorResult<AsyncGraph> {
-        poll_async(&options, WaitOperation::GraphCopy, async || {
-            Ok(classify_copy_result(
-                self.client
-                    .copy_graph(&self.source, &self.destination)
-                    .await,
-            ))
+        let mut this = self;
+        poll_async(&mut this, &options, WaitOperation::GraphCopy, |this| {
+            Box::pin(async move {
+                Ok(classify_copy_result(
+                    this.client
+                        .copy_graph(&this.source, &this.destination)
+                        .await,
+                ))
+            })
         })
         .await
     }
@@ -251,10 +254,13 @@ async fn evaluate_async(
 async fn wait_async(
     graph: &mut AsyncGraph,
     options: &WaitOptions,
-    wait: &Wait,
+    wait: Wait,
 ) -> FalkorResult<()> {
-    poll_async(options, wait.operation(), async || {
-        evaluate_async(graph, wait).await
+    let operation = wait.operation();
+    let mut state = (graph, wait);
+    poll_async(&mut state, options, operation, |state| {
+        let (graph, wait) = state;
+        Box::pin(evaluate_async(graph, wait))
     })
     .await
 }

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -6,8 +6,8 @@
 //! Async builder terminals for the background-operation helpers.
 
 use super::{
-    is_transient_copy_error, next_wakeup, owned_properties, property_refs, ConstraintOp, IndexOp,
-    Step, Wait, WaitOperation, WaitOptions, Wakeup,
+    classify_copy_result, owned_properties, poll_async, property_refs, ConstraintOp, IndexOp, Step,
+    Wait, WaitOperation, WaitOptions,
 };
 use crate::{
     AsyncGraph, ConstraintType, EntityType, FalkorAsyncClient, FalkorResult, IndexType,
@@ -15,7 +15,6 @@ use crate::{
 };
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::time::Instant;
 
 /// Builder for creating or dropping an index on an [`AsyncGraph`].
 ///
@@ -150,29 +149,14 @@ impl<'a> AsyncCopyGraphBuilder<'a> {
         self,
         options: WaitOptions,
     ) -> FalkorResult<AsyncGraph> {
-        let deadline = Instant::now() + options.timeout;
-        let mut attempts = 0u32;
-        loop {
-            match self
-                .client
-                .copy_graph(&self.source, &self.destination)
-                .await
-            {
-                Ok(graph) => return Ok(graph),
-                Err(error) if is_transient_copy_error(&error) => {}
-                Err(error) => return Err(error),
-            }
-            match next_wakeup(&options, deadline, attempts) {
-                Wakeup::TimedOut => {
-                    return Err(crate::FalkorDBError::Timeout {
-                        operation: WaitOperation::GraphCopy,
-                        timeout: options.timeout,
-                    })
-                }
-                Wakeup::Sleep(delay) => tokio::time::sleep(delay).await,
-            }
-            attempts += 1;
-        }
+        poll_async(&options, WaitOperation::GraphCopy, async || {
+            Ok(classify_copy_result(
+                self.client
+                    .copy_graph(&self.source, &self.destination)
+                    .await,
+            ))
+        })
+        .await
     }
 }
 
@@ -257,11 +241,7 @@ async fn evaluate_async(
     wait: &Wait,
 ) -> FalkorResult<Step<()>> {
     match wait {
-        Wait::Index(index_wait) => Ok(if index_wait.satisfied(&graph.list_indices().await?.data) {
-            Step::Done(())
-        } else {
-            Step::Retry
-        }),
+        Wait::Index(index_wait) => Ok(index_wait.step(&graph.list_indices().await?.data)),
         Wait::Constraint(constraint_wait) => {
             Ok(constraint_wait.step(&graph.list_constraints().await?.data))
         }
@@ -273,25 +253,10 @@ async fn wait_async(
     options: &WaitOptions,
     wait: &Wait,
 ) -> FalkorResult<()> {
-    let deadline = Instant::now() + options.timeout;
-    let mut attempts = 0u32;
-    loop {
-        match evaluate_async(graph, wait).await? {
-            Step::Done(value) => return Ok(value),
-            Step::Fail(error) => return Err(error),
-            Step::Retry => {}
-        }
-        match next_wakeup(options, deadline, attempts) {
-            Wakeup::TimedOut => {
-                return Err(crate::FalkorDBError::Timeout {
-                    operation: wait.operation(),
-                    timeout: options.timeout,
-                })
-            }
-            Wakeup::Sleep(delay) => tokio::time::sleep(delay).await,
-        }
-        attempts += 1;
-    }
+    poll_async(options, wait.operation(), async || {
+        evaluate_async(graph, wait).await
+    })
+    .await
 }
 
 impl AsyncGraph {

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -1,0 +1,404 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Async builder terminals for the background-operation helpers.
+
+use super::{
+    is_transient_copy_error, next_wakeup, owned_properties, property_refs, ConstraintOp, IndexOp,
+    Step, Wait, WaitOperation, WaitOptions, Wakeup,
+};
+use crate::{
+    AsyncGraph, ConstraintType, EntityType, FalkorAsyncClient, FalkorResult, IndexType,
+    LazyResultSet, QueryResult,
+};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::time::Instant;
+
+/// Builder for creating or dropping an index on an [`AsyncGraph`].
+///
+/// Created via [`AsyncGraph::create_index_op`] / [`AsyncGraph::drop_index_op`]. Use
+/// [`execute`](Self::execute) to issue the command without waiting, or [`wait`](Self::wait) /
+/// [`wait_with`](Self::wait_with) to await until the index is operational (create) or gone (drop).
+///
+/// Dropping the `wait` future cancels only client-side polling; the server keeps running the
+/// background operation.
+#[must_use = "an index op builder does nothing unless `.execute()` or `.wait()` is awaited"]
+pub struct AsyncIndexOpBuilder<'a> {
+    graph: &'a mut AsyncGraph,
+    op: IndexOp,
+}
+
+impl<'a> AsyncIndexOpBuilder<'a> {
+    pub(crate) fn new(
+        graph: &'a mut AsyncGraph,
+        op: IndexOp,
+    ) -> Self {
+        Self { graph, op }
+    }
+
+    /// Issues the index command without waiting (identical to the eager `create_index`/`drop_index`).
+    pub async fn execute(self) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+        run_index_command(self.graph, &self.op).await
+    }
+
+    /// Issues the command, then awaits (with default [`WaitOptions`]) until it has taken effect.
+    pub async fn wait(self) -> FalkorResult<()> {
+        self.wait_with(WaitOptions::default()).await
+    }
+
+    /// Issues the command, then awaits until it has taken effect or `options.timeout` elapses.
+    pub async fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<()> {
+        let wait = self.op.to_wait();
+        run_index_command(self.graph, &self.op).await?;
+        wait_async(self.graph, &options, &wait).await
+    }
+}
+
+/// Builder for creating or dropping a constraint on an [`AsyncGraph`].
+///
+/// Created via [`AsyncGraph::create_unique_constraint_op`],
+/// [`AsyncGraph::create_mandatory_constraint_op`] or [`AsyncGraph::drop_constraint_op`]. A `wait`
+/// on a create terminal returns [`crate::FalkorDBError::ConstraintFailed`] if the constraint
+/// reaches the terminal `FAILED` state.
+#[must_use = "a constraint op builder does nothing unless `.execute()` or `.wait()` is awaited"]
+pub struct AsyncConstraintOpBuilder<'a> {
+    graph: &'a mut AsyncGraph,
+    op: ConstraintOp,
+}
+
+impl<'a> AsyncConstraintOpBuilder<'a> {
+    pub(crate) fn new(
+        graph: &'a mut AsyncGraph,
+        op: ConstraintOp,
+    ) -> Self {
+        Self { graph, op }
+    }
+
+    /// Issues the constraint command without waiting.
+    pub async fn execute(self) -> FalkorResult<redis::Value> {
+        run_constraint_command(self.graph, &self.op).await
+    }
+
+    /// Issues the command, then awaits (with default [`WaitOptions`]) until it has taken effect.
+    pub async fn wait(self) -> FalkorResult<()> {
+        self.wait_with(WaitOptions::default()).await
+    }
+
+    /// Issues the command, then awaits until it has taken effect or `options.timeout` elapses.
+    pub async fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<()> {
+        let wait = self.op.to_wait();
+        run_constraint_command(self.graph, &self.op).await?;
+        wait_async(self.graph, &options, &wait).await
+    }
+}
+
+/// Builder for copying a graph via a [`FalkorAsyncClient`].
+///
+/// Created via [`FalkorAsyncClient::copy_graph_op`]. [`execute`](Self::execute) performs a single
+/// copy (identical to `copy_graph`); [`wait`](Self::wait) retries while the server reports a
+/// transient `could not fork` failure.
+#[must_use = "a copy graph builder does nothing unless `.execute()` or `.wait()` is awaited"]
+pub struct AsyncCopyGraphBuilder<'a> {
+    client: &'a FalkorAsyncClient,
+    source: String,
+    destination: String,
+}
+
+impl<'a> AsyncCopyGraphBuilder<'a> {
+    pub(crate) fn new(
+        client: &'a FalkorAsyncClient,
+        source: String,
+        destination: String,
+    ) -> Self {
+        Self {
+            client,
+            source,
+            destination,
+        }
+    }
+
+    /// Performs a single copy attempt (identical to [`FalkorAsyncClient::copy_graph`]).
+    pub async fn execute(self) -> FalkorResult<AsyncGraph> {
+        self.client
+            .copy_graph(&self.source, &self.destination)
+            .await
+    }
+
+    /// Copies the graph, retrying transient `could not fork` failures with the default copy
+    /// [`WaitOptions`] (60s). Non-transient errors are returned immediately and the destination
+    /// is never deleted.
+    pub async fn wait(self) -> FalkorResult<AsyncGraph> {
+        self.wait_with(WaitOptions::for_copy()).await
+    }
+
+    /// Copies the graph, retrying transient failures until success or `options.timeout`.
+    pub async fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<AsyncGraph> {
+        let deadline = Instant::now() + options.timeout;
+        let mut attempts = 0u32;
+        loop {
+            match self
+                .client
+                .copy_graph(&self.source, &self.destination)
+                .await
+            {
+                Ok(graph) => return Ok(graph),
+                Err(error) if is_transient_copy_error(&error) => {}
+                Err(error) => return Err(error),
+            }
+            match next_wakeup(&options, deadline, attempts) {
+                Wakeup::TimedOut => {
+                    return Err(crate::FalkorDBError::Timeout {
+                        operation: WaitOperation::GraphCopy,
+                        timeout: options.timeout,
+                    })
+                }
+                Wakeup::Sleep(delay) => tokio::time::sleep(delay).await,
+            }
+            attempts += 1;
+        }
+    }
+}
+
+async fn run_index_command<'a>(
+    graph: &'a mut AsyncGraph,
+    op: &IndexOp,
+) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+    match op {
+        IndexOp::Create {
+            index_type,
+            entity_type,
+            label,
+            properties,
+            options,
+        } => {
+            graph
+                .create_index(
+                    *index_type,
+                    *entity_type,
+                    label,
+                    properties,
+                    options.as_ref(),
+                )
+                .await
+        }
+        IndexOp::Drop {
+            index_type,
+            entity_type,
+            label,
+            properties,
+        } => {
+            graph
+                .drop_index(*index_type, *entity_type, label, properties)
+                .await
+        }
+    }
+}
+
+async fn run_constraint_command(
+    graph: &mut AsyncGraph,
+    op: &ConstraintOp,
+) -> FalkorResult<redis::Value> {
+    match op {
+        ConstraintOp::CreateUnique {
+            entity_type,
+            label,
+            properties,
+        } => {
+            graph
+                .create_unique_constraint(*entity_type, label.clone(), &property_refs(properties))
+                .await
+        }
+        ConstraintOp::CreateMandatory {
+            entity_type,
+            label,
+            properties,
+        } => {
+            graph
+                .create_mandatory_constraint(*entity_type, label, &property_refs(properties))
+                .await
+        }
+        ConstraintOp::Drop {
+            constraint_type,
+            entity_type,
+            label,
+            properties,
+        } => {
+            graph
+                .drop_constraint(
+                    *constraint_type,
+                    *entity_type,
+                    label,
+                    &property_refs(properties),
+                )
+                .await
+        }
+    }
+}
+
+async fn evaluate_async(
+    graph: &mut AsyncGraph,
+    wait: &Wait,
+) -> FalkorResult<Step<()>> {
+    match wait {
+        Wait::Index(index_wait) => Ok(if index_wait.satisfied(&graph.list_indices().await?.data) {
+            Step::Done(())
+        } else {
+            Step::Retry
+        }),
+        Wait::Constraint(constraint_wait) => {
+            Ok(constraint_wait.step(&graph.list_constraints().await?.data))
+        }
+    }
+}
+
+async fn wait_async(
+    graph: &mut AsyncGraph,
+    options: &WaitOptions,
+    wait: &Wait,
+) -> FalkorResult<()> {
+    let deadline = Instant::now() + options.timeout;
+    let mut attempts = 0u32;
+    loop {
+        match evaluate_async(graph, wait).await? {
+            Step::Done(value) => return Ok(value),
+            Step::Fail(error) => return Err(error),
+            Step::Retry => {}
+        }
+        match next_wakeup(options, deadline, attempts) {
+            Wakeup::TimedOut => {
+                return Err(crate::FalkorDBError::Timeout {
+                    operation: wait.operation(),
+                    timeout: options.timeout,
+                })
+            }
+            Wakeup::Sleep(delay) => tokio::time::sleep(delay).await,
+        }
+        attempts += 1;
+    }
+}
+
+impl AsyncGraph {
+    /// Returns a builder for creating an index, supporting `.execute()` (non-blocking) and
+    /// `.wait()` (await until operational). Arguments mirror [`AsyncGraph::create_index`].
+    pub fn create_index_op<P: Display>(
+        &mut self,
+        index_field_type: IndexType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[P],
+        options: Option<&HashMap<String, String>>,
+    ) -> AsyncIndexOpBuilder<'_> {
+        AsyncIndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: index_field_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+                options: options.cloned(),
+            },
+        )
+    }
+
+    /// Returns a builder for dropping an index, supporting `.execute()` (non-blocking) and
+    /// `.wait()` (await until gone). Arguments mirror [`AsyncGraph::drop_index`].
+    pub fn drop_index_op<P: Display>(
+        &mut self,
+        index_field_type: IndexType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[P],
+    ) -> AsyncIndexOpBuilder<'_> {
+        AsyncIndexOpBuilder::new(
+            self,
+            IndexOp::Drop {
+                index_type: index_field_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a unique constraint, supporting `.execute()` (non-blocking)
+    /// and `.wait()` (await until operational, or `FAILED`). Mirrors
+    /// [`AsyncGraph::create_unique_constraint`].
+    pub fn create_unique_constraint_op(
+        &mut self,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> AsyncConstraintOpBuilder<'_> {
+        AsyncConstraintOpBuilder::new(
+            self,
+            ConstraintOp::CreateUnique {
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a mandatory constraint, supporting `.execute()` and
+    /// `.wait()`. Mirrors [`AsyncGraph::create_mandatory_constraint`].
+    pub fn create_mandatory_constraint_op(
+        &mut self,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> AsyncConstraintOpBuilder<'_> {
+        AsyncConstraintOpBuilder::new(
+            self,
+            ConstraintOp::CreateMandatory {
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for dropping a constraint, supporting `.execute()` and `.wait()` (await
+    /// until the constraint is gone). Mirrors [`AsyncGraph::drop_constraint`].
+    pub fn drop_constraint_op(
+        &mut self,
+        constraint_type: ConstraintType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> AsyncConstraintOpBuilder<'_> {
+        AsyncConstraintOpBuilder::new(
+            self,
+            ConstraintOp::Drop {
+                constraint_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+}
+
+impl FalkorAsyncClient {
+    /// Returns a builder for copying a graph, supporting `.execute()` (single attempt) and
+    /// `.wait()` (retry transient `could not fork` failures). Mirrors
+    /// [`FalkorAsyncClient::copy_graph`].
+    pub fn copy_graph_op(
+        &self,
+        graph_to_clone: &str,
+        new_graph_name: &str,
+    ) -> AsyncCopyGraphBuilder<'_> {
+        AsyncCopyGraphBuilder::new(self, graph_to_clone.to_string(), new_graph_name.to_string())
+    }
+}

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -66,6 +66,11 @@ impl<'a> AsyncIndexOpBuilder<'a> {
 /// [`AsyncGraph::create_mandatory_constraint_op`] or [`AsyncGraph::drop_constraint_op`]. A `wait`
 /// on a create terminal returns [`crate::FalkorDBError::ConstraintFailed`] if the constraint
 /// reaches the terminal `FAILED` state.
+///
+/// For a unique constraint, `wait` polls `DB.CONSTRAINTS` until the constraint itself becomes
+/// operational. The server activates a unique constraint only after its backing range index is
+/// enabled, so polling the constraint already accounts for the backing index becoming ready — no
+/// separate index-readiness step is required.
 #[must_use = "a constraint op builder does nothing unless `.execute()` or `.wait()` is awaited"]
 pub struct AsyncConstraintOpBuilder<'a> {
     graph: &'a mut AsyncGraph,

--- a/src/graph/ops/blocking_ops.rs
+++ b/src/graph/ops/blocking_ops.rs
@@ -6,8 +6,8 @@
 //! Blocking builder terminals for the background-operation helpers.
 
 use super::{
-    is_transient_copy_error, owned_properties, poll_sync, property_refs, ConstraintOp, IndexOp,
-    Step, Wait, WaitOperation, WaitOptions,
+    classify_copy_result, owned_properties, poll_sync, property_refs, ConstraintOp, IndexOp, Wait,
+    WaitOperation, WaitOptions,
 };
 use crate::{
     ConstraintType, EntityType, FalkorResult, FalkorSyncClient, IndexType, LazyResultSet,
@@ -145,11 +145,9 @@ impl<'a> CopyGraphBuilder<'a> {
         options: WaitOptions,
     ) -> FalkorResult<SyncGraph> {
         poll_sync(&options, WaitOperation::GraphCopy, || {
-            match self.client.copy_graph(&self.source, &self.destination) {
-                Ok(graph) => Ok(Step::Done(graph)),
-                Err(error) if is_transient_copy_error(&error) => Ok(Step::Retry),
-                Err(error) => Ok(Step::Fail(error)),
-            }
+            Ok(classify_copy_result(
+                self.client.copy_graph(&self.source, &self.destination),
+            ))
         })
     }
 }
@@ -218,11 +216,7 @@ fn wait_sync(
     wait: &Wait,
 ) -> FalkorResult<()> {
     poll_sync(options, wait.operation(), || match wait {
-        Wait::Index(index_wait) => Ok(if index_wait.satisfied(&graph.list_indices()?.data) {
-            Step::Done(())
-        } else {
-            Step::Retry
-        }),
+        Wait::Index(index_wait) => Ok(index_wait.step(&graph.list_indices()?.data)),
         Wait::Constraint(constraint_wait) => {
             Ok(constraint_wait.step(&graph.list_constraints()?.data))
         }

--- a/src/graph/ops/blocking_ops.rs
+++ b/src/graph/ops/blocking_ops.rs
@@ -62,6 +62,11 @@ impl<'a> IndexOpBuilder<'a> {
 /// [`SyncGraph::create_mandatory_constraint_op`] or [`SyncGraph::drop_constraint_op`]. A `wait`
 /// on a create terminal returns [`crate::FalkorDBError::ConstraintFailed`] if the constraint
 /// reaches the terminal `FAILED` state (e.g. existing data violates a unique constraint).
+///
+/// For a unique constraint, `wait` polls `DB.CONSTRAINTS` until the constraint itself becomes
+/// operational. The server activates a unique constraint only after its backing range index is
+/// enabled, so polling the constraint already accounts for the backing index becoming ready — no
+/// separate index-readiness step is required.
 #[must_use = "a constraint op builder does nothing unless `.execute()` or `.wait()` is called"]
 pub struct ConstraintOpBuilder<'a> {
     graph: &'a mut SyncGraph,

--- a/src/graph/ops/blocking_ops.rs
+++ b/src/graph/ops/blocking_ops.rs
@@ -1,0 +1,339 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Blocking builder terminals for the background-operation helpers.
+
+use super::{
+    is_transient_copy_error, owned_properties, poll_sync, property_refs, ConstraintOp, IndexOp,
+    Step, Wait, WaitOperation, WaitOptions,
+};
+use crate::{
+    ConstraintType, EntityType, FalkorResult, FalkorSyncClient, IndexType, LazyResultSet,
+    QueryResult, SyncGraph,
+};
+use std::collections::HashMap;
+use std::fmt::Display;
+
+/// Builder for creating or dropping an index on a [`SyncGraph`].
+///
+/// Created via [`SyncGraph::create_index_op`] / [`SyncGraph::drop_index_op`]. Use
+/// [`execute`](Self::execute) to issue the command without waiting, or [`wait`](Self::wait) /
+/// [`wait_with`](Self::wait_with) to block until the index is operational (create) or gone (drop).
+#[must_use = "an index op builder does nothing unless `.execute()` or `.wait()` is called"]
+pub struct IndexOpBuilder<'a> {
+    graph: &'a mut SyncGraph,
+    op: IndexOp,
+}
+
+impl<'a> IndexOpBuilder<'a> {
+    pub(crate) fn new(
+        graph: &'a mut SyncGraph,
+        op: IndexOp,
+    ) -> Self {
+        Self { graph, op }
+    }
+
+    /// Issues the index command without waiting (identical to the eager `create_index`/`drop_index`).
+    pub fn execute(self) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+        run_index_command(self.graph, &self.op)
+    }
+
+    /// Issues the command, then blocks (with default [`WaitOptions`]) until it has taken effect.
+    pub fn wait(self) -> FalkorResult<()> {
+        self.wait_with(WaitOptions::default())
+    }
+
+    /// Issues the command, then blocks until it has taken effect or `options.timeout` elapses.
+    pub fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<()> {
+        let wait = self.op.to_wait();
+        run_index_command(self.graph, &self.op)?;
+        wait_sync(self.graph, &options, &wait)
+    }
+}
+
+/// Builder for creating or dropping a constraint on a [`SyncGraph`].
+///
+/// Created via [`SyncGraph::create_unique_constraint_op`],
+/// [`SyncGraph::create_mandatory_constraint_op`] or [`SyncGraph::drop_constraint_op`]. A `wait`
+/// on a create terminal returns [`crate::FalkorDBError::ConstraintFailed`] if the constraint
+/// reaches the terminal `FAILED` state (e.g. existing data violates a unique constraint).
+#[must_use = "a constraint op builder does nothing unless `.execute()` or `.wait()` is called"]
+pub struct ConstraintOpBuilder<'a> {
+    graph: &'a mut SyncGraph,
+    op: ConstraintOp,
+}
+
+impl<'a> ConstraintOpBuilder<'a> {
+    pub(crate) fn new(
+        graph: &'a mut SyncGraph,
+        op: ConstraintOp,
+    ) -> Self {
+        Self { graph, op }
+    }
+
+    /// Issues the constraint command without waiting.
+    pub fn execute(self) -> FalkorResult<redis::Value> {
+        run_constraint_command(self.graph, &self.op)
+    }
+
+    /// Issues the command, then blocks (with default [`WaitOptions`]) until it has taken effect.
+    pub fn wait(self) -> FalkorResult<()> {
+        self.wait_with(WaitOptions::default())
+    }
+
+    /// Issues the command, then blocks until it has taken effect or `options.timeout` elapses.
+    pub fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<()> {
+        let wait = self.op.to_wait();
+        run_constraint_command(self.graph, &self.op)?;
+        wait_sync(self.graph, &options, &wait)
+    }
+}
+
+/// Builder for copying a graph via a [`FalkorSyncClient`].
+///
+/// Created via [`FalkorSyncClient::copy_graph_op`]. [`execute`](Self::execute) performs a single
+/// copy (identical to `copy_graph`); [`wait`](Self::wait) retries while the server reports a
+/// transient `could not fork` failure.
+#[must_use = "a copy graph builder does nothing unless `.execute()` or `.wait()` is called"]
+pub struct CopyGraphBuilder<'a> {
+    client: &'a FalkorSyncClient,
+    source: String,
+    destination: String,
+}
+
+impl<'a> CopyGraphBuilder<'a> {
+    pub(crate) fn new(
+        client: &'a FalkorSyncClient,
+        source: String,
+        destination: String,
+    ) -> Self {
+        Self {
+            client,
+            source,
+            destination,
+        }
+    }
+
+    /// Performs a single copy attempt (identical to [`FalkorSyncClient::copy_graph`]).
+    pub fn execute(self) -> FalkorResult<SyncGraph> {
+        self.client.copy_graph(&self.source, &self.destination)
+    }
+
+    /// Copies the graph, retrying transient `could not fork` failures with the default copy
+    /// [`WaitOptions`] (60s). Non-transient errors are returned immediately and the destination
+    /// is never deleted.
+    pub fn wait(self) -> FalkorResult<SyncGraph> {
+        self.wait_with(WaitOptions::for_copy())
+    }
+
+    /// Copies the graph, retrying transient failures until success or `options.timeout`.
+    pub fn wait_with(
+        self,
+        options: WaitOptions,
+    ) -> FalkorResult<SyncGraph> {
+        poll_sync(&options, WaitOperation::GraphCopy, || {
+            match self.client.copy_graph(&self.source, &self.destination) {
+                Ok(graph) => Ok(Step::Done(graph)),
+                Err(error) if is_transient_copy_error(&error) => Ok(Step::Retry),
+                Err(error) => Ok(Step::Fail(error)),
+            }
+        })
+    }
+}
+
+fn run_index_command<'a>(
+    graph: &'a mut SyncGraph,
+    op: &IndexOp,
+) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+    match op {
+        IndexOp::Create {
+            index_type,
+            entity_type,
+            label,
+            properties,
+            options,
+        } => graph.create_index(
+            *index_type,
+            *entity_type,
+            label,
+            properties,
+            options.as_ref(),
+        ),
+        IndexOp::Drop {
+            index_type,
+            entity_type,
+            label,
+            properties,
+        } => graph.drop_index(*index_type, *entity_type, label, properties),
+    }
+}
+
+fn run_constraint_command(
+    graph: &mut SyncGraph,
+    op: &ConstraintOp,
+) -> FalkorResult<redis::Value> {
+    match op {
+        ConstraintOp::CreateUnique {
+            entity_type,
+            label,
+            properties,
+        } => {
+            graph.create_unique_constraint(*entity_type, label.clone(), &property_refs(properties))
+        }
+        ConstraintOp::CreateMandatory {
+            entity_type,
+            label,
+            properties,
+        } => graph.create_mandatory_constraint(*entity_type, label, &property_refs(properties)),
+        ConstraintOp::Drop {
+            constraint_type,
+            entity_type,
+            label,
+            properties,
+        } => graph.drop_constraint(
+            *constraint_type,
+            *entity_type,
+            label,
+            &property_refs(properties),
+        ),
+    }
+}
+
+fn wait_sync(
+    graph: &mut SyncGraph,
+    options: &WaitOptions,
+    wait: &Wait,
+) -> FalkorResult<()> {
+    poll_sync(options, wait.operation(), || match wait {
+        Wait::Index(index_wait) => Ok(if index_wait.satisfied(&graph.list_indices()?.data) {
+            Step::Done(())
+        } else {
+            Step::Retry
+        }),
+        Wait::Constraint(constraint_wait) => {
+            Ok(constraint_wait.step(&graph.list_constraints()?.data))
+        }
+    })
+}
+
+impl SyncGraph {
+    /// Returns a builder for creating an index, supporting `.execute()` (non-blocking) and
+    /// `.wait()` (block until the index is operational). Arguments mirror [`SyncGraph::create_index`].
+    pub fn create_index_op<P: Display>(
+        &mut self,
+        index_field_type: IndexType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[P],
+        options: Option<&HashMap<String, String>>,
+    ) -> IndexOpBuilder<'_> {
+        IndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: index_field_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+                options: options.cloned(),
+            },
+        )
+    }
+
+    /// Returns a builder for dropping an index, supporting `.execute()` (non-blocking) and
+    /// `.wait()` (block until the index is gone). Arguments mirror [`SyncGraph::drop_index`].
+    pub fn drop_index_op<P: Display>(
+        &mut self,
+        index_field_type: IndexType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[P],
+    ) -> IndexOpBuilder<'_> {
+        IndexOpBuilder::new(
+            self,
+            IndexOp::Drop {
+                index_type: index_field_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a unique constraint, supporting `.execute()` (non-blocking)
+    /// and `.wait()` (block until operational, or `FAILED`). Mirrors
+    /// [`SyncGraph::create_unique_constraint`].
+    pub fn create_unique_constraint_op(
+        &mut self,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> ConstraintOpBuilder<'_> {
+        ConstraintOpBuilder::new(
+            self,
+            ConstraintOp::CreateUnique {
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a mandatory constraint, supporting `.execute()` and
+    /// `.wait()`. Mirrors [`SyncGraph::create_mandatory_constraint`].
+    pub fn create_mandatory_constraint_op(
+        &mut self,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> ConstraintOpBuilder<'_> {
+        ConstraintOpBuilder::new(
+            self,
+            ConstraintOp::CreateMandatory {
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+
+    /// Returns a builder for dropping a constraint, supporting `.execute()` and `.wait()` (block
+    /// until the constraint is gone). Mirrors [`SyncGraph::drop_constraint`].
+    pub fn drop_constraint_op(
+        &mut self,
+        constraint_type: ConstraintType,
+        entity_type: EntityType,
+        label: &str,
+        properties: &[&str],
+    ) -> ConstraintOpBuilder<'_> {
+        ConstraintOpBuilder::new(
+            self,
+            ConstraintOp::Drop {
+                constraint_type,
+                entity_type,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+            },
+        )
+    }
+}
+
+impl FalkorSyncClient {
+    /// Returns a builder for copying a graph, supporting `.execute()` (single attempt) and
+    /// `.wait()` (retry transient `could not fork` failures). Mirrors
+    /// [`FalkorSyncClient::copy_graph`].
+    pub fn copy_graph_op(
+        &self,
+        graph_to_clone: &str,
+        new_graph_name: &str,
+    ) -> CopyGraphBuilder<'_> {
+        CopyGraphBuilder::new(self, graph_to_clone.to_string(), new_graph_name.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use connection_info::FalkorConnectionInfo;
 pub use error::FalkorDBError;
 pub use graph::{
     blocking::SyncGraph,
+    ops::{ConstraintOpBuilder, CopyGraphBuilder, IndexOpBuilder, WaitOperation, WaitOptions},
     query_builder::{ProcedureQueryBuilder, QueryBuilder},
 };
 pub use graph_schema::{GraphSchema, SchemaType};
@@ -54,6 +55,8 @@ pub use value::{
 pub use client::asynchronous::FalkorAsyncClient;
 #[cfg(feature = "tokio")]
 pub use graph::asynchronous::AsyncGraph;
+#[cfg(feature = "tokio")]
+pub use graph::ops::{AsyncConstraintOpBuilder, AsyncCopyGraphBuilder, AsyncIndexOpBuilder};
 
 #[cfg(feature = "embedded")]
 pub use embedded::{EmbeddedConfig, EmbeddedServer};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -187,27 +187,6 @@ pub(crate) fn redis_value_as_typed_string(value: redis::Value) -> FalkorResult<S
 
 #[cfg_attr(
     feature = "tracing",
-    tracing::instrument(name = "String Vec From Redis Value", skip_all, level = "debug")
-)]
-pub(crate) fn redis_value_as_typed_string_vec(value: redis::Value) -> FalkorResult<Vec<String>> {
-    type_val_from_value(value)
-        .and_then(|(type_marker, val)| {
-            if type_marker == ParserTypeMarker::Array {
-                redis_value_as_vec(val)
-            } else {
-                Err(FalkorDBError::ParsingArray)
-            }
-        })
-        .map(|val_vec| {
-            val_vec
-                .into_iter()
-                .flat_map(redis_value_as_string)
-                .collect()
-        })
-}
-
-#[cfg_attr(
-    feature = "tracing",
     tracing::instrument(name = "String Vec From Untyped Value", skip_all, level = "trace")
 )]
 pub(crate) fn redis_value_as_untyped_string_vec(value: redis::Value) -> FalkorResult<Vec<String>> {

--- a/src/response/constraint.rs
+++ b/src/response/constraint.rs
@@ -4,10 +4,8 @@
  */
 
 use crate::{
-    parser::{
-        parse_falkor_enum, redis_value_as_typed_string, redis_value_as_typed_string_vec,
-        redis_value_as_vec, SchemaParsable,
-    },
+    parser::{parse_falkor_enum, redis_value_as_typed_string, redis_value_as_vec, SchemaParsable},
+    response::index::parse_string_array,
     EntityType, FalkorDBError, FalkorResult, GraphSchema,
 };
 
@@ -32,6 +30,7 @@ pub enum ConstraintStatus {
     #[strum(serialize = "UNDER CONSTRUCTION")]
     Pending,
     /// This constraint could not be applied, not all entities of this type and label are compliant.
+    #[strum(serialize = "FAILED")]
     Failed,
 }
 
@@ -57,7 +56,7 @@ impl SchemaParsable for Constraint {
     )]
     fn parse(
         value: redis::Value,
-        _: &mut GraphSchema,
+        graph_schema: &mut GraphSchema,
     ) -> FalkorResult<Self> {
         let [constraint_type_raw, label_raw, properties_raw, entity_type_raw, status_raw]: [redis::Value; 5] = redis_value_as_vec(value)
             .and_then(|res| res.try_into()
@@ -66,7 +65,7 @@ impl SchemaParsable for Constraint {
         Ok(Self {
             constraint_type: parse_falkor_enum(constraint_type_raw)?,
             label: redis_value_as_typed_string(label_raw)?,
-            properties: redis_value_as_typed_string_vec(properties_raw)?,
+            properties: parse_string_array(properties_raw, graph_schema)?,
             entity_type: parse_falkor_enum(entity_type_raw)?,
             status: parse_falkor_enum(status_raw)?,
         })
@@ -125,7 +124,24 @@ mod tests {
 
     #[test]
     fn test_constraint_status_failed() {
-        assert_eq!(ConstraintStatus::Failed.to_string(), "Failed");
+        assert_eq!(ConstraintStatus::Failed.to_string(), "FAILED");
+    }
+
+    #[test]
+    fn test_constraint_status_from_string() {
+        use std::str::FromStr;
+        assert_eq!(
+            ConstraintStatus::from_str("OPERATIONAL").unwrap(),
+            ConstraintStatus::Active
+        );
+        assert_eq!(
+            ConstraintStatus::from_str("UNDER CONSTRUCTION").unwrap(),
+            ConstraintStatus::Pending
+        );
+        assert_eq!(
+            ConstraintStatus::from_str("FAILED").unwrap(),
+            ConstraintStatus::Failed
+        );
     }
 
     #[test]

--- a/src/response/index.rs
+++ b/src/response/index.rs
@@ -26,7 +26,7 @@ pub enum IndexStatus {
 }
 
 impl std::str::FromStr for IndexStatus {
-    type Err = FalkorDBError;
+    type Err = strum::ParseError;
 
     /// Parses an index status as reported by `DB.INDEXES`. While being populated the server
     /// reports a dynamic string such as `"[Indexing] 5/10: UNDER CONSTRUCTION"`, so matching is
@@ -37,13 +37,13 @@ impl std::str::FromStr for IndexStatus {
         } else if value.contains("UNDER CONSTRUCTION") {
             Ok(IndexStatus::Pending)
         } else {
-            Err(FalkorDBError::InvalidEnumType(value.to_string()))
+            Err(strum::ParseError::VariantNotFound)
         }
     }
 }
 
 impl TryFrom<&str> for IndexStatus {
-    type Error = FalkorDBError;
+    type Error = strum::ParseError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         value.parse()

--- a/src/response/index.rs
+++ b/src/response/index.rs
@@ -14,7 +14,7 @@ use crate::{
 use std::collections::HashMap;
 
 /// The status of this index
-#[derive(Copy, Clone, Debug, Eq, PartialEq, strum::EnumString, strum::Display)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, strum::Display)]
 #[strum(serialize_all = "UPPERCASE")]
 pub enum IndexStatus {
     /// This index is active.
@@ -23,6 +23,31 @@ pub enum IndexStatus {
     /// This index is still being created.
     #[strum(serialize = "UNDER CONSTRUCTION")]
     Pending,
+}
+
+impl std::str::FromStr for IndexStatus {
+    type Err = FalkorDBError;
+
+    /// Parses an index status as reported by `DB.INDEXES`. While being populated the server
+    /// reports a dynamic string such as `"[Indexing] 5/10: UNDER CONSTRUCTION"`, so matching is
+    /// done by substring rather than exact equality.
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.contains("OPERATIONAL") {
+            Ok(IndexStatus::Active)
+        } else if value.contains("UNDER CONSTRUCTION") {
+            Ok(IndexStatus::Pending)
+        } else {
+            Err(FalkorDBError::InvalidEnumType(value.to_string()))
+        }
+    }
+}
+
+impl TryFrom<&str> for IndexStatus {
+    type Error = FalkorDBError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
 }
 
 /// The type of this indexed field
@@ -38,7 +63,7 @@ pub enum IndexType {
 }
 
 // parse array of strings, both array and strings represent as redis values
-fn parse_string_array(
+pub(crate) fn parse_string_array(
     value: redis::Value,
     graph_schema: &mut GraphSchema,
 ) -> Result<Vec<String>, FalkorDBError> {
@@ -166,6 +191,31 @@ mod tests {
             IndexStatus::from_str("UNDER CONSTRUCTION").unwrap(),
             IndexStatus::Pending
         );
+    }
+
+    #[test]
+    fn test_index_status_from_dynamic_under_construction_string() {
+        use std::str::FromStr;
+        // While populating, the server reports progress, e.g. "[Indexing] 5/10: UNDER CONSTRUCTION".
+        assert_eq!(
+            IndexStatus::from_str("[Indexing] 1545/200000: UNDER CONSTRUCTION").unwrap(),
+            IndexStatus::Pending
+        );
+    }
+
+    #[test]
+    fn test_index_status_from_unknown_string_errors() {
+        use std::str::FromStr;
+        assert!(IndexStatus::from_str("SOMETHING ELSE").is_err());
+    }
+
+    #[test]
+    fn test_index_status_try_from_str() {
+        assert_eq!(
+            IndexStatus::try_from("OPERATIONAL").unwrap(),
+            IndexStatus::Active
+        );
+        assert!(IndexStatus::try_from("nope").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an opt-in, **fully backward-compatible** builder API for waiting on the FalkorDB operations that complete *after* the issuing command returns: index create/drop, constraint create/drop, and graph copy. Implements the design from the rubber-duck–reviewed plan.

Each existing eager method (`create_index`, `create_unique_constraint`, `copy_graph`, …) now has an additive `*_op` builder:

```rust
// non-blocking (identical to the eager method)
graph.create_index_op(...).execute().await?;
// wait until the index is OPERATIONAL
graph.create_index_op(...).wait().await?;
// custom timeout / backoff
graph.create_index_op(...).wait_with(WaitOptions::with_timeout(Duration::from_secs(10))).await?;
```

Available on **both** the sync and async clients; the only difference is `.execute()` vs `.execute().await`, matching the crate's existing `QueryBuilder` convention.

## New public API
- `WaitOptions` — timeout + exponential backoff with normalizing setters.
- `WaitOperation` — enum identifying what was being awaited (used in `Timeout`).
- `IndexOpBuilder` / `ConstraintOpBuilder` / `CopyGraphBuilder` (+ async variants).
- `FalkorDBError::Timeout { operation, timeout }` and `FalkorDBError::ConstraintFailed { label, properties, constraint_type }`.
- `*_op` entry methods on `SyncGraph`/`AsyncGraph` and the clients.

## Semantics
- **Index create** — waits until each requested property lists the requested `IndexType` and the row is `OPERATIONAL`.
- **Index drop** — waits until the requested type is absent per property (other types on the same property may remain).
- **Constraint create** — matches by entity type + label + property *set* + type; `Active` is success, `FAILED` returns `ConstraintFailed`.
- **Constraint drop** — waits until the matching constraint is absent.
- **Copy** — `.execute()` is one attempt; `.wait()` retries only transient `could not fork` failures (non-destructive, 60s default). Copy content verification was intentionally left out of scope (caller's responsibility; documented in the README).

## Latent bugs fixed (uncovered while polling status)
1. `IndexStatus` exact-match parsing failed on dynamic `UNDER CONSTRUCTION` progress strings, now tolerant.
2. `ConstraintStatus::Failed` lacked a `FAILED` serialization, now added.
3. `Constraint.properties` always parsed empty because the parser silently dropped typed (compact-mode) elements, now uses the schema-aware `parse_string_array`, same as the index path.

## Compatibility note
`FalkorDBError` is marked `#[non_exhaustive]` so the new (and any future) variants are non-breaking. This is the only non-additive change; everything else is purely additive.

## Tests & docs
- Unit tests for every pure predicate and `WaitOptions` normalization.
- Sync + async integration tests for every builder against a live server (wait success, timeout, constraint failure, copy retry).
- Rustdoc on all new items; README "Waiting for background operations" section with sync and async examples.

All local checks pass: `cargo fmt --all --check`, `cargo clippy --all` / `--all-features --tests`, `cargo build`, full lib + integration test suites (tokio / all-features), doctests (`tokio,embedded`), `cargo doc --all`, and spellcheck.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in “op” builders for index/constraint creation & drop and graph copy, with `.execute()` plus readiness-aware `.wait()` / `.wait_with(...)` for both sync and async usage.
  * Introduced configurable `WaitOptions` for timeouts and polling/backoff.
* **Improvements**
  * Added `FalkorDBError::Timeout` and `FalkorDBError::ConstraintFailed` (non-exhaustive) and improved transient graph copy retry behavior.
* **Documentation**
  * Updated README with “Waiting for background operations” guidance and examples.
* **Bug Fixes**
  * Improved index status parsing for dynamic progress text and standardized failed constraint status formatting.
* **Tests**
  * Added integration coverage for copy/index/constraint op wait & execute flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->