### PR TITLE
feat: typed result mapping via serde

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -93,3 +93,10 @@ RSS
 runnable
 serverless
 subprocess
+serde
+Deserialize
+deserialize
+deserialized
+imdb
+iter
+struct

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,3 +64,13 @@ jobs:
           tool: just
       - name: Build
         run: just build
+
+  check-proptest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just, nextest
+        with:
+          tool: just,nextest
+      - name: Property tests
+        run: just proptest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +142,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -361,9 +376,11 @@ dependencies = [
  "criterion",
  "libc",
  "parking_lot",
+ "proptest",
  "redis",
  "regex",
  "serde",
+ "serde_json",
  "strum",
  "thiserror",
  "tokio",
@@ -382,6 +399,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -487,14 +510,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -916,6 +951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +979,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,9 +1014,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -957,7 +1042,26 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -965,6 +1069,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -1006,7 +1119,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.10.1",
  "rustls",
  "rustls-native-certs",
  "ryu",
@@ -1134,6 +1247,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1463,6 +1588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1634,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "parking_lot",
  "redis",
  "regex",
+ "serde",
  "strum",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 parking_lot = { version = "0.12.5", default-features = false }
 redis = { version = "1.2.2", default-features = false, features = ["sentinel"] }
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
+serde = { version = "1.0", default-features = false, features = ["std", "derive"], optional = true }
 strum = { version = "0.28.0", default-features = false, features = ["std", "derive"] }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", default-features = false, features = ["macros", "sync", "rt-multi-thread", "time"], optional = true }
@@ -56,6 +57,10 @@ tracing = ["dep:tracing"]
 
 embedded = ["dep:which"]
 
+# Optional `serde` integration: derive `serde::Deserialize` on your own types and
+# map query results straight into them via [`FalkorValue::deserialize_into`].
+serde = ["dep:serde"]
+
 [[example]]
 name = "basic_usage"
 
@@ -70,3 +75,7 @@ required-features = ["tokio"]
 [[example]]
 name = "embedded_usage"
 required-features = ["embedded"]
+
+[[example]]
+name = "typed_mapping"
+required-features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ which = { version = "8.0", optional = true }
 [dev-dependencies]
 approx = "0.5.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
+proptest = "1"
+serde_json = "1"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"

--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ image := "falkordb/falkordb:edge"
 container := "falkordb-rs-dev"
 
 # Feature set exercised by the full local suite (mirrors the coverage CI job).
-features := "tokio,embedded"
+features := "tokio,embedded,serde"
 
 # Default recipe: list everything.
 default:

--- a/Justfile
+++ b/Justfile
@@ -95,6 +95,10 @@ test-one filter:
     FALKORDB_HOST={{host}} FALKORDB_PORT={{port}} \
         cargo nextest run --all --features {{features}} {{filter}}
 
+# Run only the `serde` property-based tests (no server); `cases` sets PROPTEST_CASES (default 256).
+proptest cases="256":
+    PROPTEST_CASES={{cases}} cargo nextest run --lib --features serde de_proptest
+
 # Spin up a server, populate the fixture, run the full suite, then tear it down.
 test-local: db-up db-populate
     @just test || (just db-down && exit 1)

--- a/README.md
+++ b/README.md
@@ -397,6 +397,27 @@ for row in result.data.by_ref() {
 
 A runnable version lives in [`examples/typed_mapping.rs`](examples/typed_mapping.rs).
 
+To map a whole result set in one shot, call `query_as::<T>()` before `execute()`. Each row is
+deserialized into a `T`, and the result's `data` becomes an iterator of `FalkorResult<T>`, so it
+collects directly into a `Vec`:
+
+```rust,ignore
+let movies: Vec<Movie> = graph
+    .query("MATCH (m:Movie) RETURN m")
+    .query_as::<Movie>()
+    .execute()
+    .expect("Failed executing query")
+    .data
+    .collect::<Result<_, _>>()
+    .expect("Failed mapping rows");
+```
+
+A single-column row (such as `RETURN m`) is deserialized from that one column's value, so a node
+maps from its properties and `RETURN count(m)` maps a scalar. A multi-column row (such as
+`RETURN m.title AS title, m.year AS year`) maps each column alias onto the matching struct field,
+or yields the values in order for a tuple. The query `header` and `stats` remain available on the
+returned result.
+
 ### Embedded FalkorDB Server
 
 This client supports running an embedded FalkorDB server, which is useful for:

--- a/README.md
+++ b/README.md
@@ -356,6 +356,47 @@ falkordb = { version = "0.3.0", features = ["tracing"] }
 Note that different functions use different filtration levels, to avoid spamming your tests, be sure to enable the
 correct level as you desire it.
 
+### Typed result mapping (serde)
+
+Enable the optional `serde` feature to map query results straight into your own types instead of hand-matching every
+`FalkorValue` variant:
+
+```toml
+falkordb = { version = "0.3.0", features = ["serde"] }
+```
+
+Derive `serde::Deserialize` on your type and call `FalkorValue::deserialize_into` (or the free function
+`falkordb::from_falkor_value`) on a returned value. A node is deserialized from its properties, and scalars, `Option`,
+sequences and maps map onto the matching Rust types:
+
+```rust,ignore
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo};
+use serde::Deserialize;
+#[derive(Debug, Deserialize)]
+struct Movie {
+    title: String,
+    year: i64,
+    rating: Option<f64>,
+}
+let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()
+    .expect("Invalid connection info");
+let client = FalkorClientBuilder::new()
+    .with_connection_info(connection_info)
+    .build()
+    .expect("Failed to build client");
+let mut graph = client.select_graph("imdb");
+let mut result = graph.query("MATCH (m:Movie) RETURN m").execute()
+    .expect("Failed executing query");
+for row in result.data.by_ref() {
+    if let Some(node) = row.into_iter().next() {
+        let movie: Movie = node.deserialize_into().expect("Failed to map node");
+        println!("{} ({})", movie.title, movie.year);
+    }
+}
+```
+
+A runnable version lives in [`examples/typed_mapping.rs`](examples/typed_mapping.rs).
+
 ### Embedded FalkorDB Server
 
 This client supports running an embedded FalkorDB server, which is useful for:

--- a/README.md
+++ b/README.md
@@ -531,7 +531,8 @@ just bench-local      # start DB, run all benchmarks, tear down
 ```
 
 Targeted recipes are available too, e.g. `just test-parity`, `just test-embedded`,
-`just test-one <filter>`, `just bench-one '<criterion-id>'`, and `just coverage-html`.
+`just test-one <filter>`, `just proptest`, `just bench-one '<criterion-id>'`, and
+`just coverage-html`.
 
 The host, port, Docker image and feature set can be overridden on the command line, for
 example `just port=6380 test` or `just image=falkordb/falkordb:latest db-up`.
@@ -548,6 +549,7 @@ reproduced with a single command:
 | `check-build` | `just build` |
 | `check-doc` | `just doc` |
 | `check-deny` | `just deny` |
+| `check-proptest` | `just proptest` |
 | `integration-tests` | `just integration` and `just integration --all-features` |
 | `integration-tests-tokio` | `just integration --features tokio` |
 | `coverage` | `just coverage` |
@@ -573,6 +575,26 @@ cargo test --lib
 # Run unit tests with embedded feature
 cargo test --lib --features embedded
 ```
+
+#### Property-Based Tests
+
+The optional `serde` integration is covered by [`proptest`](https://docs.rs/proptest) cases in
+`src/value/de_proptest.rs`, which need no running server. They assert that value- and row-level
+mapping agrees with `serde_json` over the shared data model, never panics on arbitrary input, and
+rejects malformed row shapes. Run just these:
+
+```bash
+# 256 cases per property (the proptest default)
+just proptest
+
+# crank the generated case count up (or set PROPTEST_CASES yourself)
+just proptest 4096
+
+# equivalent raw cargo command
+cargo nextest run --lib --features serde de_proptest
+```
+
+They also run in CI: as the dedicated `check-proptest` job, and within the `coverage` job.
 
 #### Integration Tests
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,8 @@ coverage:
     project:
       default:
         threshold: 2%
+
+# Examples are illustrative and run against a live server, not under the
+# coverage harness, so they should not count toward coverage.
+ignore:
+  - "examples"

--- a/examples/typed_mapping.rs
+++ b/examples/typed_mapping.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Typed result mapping with `serde`.
+//!
+//! Run with: `cargo run --example typed_mapping --features serde`
+//!
+//! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
+
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorValue};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Movie {
+    title: String,
+    year: i64,
+    #[serde(default)]
+    rating: Option<f64>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()?;
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info)
+        .build()?;
+
+    let mut graph = client.select_graph("typed_mapping_example");
+
+    // Start from a clean slate so the example is idempotent across repeated runs.
+    // The graph may not exist yet, so ignore a "missing graph" error here.
+    let _ = graph.delete();
+
+    graph
+        .query("CREATE (:Movie {title: 'Heat', year: 1995, rating: 8.3})")
+        .execute()?;
+
+    // Without typed mapping you would hand-match every `FalkorValue` variant.
+    // With the `serde` feature, deserialize a returned node straight into a struct:
+    let mut result = graph.query("MATCH (m:Movie) RETURN m").execute()?;
+    for row in result.data.by_ref() {
+        if let Some(node) = row.into_iter().next() {
+            let movie: Movie = node.deserialize_into()?;
+            println!("{} ({}) rating={:?}", movie.title, movie.year, movie.rating);
+        }
+    }
+
+    // Scalars and collections work too:
+    let mut titles = graph.query("MATCH (m:Movie) RETURN m.title").execute()?;
+    for row in titles.data.by_ref() {
+        if let Some(FalkorValue::String(_)) = row.first() {
+            let title: String = row.into_iter().next().unwrap().deserialize_into()?;
+            println!("title = {title}");
+        }
+    }
+
+    graph.delete()?;
+    Ok(())
+}

--- a/examples/typed_mapping.rs
+++ b/examples/typed_mapping.rs
@@ -9,7 +9,7 @@
 //!
 //! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
 
-use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorValue};
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -36,24 +36,51 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .query("CREATE (:Movie {title: 'Heat', year: 1995, rating: 8.3})")
         .execute()?;
 
+    // ── Value-level mapping ──────────────────────────────────────────────────
     // Without typed mapping you would hand-match every `FalkorValue` variant.
-    // With the `serde` feature, deserialize a returned node straight into a struct:
+    // With the `serde` feature, deserialize a single returned value into a struct:
     let mut result = graph.query("MATCH (m:Movie) RETURN m").execute()?;
     for row in result.data.by_ref() {
         if let Some(node) = row.into_iter().next() {
             let movie: Movie = node.deserialize_into()?;
-            println!("{} ({}) rating={:?}", movie.title, movie.year, movie.rating);
+            println!(
+                "value:   {} ({}) rating={:?}",
+                movie.title, movie.year, movie.rating
+            );
         }
     }
 
-    // Scalars and collections work too:
-    let mut titles = graph.query("MATCH (m:Movie) RETURN m.title").execute()?;
-    for row in titles.data.by_ref() {
-        if let Some(FalkorValue::String(_)) = row.first() {
-            let title: String = row.into_iter().next().unwrap().deserialize_into()?;
-            println!("title = {title}");
-        }
+    // ── Row-level mapping with `query_as` ────────────────────────────────────
+    // Map every row in one shot. A single-column `RETURN m` maps the node's properties:
+    let movies: Vec<Movie> = graph
+        .query("MATCH (m:Movie) RETURN m")
+        .query_as::<Movie>()
+        .execute()?
+        .data
+        .collect::<Result<_, _>>()?;
+    for movie in &movies {
+        println!("row:     {} ({})", movie.title, movie.year);
     }
+
+    // Multi-column rows map column aliases onto struct fields:
+    let summaries: Vec<Movie> = graph
+        .query("MATCH (m:Movie) RETURN m.title AS title, m.year AS year")
+        .query_as::<Movie>()
+        .execute()?
+        .data
+        .collect::<Result<_, _>>()?;
+    for movie in &summaries {
+        println!("aliased: {} ({})", movie.title, movie.year);
+    }
+
+    // Scalars work too — `RETURN count(m)` is a single-column row:
+    let counts: Vec<i64> = graph
+        .query("MATCH (m:Movie) RETURN count(m)")
+        .query_as::<i64>()
+        .execute()?
+        .data
+        .collect::<Result<_, _>>()?;
+    println!("count:   {counts:?}");
 
     graph.delete()?;
     Ok(())

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -148,9 +148,11 @@ pub enum FalkorDBError {
         /// Whether the failed constraint was unique or mandatory.
         constraint_type: crate::ConstraintType,
     },
-    /// Deserializing a [`crate::FalkorValue`] into a user type via `serde` failed.
+    /// Mapping a FalkorDB result into a user type via `serde` failed. This covers both
+    /// value-level deserialization (a [`crate::FalkorValue`]) and row-level mapping (a result
+    /// row, e.g. a header/value length mismatch).
     #[cfg(feature = "serde")]
-    #[error("Failed to deserialize FalkorValue: {0}")]
+    #[error("Failed to deserialize via serde: {0}")]
     SerdeError(String),
 }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -148,6 +148,17 @@ pub enum FalkorDBError {
         /// Whether the failed constraint was unique or mandatory.
         constraint_type: crate::ConstraintType,
     },
+    /// Deserializing a [`crate::FalkorValue`] into a user type via `serde` failed.
+    #[cfg(feature = "serde")]
+    #[error("Failed to deserialize FalkorValue: {0}")]
+    SerdeError(String),
+}
+
+#[cfg(feature = "serde")]
+impl serde::de::Error for FalkorDBError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        FalkorDBError::SerdeError(msg.to_string())
+    }
 }
 
 impl From<strum::ParseError> for FalkorDBError {

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -14,6 +14,9 @@ use std::{collections::HashMap, fmt::Display, marker::PhantomData, ops::Not};
 #[cfg(feature = "tokio")]
 use crate::AsyncGraph;
 
+#[cfg(feature = "serde")]
+use crate::TypedLazyResultSet;
+
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(name = "Construct Query", skip_all, level = "trace")
@@ -250,6 +253,78 @@ impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, AsyncGr
         self.common_execute_steps()
             .await
             .and_then(|res| self.generate_query_result_set(res))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a, T: Display, G: HasGraphSchema> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, G> {
+    /// Map each result row into `U`, where `U` implements [`serde::Deserialize`].
+    ///
+    /// This changes the type produced by [`execute`](Self::execute) from
+    /// `QueryResult<LazyResultSet>` to `QueryResult<TypedLazyResultSet<U>>`, whose `data` is an
+    /// iterator yielding one `FalkorResult<U>` per row. The [`header`](QueryResult::header) and
+    /// [`stats`](QueryResult::stats) are preserved.
+    ///
+    /// A single-column row maps the column's value (so `RETURN m` maps the node and
+    /// `RETURN n.name` maps the scalar); a multi-column row maps column name to value for
+    /// structs and maps, or the values in order for tuples and [`Vec`]. See
+    /// [`from_falkor_row`](crate::from_falkor_row) for the full mapping rules.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let result = graph.query("MATCH (m:Movie) RETURN m").query_as::<Movie>().execute()?;
+    /// let movies: Vec<Movie> = result.data.collect::<Result<_, _>>()?;
+    /// ```
+    pub fn query_as<U>(self) -> QueryBuilder<'a, QueryResult<TypedLazyResultSet<'a, U>>, T, G>
+    where
+        U: serde::de::DeserializeOwned,
+    {
+        QueryBuilder {
+            _unused: PhantomData,
+            graph: self.graph,
+            command: self.command,
+            query_string: self.query_string,
+            params: self.params,
+            timeout: self.timeout,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a, T: Display, U> QueryBuilder<'a, QueryResult<TypedLazyResultSet<'a, U>>, T, SyncGraph>
+where
+    U: serde::de::DeserializeOwned,
+{
+    /// Executes the query, returning a [`QueryResult`] whose `data` is a
+    /// [`TypedLazyResultSet`] that deserializes each row into `U`.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Execute Typed Query", skip_all, level = "info")
+    )]
+    pub fn execute(mut self) -> FalkorResult<QueryResult<TypedLazyResultSet<'a, U>>> {
+        self.common_execute_steps()
+            .and_then(|res| self.generate_query_result_set(res))
+            .map(|result| result.into_typed::<U>())
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "tokio"))]
+impl<'a, T: Display, U> QueryBuilder<'a, QueryResult<TypedLazyResultSet<'a, U>>, T, AsyncGraph>
+where
+    U: serde::de::DeserializeOwned,
+{
+    /// Executes the query, returning a [`QueryResult`] whose `data` is a
+    /// [`TypedLazyResultSet`] that deserializes each row into `U`.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Execute Typed Query", skip_all, level = "info")
+    )]
+    pub async fn execute(mut self) -> FalkorResult<QueryResult<TypedLazyResultSet<'a, U>>> {
+        self.common_execute_steps()
+            .await
+            .and_then(|res| self.generate_query_result_set(res))
+            .map(|result| result.into_typed::<U>())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub use value::{
     FalkorValue,
 };
 
+#[cfg(feature = "serde")]
+pub use value::{from_falkor_value, FalkorValueDeserializer};
+
 #[cfg(feature = "tokio")]
 pub use client::asynchronous::FalkorAsyncClient;
 #[cfg(feature = "tokio")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,9 @@ pub use value::{
 };
 
 #[cfg(feature = "serde")]
-pub use value::{from_falkor_value, FalkorValueDeserializer};
+pub use response::typed_result_set::TypedLazyResultSet;
+#[cfg(feature = "serde")]
+pub use value::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};
 
 #[cfg(feature = "tokio")]
 pub use client::asynchronous::FalkorAsyncClient;

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod execution_plan;
 pub(crate) mod index;
 pub(crate) mod lazy_result_set;
 pub(crate) mod slowlog_entry;
+#[cfg(feature = "serde")]
+pub(crate) mod typed_result_set;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, strum::IntoStaticStr)]
 enum StatisticType {
@@ -160,6 +162,23 @@ impl<T> QueryResult<T> {
     /// Returns the internal execution time of this query
     pub fn get_internal_execution_time(&self) -> Option<f64> {
         self.get_statistics(StatisticType::InternalExecutionTime)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'a> QueryResult<crate::LazyResultSet<'a>> {
+    /// Convert this result set into one whose rows are deserialized into `T` on demand.
+    ///
+    /// The [`header`](Self::header) and [`stats`](Self::stats) are preserved; only `data` is
+    /// replaced by a [`TypedLazyResultSet`](crate::TypedLazyResultSet) that maps each row with
+    /// [`from_falkor_row`](crate::from_falkor_row).
+    pub(crate) fn into_typed<T>(self) -> QueryResult<typed_result_set::TypedLazyResultSet<'a, T>> {
+        let header: std::sync::Arc<[String]> = std::sync::Arc::from(self.header.as_slice());
+        QueryResult {
+            data: typed_result_set::TypedLazyResultSet::new(header, self.data),
+            header: self.header,
+            stats: self.stats,
+        }
     }
 }
 

--- a/src/response/typed_result_set.rs
+++ b/src/response/typed_result_set.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Typed iteration over a query result set, available with the `serde` feature.
+
+use crate::value::from_falkor_row;
+use crate::{FalkorResult, LazyResultSet};
+use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+/// A typed view over a [`LazyResultSet`] that deserializes each row into `T` on demand.
+///
+/// This is the `data` member of the [`crate::QueryResult`] returned by
+/// [`crate::QueryBuilder::query_as`]. It implements [`Iterator`], yielding one
+/// `FalkorResult<T>` per row, so it composes with the standard iterator adapters:
+///
+/// ```rust,ignore
+/// let result = graph.query("MATCH (m:Movie) RETURN m").query_as::<Movie>().execute()?;
+/// let movies: Vec<Movie> = result.data.collect::<Result<_, _>>()?;
+/// ```
+///
+/// Each row is mapped with [`from_falkor_row`]: a single-column row deserializes as that
+/// column's value (so `RETURN m` maps the node and `RETURN n.name` maps the scalar), while a
+/// multi-column row deserializes as a map from column name to value, or as a sequence.
+pub struct TypedLazyResultSet<'a, T> {
+    header: Arc<[String]>,
+    inner: LazyResultSet<'a>,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<'a, T> TypedLazyResultSet<'a, T> {
+    pub(crate) fn new(
+        header: Arc<[String]>,
+        inner: LazyResultSet<'a>,
+    ) -> Self {
+        Self {
+            header,
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the number of rows remaining in the result set.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether this result set is empty or depleted.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl<T> Iterator for TypedLazyResultSet<'_, T>
+where
+    T: DeserializeOwned,
+{
+    type Item = FalkorResult<T>;
+
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Deserialize Next Row", skip_all)
+    )]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|row| from_falkor_row(&self.header, row))
+    }
+}

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -164,7 +164,7 @@ impl<'de> Deserializer<'de> for FalkorValueDeserializer {
     {
         match self.value {
             FalkorValue::None => visitor.visit_none(),
-            _ => visitor.visit_some(self),
+            value => visitor.visit_some(value.into_deserializer()),
         }
     }
 
@@ -177,7 +177,7 @@ impl<'de> Deserializer<'de> for FalkorValueDeserializer {
     {
         match self.value {
             FalkorValue::None => visitor.visit_unit(),
-            _ => self.deserialize_any(visitor),
+            value => value.into_deserializer().deserialize_any(visitor),
         }
     }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -341,7 +341,9 @@ impl<'de> Deserializer<'de> for RowDeserializer<'_> {
     where
         V: Visitor<'de>,
     {
-        let pairs = self.header.iter().cloned().zip(self.values);
+        // Borrow `&str` keys from the header rather than cloning each `String` per row.
+        let RowDeserializer { header, values } = self;
+        let pairs = header.iter().map(String::as_str).zip(values);
         MapDeserializer::new(pairs).deserialize_any(visitor)
     }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -43,6 +43,38 @@ where
     T::deserialize(value.into_deserializer())
 }
 
+/// Deserialize a single result row into any type that implements [`serde::Deserialize`].
+///
+/// A row is the `header` (the column aliases) zipped with its `values`. This powers
+/// [`crate::QueryBuilder::query_as`] and is also useful directly when you already hold a
+/// header and a row.
+///
+/// # Mapping
+///
+/// - A **single-column** row deserializes as that one column's value, using the same rules as
+///   [`from_falkor_value`]. This is the common case: `RETURN m` maps the node, `RETURN n.name`
+///   and `RETURN 42` map the scalar.
+/// - A **multi-column** row deserializes as a map from column name to value (for structs and
+///   maps) or as a sequence (for tuples and [`Vec`]). Column names come from `header`, so use
+///   query aliases (`RETURN m.title AS title`) to match struct field names.
+///
+/// # Errors
+///
+/// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto the target type.
+pub fn from_falkor_row<T>(
+    header: &[String],
+    mut values: Vec<FalkorValue>,
+) -> FalkorResult<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    if values.len() == 1 {
+        let value = values.pop().expect("length checked to be exactly one");
+        return T::deserialize(value.into_deserializer());
+    }
+    T::deserialize(RowDeserializer { header, values })
+}
+
 impl FalkorValue {
     /// Deserialize this [`FalkorValue`] into any type that implements [`serde::Deserialize`].
     ///
@@ -262,6 +294,81 @@ impl<'de> VariantAccess<'de> for VariantValueAccess {
         V: Visitor<'de>,
     {
         self.value.into_deserializer().deserialize_any(visitor)
+    }
+}
+
+/// A [`serde::Deserializer`] over a single multi-column result row, pairing the result
+/// `header` with the row's `values`.
+///
+/// Single-column rows are unwrapped by [`from_falkor_row`] before this is constructed, so this
+/// only handles rows with two or more columns: structs and maps are built from the
+/// column-name/value pairs, while tuples and sequences consume the values in order.
+struct RowDeserializer<'h> {
+    header: &'h [String],
+    values: Vec<FalkorValue>,
+}
+
+impl<'de> Deserializer<'de> for RowDeserializer<'_> {
+    type Error = FalkorDBError;
+
+    fn deserialize_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        SeqDeserializer::new(self.values.into_iter()).deserialize_any(visitor)
+    }
+
+    fn deserialize_map<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let pairs = self.header.iter().cloned().zip(self.values);
+        MapDeserializer::new(pairs).deserialize_any(visitor)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_map(visitor)
+    }
+
+    fn deserialize_option<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf unit unit_struct seq tuple tuple_struct enum identifier
+        ignored_any
     }
 }
 
@@ -495,6 +602,98 @@ mod tests {
     #[test]
     fn test_deserialize_enum_from_invalid_value_is_error() {
         let err = FalkorValue::I64(1).deserialize_into::<Genre>().unwrap_err();
+        assert!(matches!(err, FalkorDBError::SerdeError(_)));
+    }
+
+    #[test]
+    fn test_row_single_column_node_into_struct() {
+        let mut properties = HashMap::new();
+        properties.insert("title".to_string(), FalkorValue::String("Heat".to_string()));
+        properties.insert("year".to_string(), FalkorValue::I64(1995));
+        let node = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["Movie".to_string()],
+            properties,
+        });
+
+        let movie: Movie = from_falkor_row(&["m".to_string()], vec![node]).unwrap();
+        assert_eq!(
+            movie,
+            Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+                rating: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_row_single_column_scalar() {
+        let value: i64 =
+            from_falkor_row(&["count(*)".to_string()], vec![FalkorValue::I64(42)]).unwrap();
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn test_row_single_column_none_into_option() {
+        let value: Option<i64> =
+            from_falkor_row(&["x".to_string()], vec![FalkorValue::None]).unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn test_row_multi_column_into_struct_by_header() {
+        let header = ["title".to_string(), "year".to_string()];
+        let values = vec![
+            FalkorValue::String("Heat".to_string()),
+            FalkorValue::I64(1995),
+        ];
+        let movie: Movie = from_falkor_row(&header, values).unwrap();
+        assert_eq!(
+            movie,
+            Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+                rating: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_row_multi_column_into_tuple() {
+        let header = ["a".to_string(), "b".to_string()];
+        let values = vec![FalkorValue::I64(1), FalkorValue::String("two".to_string())];
+        let pair: (i64, String) = from_falkor_row(&header, values).unwrap();
+        assert_eq!(pair, (1, "two".to_string()));
+    }
+
+    #[test]
+    fn test_row_multi_column_into_map() {
+        let header = ["a".to_string(), "b".to_string()];
+        let values = vec![FalkorValue::I64(1), FalkorValue::I64(2)];
+        let map: HashMap<String, i64> = from_falkor_row(&header, values).unwrap();
+        assert_eq!(map.get("a"), Some(&1));
+        assert_eq!(map.get("b"), Some(&2));
+    }
+
+    #[test]
+    fn test_row_missing_struct_field_is_error() {
+        // The `year` column is absent, so the non-optional field cannot be filled.
+        let header = ["title".to_string()];
+        let values = vec![
+            FalkorValue::String("Heat".to_string()),
+            FalkorValue::I64(1995),
+        ];
+        assert!(from_falkor_row::<Movie>(&header, values).is_err());
+    }
+
+    #[test]
+    fn test_row_single_column_unparseable_is_error() {
+        let err = from_falkor_row::<i64>(
+            &["x".to_string()],
+            vec![FalkorValue::Unparseable("boom".to_string())],
+        )
+        .unwrap_err();
         assert!(matches!(err, FalkorDBError::SerdeError(_)));
     }
 }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -60,7 +60,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto the target type.
+/// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto the target type, or if
+/// a multi-column row's `values` length does not match the `header` length (a malformed result
+/// shape that would otherwise be silently truncated by the header/value zip).
 pub fn from_falkor_row<T>(
     header: &[String],
     mut values: Vec<FalkorValue>,
@@ -68,9 +70,20 @@ pub fn from_falkor_row<T>(
 where
     T: serde::de::DeserializeOwned,
 {
+    // A single value (the common case, and also how a failed row parse is reported, as a lone
+    // `Unparseable`) is mapped on its own so the parse error surfaces with its real message.
     if values.len() == 1 {
         let value = values.pop().expect("length checked to be exactly one");
         return T::deserialize(value.into_deserializer());
+    }
+    // Otherwise the row is zipped with the header by name, so a length mismatch would silently
+    // drop columns or values; reject it instead of deserializing a truncated row.
+    if header.len() != values.len() {
+        return Err(FalkorDBError::SerdeError(format!(
+            "result row shape mismatch: header has {} column(s) but the row has {} value(s)",
+            header.len(),
+            values.len(),
+        )));
     }
     T::deserialize(RowDeserializer { header, values })
 }
@@ -678,13 +691,23 @@ mod tests {
 
     #[test]
     fn test_row_missing_struct_field_is_error() {
-        // The `year` column is absent, so the non-optional field cannot be filled.
-        let header = ["title".to_string()];
+        // Header/value lengths match, but the required `year` column is absent.
+        let header = ["title".to_string(), "other".to_string()];
         let values = vec![
             FalkorValue::String("Heat".to_string()),
             FalkorValue::I64(1995),
         ];
         assert!(from_falkor_row::<Movie>(&header, values).is_err());
+    }
+
+    #[test]
+    fn test_row_length_mismatch_is_error() {
+        // A multi-column row whose value count differs from the header is rejected rather than
+        // silently truncated by the header/value zip.
+        let header = ["a".to_string(), "b".to_string(), "c".to_string()];
+        let values = vec![FalkorValue::I64(1), FalkorValue::I64(2)];
+        let err = from_falkor_row::<HashMap<String, i64>>(&header, values).unwrap_err();
+        assert!(matches!(err, FalkorDBError::SerdeError(_)));
     }
 
     #[test]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,0 +1,500 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! `serde` integration for [`FalkorValue`].
+//!
+//! This module provides a [`serde::Deserializer`] implementation for [`FalkorValue`],
+//! allowing query results to be mapped directly into user-defined types that derive
+//! [`serde::Deserialize`]. It is only available when the `serde` feature is enabled.
+
+use crate::{FalkorDBError, FalkorResult, FalkorValue};
+use serde::de::{
+    value::{MapDeserializer, SeqDeserializer, StringDeserializer},
+    DeserializeSeed, Deserializer, EnumAccess, IntoDeserializer, VariantAccess, Visitor,
+};
+use serde::forward_to_deserialize_any;
+
+/// Deserialize a [`FalkorValue`] into any type that implements [`serde::Deserialize`].
+///
+/// This is the free-function form of [`FalkorValue::deserialize_into`].
+///
+/// # Mapping
+///
+/// | [`FalkorValue`]            | Rust representation                                  |
+/// |----------------------------|-----------------------------------------------------|
+/// | `I64` / `F64` / `Bool`     | the matching primitive                              |
+/// | `String`                   | [`String`]                                          |
+/// | `None`                     | `()` or `Option::None`                              |
+/// | `Array` / `Vec32`          | a sequence (e.g. [`Vec`])                           |
+/// | `Map`                      | a map / struct keyed by string                      |
+/// | `Node` / `Edge`            | a map / struct built from the entity's `properties` |
+/// | `Point`                    | a map / struct with `latitude` and `longitude`      |
+/// | `Path` / `Unparseable`     | an error                                            |
+///
+/// # Errors
+///
+/// Returns [`FalkorDBError::SerdeError`] if the value cannot be mapped onto the target type.
+pub fn from_falkor_value<T>(value: FalkorValue) -> FalkorResult<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    T::deserialize(value.into_deserializer())
+}
+
+impl FalkorValue {
+    /// Deserialize this [`FalkorValue`] into any type that implements [`serde::Deserialize`].
+    ///
+    /// This is a convenience wrapper around [`from_falkor_value`]. See its documentation for the
+    /// full type mapping table.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FalkorDBError::SerdeError`] if the value cannot be mapped onto the target type.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Deserialize FalkorValue", skip_all)
+    )]
+    pub fn deserialize_into<T>(self) -> FalkorResult<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        from_falkor_value(self)
+    }
+}
+
+/// A [`serde::Deserializer`] that consumes an owned [`FalkorValue`].
+pub struct FalkorValueDeserializer {
+    value: FalkorValue,
+}
+
+impl<'de> IntoDeserializer<'de, FalkorDBError> for FalkorValue {
+    type Deserializer = FalkorValueDeserializer;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        FalkorValueDeserializer { value: self }
+    }
+}
+
+impl<'de> Deserializer<'de> for FalkorValueDeserializer {
+    type Error = FalkorDBError;
+
+    fn deserialize_any<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            FalkorValue::I64(int_val) => visitor.visit_i64(int_val),
+            FalkorValue::F64(float_val) => visitor.visit_f64(float_val),
+            FalkorValue::Bool(bool_val) => visitor.visit_bool(bool_val),
+            FalkorValue::String(str_val) => visitor.visit_string(str_val),
+            FalkorValue::None => visitor.visit_unit(),
+            FalkorValue::Array(array) => {
+                SeqDeserializer::new(array.into_iter()).deserialize_any(visitor)
+            }
+            FalkorValue::Vec32(vec32) => {
+                SeqDeserializer::new(vec32.values.into_iter()).deserialize_any(visitor)
+            }
+            FalkorValue::Map(map) => MapDeserializer::new(map.into_iter()).deserialize_any(visitor),
+            FalkorValue::Node(node) => {
+                MapDeserializer::new(node.properties.into_iter()).deserialize_any(visitor)
+            }
+            FalkorValue::Edge(edge) => {
+                MapDeserializer::new(edge.properties.into_iter()).deserialize_any(visitor)
+            }
+            FalkorValue::Point(point) => MapDeserializer::new(
+                [
+                    ("latitude", FalkorValue::F64(point.latitude)),
+                    ("longitude", FalkorValue::F64(point.longitude)),
+                ]
+                .into_iter(),
+            )
+            .deserialize_any(visitor),
+            FalkorValue::Path(_) => Err(FalkorDBError::SerdeError(
+                "deserializing a Path into a user type is not supported".to_string(),
+            )),
+            FalkorValue::Unparseable(reason) => Err(FalkorDBError::SerdeError(format!(
+                "cannot deserialize an unparseable value: {reason}"
+            ))),
+        }
+    }
+
+    fn deserialize_option<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            FalkorValue::None => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_unit<V>(
+        self,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            FalkorValue::None => visitor.visit_unit(),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            // Unit variants are represented as a plain string, e.g. `FalkorValue::String("Red")`.
+            FalkorValue::String(variant) => {
+                let variant: StringDeserializer<FalkorDBError> = variant.into_deserializer();
+                visitor.visit_enum(variant)
+            }
+            // Data-carrying variants use the externally tagged form: a single-entry map
+            // `{ "Variant": payload }`.
+            FalkorValue::Map(map) if map.len() == 1 => {
+                let (variant, value) = map
+                    .into_iter()
+                    .next()
+                    .expect("map with len 1 always yields one entry");
+                visitor.visit_enum(EnumValueAccess { variant, value })
+            }
+            other => Err(FalkorDBError::SerdeError(format!(
+                "cannot deserialize an enum from this value: {other:?}"
+            ))),
+        }
+    }
+
+    forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf unit_struct seq tuple tuple_struct map struct
+        identifier ignored_any
+    }
+}
+
+/// [`EnumAccess`] for an externally tagged enum carried by a single-entry [`FalkorValue::Map`].
+struct EnumValueAccess {
+    variant: String,
+    value: FalkorValue,
+}
+
+impl<'de> EnumAccess<'de> for EnumValueAccess {
+    type Error = FalkorDBError;
+    type Variant = VariantValueAccess;
+
+    fn variant_seed<S>(
+        self,
+        seed: S,
+    ) -> Result<(S::Value, Self::Variant), Self::Error>
+    where
+        S: DeserializeSeed<'de>,
+    {
+        let variant_de: StringDeserializer<FalkorDBError> = self.variant.into_deserializer();
+        let variant = seed.deserialize(variant_de)?;
+        Ok((variant, VariantValueAccess { value: self.value }))
+    }
+}
+
+/// [`VariantAccess`] yielding the payload of an externally tagged enum variant.
+struct VariantValueAccess {
+    value: FalkorValue,
+}
+
+impl<'de> VariantAccess<'de> for VariantValueAccess {
+    type Error = FalkorDBError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        serde::Deserialize::deserialize(self.value.into_deserializer())
+    }
+
+    fn newtype_variant_seed<S>(
+        self,
+        seed: S,
+    ) -> Result<S::Value, Self::Error>
+    where
+        S: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.value.into_deserializer())
+    }
+
+    fn tuple_variant<V>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.value.into_deserializer().deserialize_any(visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.value.into_deserializer().deserialize_any(visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::graph_entities::{Edge, Node};
+    use crate::value::path::Path;
+    use crate::value::point::Point;
+    use crate::value::vec32::Vec32;
+    use serde::Deserialize;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_deserialize_scalars() {
+        assert_eq!(FalkorValue::I64(42).deserialize_into::<i64>().unwrap(), 42);
+        assert_eq!(FalkorValue::I64(7).deserialize_into::<u8>().unwrap(), 7);
+        assert_eq!(
+            FalkorValue::F64(2.5).deserialize_into::<f64>().unwrap(),
+            2.5
+        );
+        assert!(FalkorValue::Bool(true).deserialize_into::<bool>().unwrap());
+        assert_eq!(
+            FalkorValue::String("hi".to_string())
+                .deserialize_into::<String>()
+                .unwrap(),
+            "hi"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_option() {
+        assert_eq!(
+            FalkorValue::None.deserialize_into::<Option<i64>>().unwrap(),
+            None
+        );
+        assert_eq!(
+            FalkorValue::I64(5)
+                .deserialize_into::<Option<i64>>()
+                .unwrap(),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_sequences() {
+        let array = FalkorValue::Array(vec![FalkorValue::I64(1), FalkorValue::I64(2)]);
+        assert_eq!(array.deserialize_into::<Vec<i64>>().unwrap(), vec![1, 2]);
+
+        let vec32 = FalkorValue::Vec32(Vec32 {
+            values: vec![1.0, 2.0],
+        });
+        assert_eq!(
+            vec32.deserialize_into::<Vec<f32>>().unwrap(),
+            vec![1.0, 2.0]
+        );
+    }
+
+    #[test]
+    fn test_deserialize_map() {
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), FalkorValue::I64(1));
+        map.insert("b".to_string(), FalkorValue::I64(2));
+        let result: HashMap<String, i64> = FalkorValue::Map(map).deserialize_into().unwrap();
+        assert_eq!(result.get("a"), Some(&1));
+        assert_eq!(result.get("b"), Some(&2));
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Movie {
+        title: String,
+        year: i64,
+        rating: Option<f64>,
+    }
+
+    #[test]
+    fn test_deserialize_node_into_struct() {
+        let mut properties = HashMap::new();
+        properties.insert("title".to_string(), FalkorValue::String("Heat".to_string()));
+        properties.insert("year".to_string(), FalkorValue::I64(1995));
+        let node = FalkorValue::Node(Node {
+            entity_id: 1,
+            labels: vec!["Movie".to_string()],
+            properties,
+        });
+
+        let movie: Movie = node.deserialize_into().unwrap();
+        assert_eq!(
+            movie,
+            Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+                rating: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_point_into_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Coord {
+            latitude: f64,
+            longitude: f64,
+        }
+        let point = FalkorValue::Point(Point {
+            latitude: 32.0,
+            longitude: 34.0,
+        });
+        let coord: Coord = point.deserialize_into().unwrap();
+        assert_eq!(
+            coord,
+            Coord {
+                latitude: 32.0,
+                longitude: 34.0
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_errors_on_unparseable() {
+        let value = FalkorValue::Unparseable("boom".to_string());
+        let err = value.deserialize_into::<i64>().unwrap_err();
+        assert!(matches!(err, FalkorDBError::SerdeError(_)));
+    }
+
+    #[test]
+    fn test_deserialize_type_mismatch_is_error() {
+        let value = FalkorValue::String("not a number".to_string());
+        assert!(value.deserialize_into::<i64>().is_err());
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Genre {
+        Action,
+        Drama,
+        Rated(i64),
+        Detailed { stars: i64 },
+    }
+
+    #[test]
+    fn test_deserialize_unit_enum_variant() {
+        let value = FalkorValue::String("Action".to_string());
+        assert_eq!(value.deserialize_into::<Genre>().unwrap(), Genre::Action);
+    }
+
+    #[test]
+    fn test_deserialize_newtype_enum_variant() {
+        let mut map = HashMap::new();
+        map.insert("Rated".to_string(), FalkorValue::I64(5));
+        assert_eq!(
+            FalkorValue::Map(map).deserialize_into::<Genre>().unwrap(),
+            Genre::Rated(5)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_struct_enum_variant() {
+        let mut inner = HashMap::new();
+        inner.insert("stars".to_string(), FalkorValue::I64(4));
+        let mut map = HashMap::new();
+        map.insert("Detailed".to_string(), FalkorValue::Map(inner));
+        assert_eq!(
+            FalkorValue::Map(map).deserialize_into::<Genre>().unwrap(),
+            Genre::Detailed { stars: 4 }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_tuple_rejects_extra_elements() {
+        let array = FalkorValue::Array(vec![FalkorValue::I64(1), FalkorValue::I64(2)]);
+        assert!(array.deserialize_into::<(i64,)>().is_err());
+    }
+
+    #[test]
+    fn test_deserialize_edge_into_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Rel {
+            since: i64,
+        }
+        let mut properties = HashMap::new();
+        properties.insert("since".to_string(), FalkorValue::I64(2020));
+        let edge = FalkorValue::Edge(Edge {
+            entity_id: 1,
+            relationship_type: "KNOWS".to_string(),
+            src_node_id: 2,
+            dst_node_id: 3,
+            properties,
+        });
+        assert_eq!(edge.deserialize_into::<Rel>().unwrap(), Rel { since: 2020 });
+    }
+
+    #[test]
+    fn test_deserialize_path_is_error() {
+        let path = FalkorValue::Path(Path::default());
+        let err = path.deserialize_into::<Vec<i64>>().unwrap_err();
+        assert!(matches!(err, FalkorDBError::SerdeError(_)));
+    }
+
+    #[test]
+    fn test_deserialize_unit_from_none() {
+        FalkorValue::None.deserialize_into::<()>().unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_newtype_struct() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Wrapper(i64);
+        assert_eq!(
+            FalkorValue::I64(9).deserialize_into::<Wrapper>().unwrap(),
+            Wrapper(9)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_tuple_enum_variant() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        enum Shape {
+            Rect(i64, i64),
+        }
+        let mut map = HashMap::new();
+        map.insert(
+            "Rect".to_string(),
+            FalkorValue::Array(vec![FalkorValue::I64(3), FalkorValue::I64(4)]),
+        );
+        assert_eq!(
+            FalkorValue::Map(map).deserialize_into::<Shape>().unwrap(),
+            Shape::Rect(3, 4)
+        );
+    }
+
+    #[test]
+    fn test_deserialize_enum_from_invalid_value_is_error() {
+        let err = FalkorValue::I64(1).deserialize_into::<Genre>().unwrap_err();
+        assert!(matches!(err, FalkorDBError::SerdeError(_)));
+    }
+}

--- a/src/value/de_proptest.rs
+++ b/src/value/de_proptest.rs
@@ -1,0 +1,178 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Property-based tests for the `serde` integration ([`from_falkor_value`] / [`from_falkor_row`]).
+//!
+//! These complement the example-based unit tests in [`super::de`] with three families of
+//! properties:
+//!
+//! 1. **Agreement with `serde_json`** — over the data model shared by [`FalkorValue`] and
+//!    `serde_json::Value` (null, bool, finite numbers, string, array, object), mapping a JSON
+//!    value into a [`FalkorValue`] and deserializing it back reproduces the original.
+//! 2. **No-panic robustness** — deserializing an *arbitrary* [`FalkorValue`] (including the
+//!    exotic variants `Node`/`Edge`/`Point`/`Path`/`Vec32`/`Unparseable` and non-finite floats)
+//!    into several targets always returns `Ok`/`Err` and never panics.
+//! 3. **Row-level invariants** — a single-column row maps exactly like the lone value (the
+//!    header is irrelevant), and a multi-column row whose length disagrees with the header is
+//!    always rejected.
+
+use crate::value::graph_entities::{Edge, Node};
+use crate::value::path::Path;
+use crate::value::point::Point;
+use crate::value::vec32::Vec32;
+use crate::{from_falkor_row, from_falkor_value, FalkorValue};
+use proptest::collection::{hash_map, vec};
+use proptest::prelude::*;
+use serde::Deserialize;
+use serde_json::{Map, Number, Value as Json};
+use std::collections::HashMap;
+
+/// A `serde_json::Value` restricted to the data model shared with [`FalkorValue`]:
+/// null, bool, finite numbers, strings, and (recursively) arrays and string-keyed objects.
+fn json_strategy() -> impl Strategy<Value = Json> {
+    let leaf = prop_oneof![
+        Just(Json::Null),
+        any::<bool>().prop_map(Json::Bool),
+        any::<i64>().prop_map(|n| Json::Number(n.into())),
+        // Finite, bounded floats so `serde_json::Number` can always represent them.
+        (-1.0e12f64..1.0e12f64)
+            .prop_map(|f| Json::Number(Number::from_f64(f).expect("bounded range is finite"))),
+        ".*".prop_map(Json::String),
+    ];
+    leaf.prop_recursive(4, 48, 6, |inner| {
+        prop_oneof![
+            vec(inner.clone(), 0..6).prop_map(Json::Array),
+            hash_map("[a-z]{1,8}", inner, 0..6)
+                .prop_map(|m| Json::Object(m.into_iter().collect::<Map<String, Json>>())),
+        ]
+    })
+}
+
+/// Map a JSON value produced by [`json_strategy`] onto the equivalent [`FalkorValue`].
+fn json_to_falkor(value: &Json) -> FalkorValue {
+    match value {
+        Json::Null => FalkorValue::None,
+        Json::Bool(b) => FalkorValue::Bool(*b),
+        Json::Number(n) => n
+            .as_i64()
+            .map(FalkorValue::I64)
+            .unwrap_or_else(|| FalkorValue::F64(n.as_f64().expect("non-i64 number is f64"))),
+        Json::String(s) => FalkorValue::String(s.clone()),
+        Json::Array(items) => FalkorValue::Array(items.iter().map(json_to_falkor).collect()),
+        Json::Object(map) => FalkorValue::Map(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_to_falkor(v)))
+                .collect(),
+        ),
+    }
+}
+
+/// An arbitrary [`FalkorValue`], spanning every variant including the ones the deserializer
+/// rejects (`Path`, `Unparseable`) and non-finite floats, to stress the mapping for panics.
+fn falkor_strategy() -> impl Strategy<Value = FalkorValue> {
+    let leaf = prop_oneof![
+        Just(FalkorValue::None),
+        any::<bool>().prop_map(FalkorValue::Bool),
+        any::<i64>().prop_map(FalkorValue::I64),
+        any::<f64>().prop_map(FalkorValue::F64),
+        ".*".prop_map(FalkorValue::String),
+        ".*".prop_map(FalkorValue::Unparseable),
+        vec(any::<f32>(), 0..6).prop_map(|values| FalkorValue::Vec32(Vec32 { values })),
+        (any::<f64>(), any::<f64>()).prop_map(|(latitude, longitude)| {
+            FalkorValue::Point(Point {
+                latitude,
+                longitude,
+            })
+        }),
+        Just(FalkorValue::Path(Path::default())),
+    ];
+    leaf.prop_recursive(4, 64, 6, |inner| {
+        prop_oneof![
+            vec(inner.clone(), 0..6).prop_map(FalkorValue::Array),
+            hash_map("[a-z]{1,8}", inner.clone(), 0..6).prop_map(FalkorValue::Map),
+            (
+                any::<i64>(),
+                vec("[a-z]{1,8}", 0..3),
+                hash_map("[a-z]{1,8}", inner.clone(), 0..4),
+            )
+                .prop_map(|(entity_id, labels, properties)| {
+                    FalkorValue::Node(Node {
+                        entity_id,
+                        labels,
+                        properties,
+                    })
+                }),
+            (
+                any::<i64>(),
+                "[a-z]{1,8}",
+                any::<i64>(),
+                any::<i64>(),
+                hash_map("[a-z]{1,8}", inner, 0..4),
+            )
+                .prop_map(
+                    |(entity_id, relationship_type, src_node_id, dst_node_id, properties)| {
+                        FalkorValue::Edge(Edge {
+                            entity_id,
+                            relationship_type,
+                            src_node_id,
+                            dst_node_id,
+                            properties,
+                        })
+                    }
+                ),
+        ]
+    })
+}
+
+/// A sample enum target, so the no-panic property also exercises the enum deserialization path.
+/// The payloads are only ever produced by `serde`, never read, hence `allow(dead_code)`.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+enum Sample {
+    Unit,
+    Newtype(i64),
+    Struct { x: i64 },
+}
+
+proptest! {
+    /// #1 — `FalkorValue`'s deserializer agrees with `serde_json` on their shared data model.
+    #[test]
+    fn prop_agrees_with_serde_json(json in json_strategy()) {
+        let falkor = json_to_falkor(&json);
+        let round_tripped: Json =
+            from_falkor_value(falkor).expect("shared-model values always deserialize");
+        prop_assert_eq!(round_tripped, json);
+    }
+
+    /// #2 — deserializing an arbitrary value never panics, whatever the target type.
+    #[test]
+    fn prop_never_panics(value in falkor_strategy()) {
+        // Each call must return `Ok` or `Err`, but must never panic or abort.
+        let _: Result<Json, _> = from_falkor_value(value.clone());
+        let _: Result<Vec<Json>, _> = from_falkor_value(value.clone());
+        let _: Result<HashMap<String, Json>, _> = from_falkor_value(value.clone());
+        let _: Result<Sample, _> = from_falkor_value(value);
+    }
+
+    /// #3a — a single-column row maps exactly like the lone value; the header is irrelevant.
+    #[test]
+    fn prop_single_column_row_matches_value(header in vec(".*", 0..5), value in falkor_strategy()) {
+        let from_row: Option<Json> = from_falkor_row(&header, vec![value.clone()]).ok();
+        let from_value: Option<Json> = from_falkor_value(value).ok();
+        prop_assert_eq!(from_row, from_value);
+    }
+
+    /// #3b — a multi-column row whose length disagrees with the header is always rejected.
+    #[test]
+    fn prop_length_mismatch_is_rejected(
+        (header_len, values_len) in (0usize..6, 0usize..6)
+            .prop_filter("multi-column with mismatched lengths", |(h, v)| *v != 1 && h != v)
+    ) {
+        let header: Vec<String> = (0..header_len).map(|i| format!("c{i}")).collect();
+        let values: Vec<FalkorValue> = (0..values_len).map(|i| FalkorValue::I64(i as i64)).collect();
+        let result: Result<Json, _> = from_falkor_row(&header, values);
+        prop_assert!(result.is_err());
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod vec32;
 mod de;
 
 #[cfg(feature = "serde")]
-pub use de::{from_falkor_value, FalkorValueDeserializer};
+pub use de::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};
 
 /// An enum of all the supported Falkor types
 #[derive(Clone, Debug, PartialEq)]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -19,6 +19,9 @@ pub(crate) mod vec32;
 #[cfg(feature = "serde")]
 mod de;
 
+#[cfg(all(test, feature = "serde"))]
+mod de_proptest;
+
 #[cfg(feature = "serde")]
 pub use de::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -16,6 +16,12 @@ pub(crate) mod path;
 pub(crate) mod point;
 pub(crate) mod vec32;
 
+#[cfg(feature = "serde")]
+mod de;
+
+#[cfg(feature = "serde")]
+pub use de::{from_falkor_value, FalkorValueDeserializer};
+
 /// An enum of all the supported Falkor types
 #[derive(Clone, Debug, PartialEq)]
 pub enum FalkorValue {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -300,6 +300,65 @@ mod async_tests {
 
         let _ = graph.delete().await;
     }
+
+    #[cfg(feature = "serde")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_async_query_as() {
+        use serde::Deserialize;
+
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match falkordb::FalkorClientBuilder::new_async()
+            .with_connection_info(conn_info)
+            .build()
+            .await
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Movie {
+            title: String,
+            year: i64,
+        }
+
+        let mut graph = client.select_graph("test_async_query_as");
+        let _ = graph.delete().await;
+
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995})")
+            .execute()
+            .await
+            .expect("create should succeed");
+
+        let movies: Vec<Movie> = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .query_as::<Movie>()
+            .execute()
+            .await
+            .expect("query should succeed")
+            .data
+            .collect::<Result<_, _>>()
+            .expect("row mapping should succeed");
+
+        assert_eq!(
+            movies,
+            vec![Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+            }]
+        );
+
+        let _ = graph.delete().await;
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -397,6 +456,154 @@ mod serde_typed_mapping {
             .deserialize_into()
             .expect("deserialize should succeed");
         assert_eq!(number, 42);
+
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_query_as_node_rows() {
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut graph = client.select_graph("test_serde_query_as_nodes");
+        let _ = graph.delete();
+
+        graph
+            .query(
+                "CREATE (:Movie {title: 'Heat', year: 1995, rating: 8.3}), \
+                 (:Movie {title: 'Casino', year: 1995})",
+            )
+            .execute()
+            .expect("create should succeed");
+
+        let mut movies: Vec<Movie> = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .query_as::<Movie>()
+            .execute()
+            .expect("query should succeed")
+            .data
+            .collect::<Result<_, _>>()
+            .expect("row mapping should succeed");
+
+        movies.sort_by(|a, b| a.title.cmp(&b.title));
+        assert_eq!(
+            movies,
+            vec![
+                Movie {
+                    title: "Casino".to_string(),
+                    year: 1995,
+                    rating: None,
+                },
+                Movie {
+                    title: "Heat".to_string(),
+                    year: 1995,
+                    rating: Some(8.3),
+                },
+            ]
+        );
+
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_query_as_multi_column_aliased() {
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut graph = client.select_graph("test_serde_query_as_aliased");
+        let _ = graph.delete();
+
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995})")
+            .execute()
+            .expect("create should succeed");
+
+        let rows: Vec<Movie> = graph
+            .query("MATCH (m:Movie) RETURN m.title AS title, m.year AS year")
+            .query_as::<Movie>()
+            .execute()
+            .expect("query should succeed")
+            .data
+            .collect::<Result<_, _>>()
+            .expect("row mapping should succeed");
+
+        assert_eq!(
+            rows,
+            vec![Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+                rating: None,
+            }]
+        );
+
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_query_as_scalar_rows() {
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut graph = client.select_graph("test_serde_query_as_scalar");
+        let _ = graph.delete();
+
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995})")
+            .execute()
+            .expect("create should succeed");
+
+        let counts: Vec<i64> = graph
+            .query("MATCH (m:Movie) RETURN count(m)")
+            .query_as::<i64>()
+            .execute()
+            .expect("query should succeed")
+            .data
+            .collect::<Result<_, _>>()
+            .expect("row mapping should succeed");
+
+        assert_eq!(counts, vec![1]);
 
         let _ = graph.delete();
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -301,3 +301,103 @@ mod async_tests {
         let _ = graph.delete().await;
     }
 }
+
+#[cfg(feature = "serde")]
+mod serde_typed_mapping {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::FalkorClientBuilder;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Movie {
+        title: String,
+        year: i64,
+        #[serde(default)]
+        rating: Option<f64>,
+    }
+
+    #[test]
+    fn test_deserialize_node_into_struct() {
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut graph = client.select_graph("test_serde_typed_mapping");
+        let _ = graph.delete();
+
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995, rating: 8.3})")
+            .execute()
+            .expect("create should succeed");
+
+        let mut result = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .execute()
+            .expect("query should succeed");
+
+        let row = result.data.next().expect("expected a row");
+        let node = row.into_iter().next().expect("expected a node column");
+        let movie: Movie = node.deserialize_into().expect("deserialize should succeed");
+
+        assert_eq!(
+            movie,
+            Movie {
+                title: "Heat".to_string(),
+                year: 1995,
+                rating: Some(8.3),
+            }
+        );
+
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_deserialize_scalar_column() {
+        if skip_if_no_server() {
+            return;
+        }
+
+        let conn_info = match get_test_connection_info() {
+            Ok(info) => info,
+            Err(_) => return,
+        };
+
+        let client = match FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut graph = client.select_graph("test_serde_scalar_column");
+        let _ = graph.delete();
+
+        let mut result = graph
+            .query("RETURN 42")
+            .execute()
+            .expect("query should succeed");
+
+        let row = result.data.next().expect("expected a row");
+        let value = row.into_iter().next().expect("expected a column");
+        let number: i64 = value
+            .deserialize_into()
+            .expect("deserialize should succeed");
+        assert_eq!(number, 42);
+
+        let _ = graph.delete();
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Idea 1 (Typed result mapping)** from the project's `next-steps.md`: an optional, zero-cost-when-disabled `serde` integration that lets users map FalkorDB query results straight into their own types instead of hand-matching every `FalkorValue` variant.

### Before

```rust
let mut res = graph.query("MATCH (m:Movie) RETURN m").execute()?;
for row in res.data.by_ref() {
    if let Some(FalkorValue::Node(node)) = row.into_iter().next() {
        let title = match node.properties.get("title") {
            Some(FalkorValue::String(s)) => s.clone(),
            _ => continue,
        };
        let year = match node.properties.get("year") {
            Some(FalkorValue::I64(y)) => *y,
            _ => continue,
        };
        // ...repeat for every field...
    }
}
```

### After

```rust
#[derive(serde::Deserialize)]
struct Movie { title: String, year: i64, rating: Option<f64> }

let mut res = graph.query("MATCH (m:Movie) RETURN m").execute()?;
for row in res.data.by_ref() {
    if let Some(node) = row.into_iter().next() {
        let movie: Movie = node.deserialize_into()?;
    }
}
```

## What's included

- A `serde::Deserializer` for owned `FalkorValue` (`src/value/de.rs`).
- `FalkorValue::deserialize_into::<T>()` and the free function `from_falkor_value::<T>()`, both re-exported from the crate root (feature-gated).
- Mapping for scalars, `Option`, sequences (`Array`/`Vec32`), maps, `Node`/`Edge` (via their `properties`), `Point`, and externally-tagged/unit enums. `Path` and `Unparseable` return a clear error.
- A new `serde`-gated `FalkorDBError::SerdeError` variant implementing `serde::de::Error`.
- Unit tests, server-backed integration tests, and a runnable `examples/typed_mapping.rs`.
- CI coverage: the new `serde` feature is added to the Justfile dev feature set, so `clippy-all`, `test`, `build-all`, and `coverage` all exercise it; `just integration --all-features` runs the server-backed serde tests.

## Scope

This is the first, narrow increment of Idea 1 (value-level mapping via the `serde` data model). A header-aware `query_as::<T>()` row builder and an optional `#[derive(FromFalkorNode)]` proc-macro remain as documented follow-ups.

## Testing

- `cargo test --lib --features serde` (12 unit tests)
- `just integration --all-features` against a local FalkorDB (server-backed serde tests pass)
- `cargo run --example typed_mapping --features serde`
- `just clippy`, `just fmt-check`, `just doc`, `just build`, `just deny`, and `cargo clippy --all-targets --features tokio,embedded,serde -- -D warnings` all green

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `serde` feature enabling typed result mapping—use `query_as::<T>()` to automatically deserialize query results into Rust structs.

* **Documentation**
  * New README section documenting typed result mapping with usage examples.

* **Examples**
  * Added example showcasing typed mapping patterns and workflows.

* **Tests**
  * Added integration tests for typed result mapping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->