### PR TITLE
feat!: type-safe, injection-proof query parameters

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -134,3 +134,7 @@ deserialize
 deserialized
 imdb
 iter
+params
+WaitOptions
+ConstraintFailed
+Ok

--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -138,3 +138,4 @@ params
 WaitOptions
 ConstraintFailed
 Ok
+NUL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- type-safe, injection-proof query parameters: `QueryBuilder::with_param`, `try_with_param`,
+  `with_params`, and `with_raw_param`, backed by the sealed `IntoFalkorParam` /
+  `IntoFalkorParams` traits and the `to_cypher_param` helper. Values (integers, floats, boolean
+  values, strings, `Option`, arrays/`Vec`, string-keyed maps, `Point`/`Vec32`, `FalkorValue`) are
+  encoded as escaped Cypher literals, and parameter names are validated.
+
+### Changed
+
+- **Not backward compatible:** `QueryBuilder::with_params` no longer takes
+  `&HashMap<String, String>` of raw, pre-quoted values. Pass typed values instead — e.g.
+  `.with_param("title", "The Matrix").with_param("year", 1999)` or
+  `.with_params([("year", 1999)])`. String values are now encoded as Cypher *strings* (quoted and
+  escaped); numbers that used to be passed as strings (`"30"`) should be passed as numbers (`30`),
+  and any value that was a raw Cypher expression should use `with_raw_param`. Procedure-call
+  arguments are likewise encoded safely.
+
 ## [0.5.0](https://github.com/FalkorDB/falkordb-rs/compare/v0.4.0...v0.5.0) - 2026-06-17
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ required-features = ["embedded"]
 [[example]]
 name = "typed_mapping"
 required-features = ["serde"]
+
+[[example]]
+name = "typed_params"

--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ test-one filter:
 
 # Run only the `serde` property-based tests (no server); `cases` sets PROPTEST_CASES (default 256).
 proptest cases="256":
-    PROPTEST_CASES={{cases}} cargo nextest run --lib --features serde de_proptest
+    PROPTEST_CASES={{cases}} cargo nextest run --lib --features serde proptest
 
 # Spin up a server, populate the fixture, run the full suite, then tear it down.
 test-local: db-up db-populate

--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ let res = graph
     .execute()?;
 ```
 
-Add several at once from an array, `Vec`, or map with `with_params`:
+Add several at once from an array, `Vec`, or map with `with_params` (the values share a single
+type; use chained `with_param` calls, as above, for a mix of types):
 
 ```rust,ignore
-.with_params([("title", "The Matrix"), ("year", 1999)])
+.with_params([("min_year", 1990), ("max_year", 2000)])
 ```
 
 Supported value types include integers, floats, boolean values, strings, `Option` (encoded as

--- a/README.md
+++ b/README.md
@@ -63,6 +63,39 @@ while let Some(node) = nodes.data.next() {
 
 ## Features
 
+### Type-safe query parameters
+
+Pass Rust values straight into a query — the client encodes them as Cypher literals and escapes
+them for you, so you never hand-quote strings or risk Cypher injection:
+
+```rust,ignore
+let res = graph
+    .query("MATCH (m:Movie {title: $title}) WHERE m.year IN $years RETURN m")
+    .with_param("title", "The Matrix")
+    .with_param("years", [1999, 2003])
+    .execute()?;
+```
+
+Add several at once from an array, `Vec`, or map with `with_params`:
+
+```rust,ignore
+.with_params([("title", "The Matrix"), ("year", 1999)])
+```
+
+Supported value types include integers, floats, boolean values, strings, `Option` (encoded as
+`null`), arrays/`Vec`, and string-keyed `HashMap`/`BTreeMap` (nested freely). Points and vectors
+cannot be bound directly (a FalkorDB limitation) — pass the components and construct them in the
+query:
+
+```rust,ignore
+use std::collections::BTreeMap;
+let coords = BTreeMap::from([("latitude", 32.07), ("longitude", 34.79)]);
+graph.query("RETURN point($p)").with_param("p", coords).execute()?;
+```
+
+If you really need a raw Cypher expression, `with_raw_param("key", "…")` is the explicit escape
+hatch — no escaping is applied to the value (the parameter name is still validated).
+
 ### Waiting for background operations
 
 Some FalkorDB operations finish **after** the command that starts them returns: when you create or

--- a/README.md
+++ b/README.md
@@ -640,10 +640,11 @@ cargo test --lib --features embedded
 
 #### Property-Based Tests
 
-The optional `serde` integration is covered by [`proptest`](https://docs.rs/proptest) cases in
-`src/value/de_proptest.rs`, which need no running server. They assert that value- and row-level
-mapping agrees with `serde_json` over the shared data model, never panics on arbitrary input, and
-rejects malformed row shapes. Run just these:
+The crate ships [`proptest`](https://docs.rs/proptest) suites that need no running server:
+`src/value/param_proptest.rs` checks query-parameter encoding (encoding arbitrary values never
+panics, string escaping is lossless, NUL is rejected), and `src/value/de_proptest.rs` checks the
+optional `serde` mapping (agreement with `serde_json`, no panics, malformed-row rejection). Run
+just these:
 
 ```bash
 # 256 cases per property (the proptest default)
@@ -653,7 +654,7 @@ just proptest
 just proptest 4096
 
 # equivalent raw cargo command
-cargo nextest run --lib --features serde de_proptest
+cargo nextest run --lib --features serde proptest
 ```
 
 They also run in CI: as the dedicated `check-proptest` job, and within the `coverage` job.

--- a/examples/typed_params.rs
+++ b/examples/typed_params.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Type-safe, injection-proof query parameters.
+//!
+//! Run with: `cargo run --example typed_params`
+//!
+//! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
+
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorValue};
+use std::collections::BTreeMap;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()?;
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info)
+        .build()?;
+
+    let mut graph = client.select_graph("typed_params_example");
+
+    // Start from a clean slate so the example is idempotent across runs.
+    let _ = graph.delete();
+
+    // ── Before: hand-quoting and escaping every value yourself ──────────────
+    // let mut params = HashMap::new();
+    // params.insert("title".to_string(), "'The Matrix'".to_string()); // manual quotes!
+    // params.insert("year".to_string(), 1999.to_string());
+    // graph.query("CREATE (:Movie {title: $title, year: $year})").with_params(&params)...
+
+    // ── After: typed values, encoding handled for you ───────────────────────
+    graph
+        .query("CREATE (:Movie {title: $title, year: $year, rating: $rating})")
+        .with_param("title", "The Matrix")
+        .with_param("year", 1999)
+        .with_param("rating", 8.7)
+        .execute()?;
+
+    // A string that would be a Cypher-injection attempt is stored as an inert literal.
+    graph
+        .query("CREATE (:Movie {title: $title, year: $year})")
+        .with_param("title", "'; MATCH (n) DETACH DELETE n //")
+        .with_param("year", 2003)
+        .execute()?;
+
+    // Collections work too: `WHERE x IN $list`.
+    let mut titles = graph
+        .query("MATCH (m:Movie) WHERE m.year IN $years RETURN m.title ORDER BY m.year")
+        .with_param("years", [1999, 2003])
+        .execute()?;
+    for row in titles.data.by_ref() {
+        if let Some(FalkorValue::String(title)) = row.into_iter().next() {
+            println!("matched: {title}");
+        }
+    }
+
+    // Points can't be bound directly — pass the components as a map and wrap with `point()`.
+    let coords = BTreeMap::from([("latitude", 32.07), ("longitude", 34.79)]);
+    let mut located = graph
+        .query("RETURN point($p)")
+        .with_param("p", coords)
+        .execute()?;
+    if let Some(row) = located.data.next() {
+        println!("point: {:?}", row.into_iter().next());
+    }
+
+    graph.delete()?;
+    Ok(())
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -154,6 +154,16 @@ pub enum FalkorDBError {
     #[cfg(feature = "serde")]
     #[error("Failed to deserialize via serde: {0}")]
     SerdeError(String),
+    /// A value could not be encoded as a Cypher query-parameter literal (for example a non-finite
+    /// float, a string containing a NUL byte, an integer outside the `i64` range, an invalid
+    /// parameter name, or a graph entity such as a `Node`/`Edge`/`Path`).
+    #[error("invalid query parameter{}: {message}", .parameter.as_deref().map(|p| format!(" '{p}'")).unwrap_or_default())]
+    ParamEncoding {
+        /// The name of the offending parameter, when known.
+        parameter: Option<String>,
+        /// A human-readable description of why encoding failed.
+        message: String,
+    },
 }
 
 #[cfg(feature = "serde")]

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -67,6 +67,9 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
     /// invalid parameter name) is reported when the query is executed; use
     /// [`try_with_param`](Self::try_with_param) to fail eagerly instead.
     ///
+    /// The query string itself must not already start with a manual `CYPHER name=value` preamble;
+    /// the preamble is generated from the parameters added here.
+    ///
     /// # Arguments
     /// * `key`: the parameter name (a Cypher identifier), referenced as `$key`
     /// * `value`: any value implementing [`IntoFalkorParam`]
@@ -711,5 +714,32 @@ mod tests {
         let mut params = FalkorParams::new();
         params.add_param("bad name", 1i64);
         assert!(construct_query("RETURN 1", &params).is_err());
+    }
+
+    #[test]
+    fn test_generate_procedure_call_arg_injection_is_escaped() {
+        let args = ["'; MATCH (n) DELETE n //"];
+        let (_query, params) = generate_procedure_call("p", Some(&args), None);
+        let mut preamble = String::new();
+        params.encode_preamble(&mut preamble).unwrap();
+        assert_eq!(preamble, "CYPHER param0='\\'; MATCH (n) DELETE n //' ");
+    }
+
+    #[test]
+    fn test_generate_procedure_call_nul_arg_errors() {
+        let args = ["a\0b"];
+        let (_query, params) = generate_procedure_call("p", Some(&args), None);
+        assert!(params.encode_preamble(&mut String::new()).is_err());
+    }
+
+    #[test]
+    fn test_construct_query_procedure_end_to_end() {
+        let args = ["Label"];
+        let (query, params) = generate_procedure_call("db.idx", Some(&args), Some(&["node"]));
+        let full = construct_query(query, &params).unwrap();
+        assert_eq!(
+            full,
+            "CYPHER param0='Label' CALL db.idx($param0) YIELD node"
+        );
     }
 }

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -6,10 +6,13 @@
 use crate::{
     graph::HasGraphSchema,
     parser::{redis_value_as_vec, SchemaParsable},
-    Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorResult, LazyResultSet,
-    QueryResult, SyncGraph,
+    Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult,
+    IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, SyncGraph,
 };
-use std::{collections::HashMap, fmt::Display, marker::PhantomData, ops::Not};
+use std::{
+    fmt::{Display, Write},
+    marker::PhantomData,
+};
 
 #[cfg(feature = "tokio")]
 use crate::AsyncGraph;
@@ -21,25 +24,14 @@ use crate::TypedLazyResultSet;
     feature = "tracing",
     tracing::instrument(name = "Construct Query", skip_all, level = "trace")
 )]
-pub(crate) fn construct_query<Q: Display, T: Display, Z: Display>(
+pub(crate) fn construct_query<Q: Display>(
     query_str: Q,
-    params: Option<&HashMap<T, Z>>,
-) -> String {
-    let params_str = params
-        .map(|p| {
-            p.iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
-        .and_then(|params_str| {
-            params_str
-                .is_empty()
-                .not()
-                .then_some(format!("CYPHER {params_str} "))
-        })
-        .unwrap_or_default();
-    format!("{params_str}{query_str}")
+    params: &FalkorParams,
+) -> FalkorResult<String> {
+    let mut query = String::new();
+    params.encode_preamble(&mut query)?;
+    let _ = write!(query, "{query_str}");
+    Ok(query)
 }
 
 /// A Builder-pattern struct that allows creating and executing queries on a graph
@@ -48,7 +40,7 @@ pub struct QueryBuilder<'a, Output, T: Display, G: HasGraphSchema> {
     graph: &'a mut G,
     command: &'a str,
     query_string: T,
-    params: Option<&'a HashMap<String, String>>,
+    params: FalkorParams,
     timeout: Option<i64>,
 }
 
@@ -63,23 +55,65 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
             graph,
             command,
             query_string,
-            params: None,
+            params: FalkorParams::new(),
             timeout: None,
         }
     }
 
-    /// Pass the following params to the query as "CYPHER {param_key}={param_val}"
+    /// Add a single typed parameter, referenced as `$key` in the query.
+    ///
+    /// The value is encoded as a Cypher literal and escaped for you, so strings, lists and maps
+    /// are safe from Cypher injection. Any encoding error (for example a non-finite float, or an
+    /// invalid parameter name) is reported when the query is executed; use
+    /// [`try_with_param`](Self::try_with_param) to fail eagerly instead.
     ///
     /// # Arguments
-    /// * `params`: A [`HashMap`] of params in key-val format
-    pub fn with_params(
-        self,
-        params: &'a HashMap<String, String>,
+    /// * `key`: the parameter name (a Cypher identifier), referenced as `$key`
+    /// * `value`: any value implementing [`IntoFalkorParam`]
+    pub fn with_param<V: IntoFalkorParam>(
+        mut self,
+        key: &str,
+        value: V,
     ) -> Self {
-        Self {
-            params: Some(params),
-            ..self
+        self.params.add_param(key, value);
+        self
+    }
+
+    /// Like [`with_param`](Self::with_param), but returns an error immediately if the parameter
+    /// name or value cannot be encoded, rather than deferring it to execution.
+    pub fn try_with_param<V: IntoFalkorParam>(
+        mut self,
+        key: &str,
+        value: V,
+    ) -> FalkorResult<Self> {
+        self.params.add_param(key, value);
+        match self.params.first_error() {
+            Some(err) => Err(err),
+            None => Ok(self),
         }
+    }
+
+    /// Add several typed parameters at once, e.g. from a `Vec<(key, value)>`, an array of pairs,
+    /// or a `HashMap`/`BTreeMap`. See [`IntoFalkorParams`].
+    pub fn with_params<P: IntoFalkorParams>(
+        mut self,
+        params: P,
+    ) -> Self {
+        self.params.merge(params.into_falkor_params());
+        self
+    }
+
+    /// Escape hatch: insert a raw, **already-valid** Cypher expression as the parameter value.
+    ///
+    /// No escaping is performed on the value (the name is still validated), so a malformed
+    /// expression can reintroduce Cypher injection — prefer [`with_param`](Self::with_param).
+    pub fn with_raw_param(
+        mut self,
+        key: &str,
+        raw_cypher: impl Into<String>,
+    ) -> Self {
+        self.params.add_raw(key, raw_cypher.into());
+        self
     }
 
     /// Specify a timeout after which to abort the query
@@ -170,7 +204,7 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         )
     )]
     fn common_execute_steps(&mut self) -> FalkorResult<redis::Value> {
-        let query = construct_query(&self.query_string, self.params);
+        let query = construct_query(&self.query_string, &self.params)?;
 
         let timeout = self.timeout.map(|timeout| format!("timeout {timeout}"));
         let mut params = vec![query.as_str(), "--compact"];
@@ -206,7 +240,7 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         )
     )]
     async fn common_execute_steps(&mut self) -> FalkorResult<redis::Value> {
-        let query = construct_query(&self.query_string, self.params);
+        let query = construct_query(&self.query_string, &self.params)?;
 
         let timeout = self.timeout.map(|timeout| format!("timeout {timeout}"));
         let mut params = vec![query.as_str(), "--compact"];
@@ -349,38 +383,27 @@ impl<'a, T: Display> QueryBuilder<'a, ExecutionPlan, T, AsyncGraph> {
     feature = "tracing",
     tracing::instrument(name = "Generate Procedure Call", skip_all, level = "trace")
 )]
-pub(crate) fn generate_procedure_call<P: Display, T: Display, Z: Display>(
-    procedure: P,
-    args: Option<&[T]>,
-    yields: Option<&[Z]>,
-) -> (String, Option<HashMap<String, String>>) {
+pub(crate) fn generate_procedure_call(
+    procedure: &str,
+    args: Option<&[&str]>,
+    yields: Option<&[&str]>,
+) -> (String, FalkorParams) {
+    let mut params = FalkorParams::new();
     let args_str = args
         .unwrap_or_default()
         .iter()
-        .map(|e| format!("${}", e))
+        .enumerate()
+        .map(|(idx, arg)| {
+            let name = format!("param{idx}");
+            params.add_param(&name, *arg);
+            format!("${name}")
+        })
         .collect::<Vec<_>>()
         .join(",");
-    let mut query_string = format!("CALL {}({})", procedure, args_str);
-
-    let params = args.map(|args| {
-        args.iter()
-            .enumerate()
-            .fold(HashMap::new(), |mut acc, (idx, param)| {
-                acc.insert(format!("param{idx}"), param.to_string());
-                acc
-            })
-    });
+    let mut query_string = format!("CALL {procedure}({args_str})");
 
     if let Some(yields) = yields {
-        query_string += format!(
-            " YIELD {}",
-            yields
-                .iter()
-                .map(|element| element.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
-        .as_str();
+        query_string += format!(" YIELD {}", yields.join(",")).as_str();
     }
 
     (query_string, params)
@@ -498,7 +521,7 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
 
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
-        let query = construct_query(query_string, params.as_ref());
+        let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
         let conn = if self.readonly {
@@ -537,7 +560,7 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
 
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
-        let query = construct_query(query_string, params.as_ref());
+        let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
         let conn = if self.readonly {
@@ -619,116 +642,74 @@ mod tests {
 
     #[test]
     fn test_generate_procedure_call_no_args_no_yields() {
-        let procedure = "my_procedure";
-        let args: Option<&[String]> = None;
-        let yields: Option<&[String]> = None;
-
-        let expected_query = "CALL my_procedure()".to_string();
-        let expected_params: Option<HashMap<String, String>> = None;
-
-        let result = generate_procedure_call(procedure, args, yields);
-
-        assert_eq!(result, (expected_query, expected_params));
+        let (query, params) = generate_procedure_call("my_procedure", None, None);
+        assert_eq!(query, "CALL my_procedure()");
+        assert!(params.is_empty());
     }
 
     #[test]
     fn test_generate_procedure_call_with_args_no_yields() {
-        let procedure = "my_procedure";
-        let args = &["arg1".to_string(), "arg2".to_string()];
-        let yields: Option<&[String]> = None;
-
-        let expected_query = "CALL my_procedure($arg1,$arg2)".to_string();
-        let mut expected_params = HashMap::new();
-        expected_params.insert("param0".to_string(), "arg1".to_string());
-        expected_params.insert("param1".to_string(), "arg2".to_string());
-
-        let result = generate_procedure_call(procedure, Some(args), yields);
-
-        assert_eq!(result, (expected_query, Some(expected_params)));
+        let args = ["arg1", "arg2"];
+        let (query, params) = generate_procedure_call("my_procedure", Some(&args), None);
+        assert_eq!(query, "CALL my_procedure($param0,$param1)");
+        // String args are encoded as safe, quoted Cypher string literals.
+        let mut preamble = String::new();
+        params.encode_preamble(&mut preamble).unwrap();
+        assert_eq!(preamble, "CYPHER param0='arg1' param1='arg2' ");
     }
 
     #[test]
     fn test_generate_procedure_call_no_args_with_yields() {
-        let procedure = "my_procedure";
-        let args: Option<&[String]> = None;
-        let yields = &["yield1".to_string(), "yield2".to_string()];
-
-        let expected_query = "CALL my_procedure() YIELD yield1,yield2".to_string();
-        let expected_params: Option<HashMap<String, String>> = None;
-
-        let result = generate_procedure_call(procedure, args, Some(yields));
-
-        assert_eq!(result, (expected_query, expected_params));
+        let yields = ["yield1", "yield2"];
+        let (query, params) = generate_procedure_call("my_procedure", None, Some(&yields));
+        assert_eq!(query, "CALL my_procedure() YIELD yield1,yield2");
+        assert!(params.is_empty());
     }
 
     #[test]
     fn test_generate_procedure_call_with_args_and_yields() {
-        let procedure = "my_procedure";
-        let args = &["arg1".to_string(), "arg2".to_string()];
-        let yields = &["yield1".to_string(), "yield2".to_string()];
-
-        let expected_query = "CALL my_procedure($arg1,$arg2) YIELD yield1,yield2".to_string();
-        let mut expected_params = HashMap::new();
-        expected_params.insert("param0".to_string(), "arg1".to_string());
-        expected_params.insert("param1".to_string(), "arg2".to_string());
-
-        let result = generate_procedure_call(procedure, Some(args), Some(yields));
-
-        assert_eq!(result, (expected_query, Some(expected_params)));
-    }
-
-    #[test]
-    fn test_construct_query_with_params() {
-        let query_str = "MATCH (n) RETURN n";
-        let mut params = HashMap::new();
-        params.insert("name", "Alice");
-        params.insert("age", "30");
-
-        let result = construct_query(query_str, Some(&params));
-        assert!(result.starts_with("CYPHER "));
-        assert!(result.ends_with(" RETURN n"));
-        assert!(result.contains(" name=Alice "));
-        assert!(result.contains(" age=30 "));
+        let args = ["arg1", "arg2"];
+        let yields = ["yield1", "yield2"];
+        let (query, params) = generate_procedure_call("my_procedure", Some(&args), Some(&yields));
+        assert_eq!(
+            query,
+            "CALL my_procedure($param0,$param1) YIELD yield1,yield2"
+        );
+        let mut preamble = String::new();
+        params.encode_preamble(&mut preamble).unwrap();
+        assert_eq!(preamble, "CYPHER param0='arg1' param1='arg2' ");
     }
 
     #[test]
     fn test_construct_query_without_params() {
-        let query_str = "MATCH (n) RETURN n";
-        let result = construct_query::<&str, &str, &str>(query_str, None);
-        assert_eq!(result, "MATCH (n) RETURN n");
-    }
-
-    #[test]
-    fn test_construct_query_empty_params() {
-        let query_str = "MATCH (n) RETURN n";
-        let params: HashMap<&str, &str> = HashMap::new();
-        let result = construct_query(query_str, Some(&params));
+        let result = construct_query("MATCH (n) RETURN n", &FalkorParams::new()).unwrap();
         assert_eq!(result, "MATCH (n) RETURN n");
     }
 
     #[test]
     fn test_construct_query_single_param() {
-        let query_str = "MATCH (n) RETURN n";
-        let mut params = HashMap::new();
-        params.insert("name", "Alice");
-
-        let result = construct_query(query_str, Some(&params));
-        assert_eq!(result, "CYPHER name=Alice MATCH (n) RETURN n");
+        let mut params = FalkorParams::new();
+        params.add_param("name", "Alice");
+        let result = construct_query("MATCH (n) RETURN n", &params).unwrap();
+        assert_eq!(result, "CYPHER name='Alice' MATCH (n) RETURN n");
     }
 
     #[test]
     fn test_construct_query_multiple_params() {
-        let query_str = "MATCH (n) RETURN n";
-        let mut params = HashMap::new();
-        params.insert("name", "Alice");
-        params.insert("age", "30");
-        params.insert("city", "Wonderland");
-
-        let result = construct_query(query_str, Some(&params));
+        let mut params = FalkorParams::new();
+        params.add_param("name", "Alice");
+        params.add_param("age", 30i64);
+        let result = construct_query("MATCH (n) RETURN n", &params).unwrap();
         assert!(result.starts_with("CYPHER "));
-        assert!(result.contains(" name=Alice "));
-        assert!(result.contains(" age=30 "));
-        assert!(result.contains(" city=Wonderland "));
+        assert!(result.contains("name='Alice'"));
+        assert!(result.contains("age=30"));
         assert!(result.ends_with("MATCH (n) RETURN n"));
+    }
+
+    #[test]
+    fn test_construct_query_param_error_propagates() {
+        let mut params = FalkorParams::new();
+        params.add_param("bad name", 1i64);
+        assert!(construct_query("RETURN 1", &params).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use value::{
     graph_entities::{Edge, EntityType, Node},
     path::Path,
     point::Point,
-    FalkorValue,
+    to_cypher_param, FalkorParams, FalkorValue, IntoFalkorParam, IntoFalkorParams, RawParam,
 };
 
 #[cfg(feature = "serde")]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -23,6 +23,9 @@ mod de;
 #[cfg(all(test, feature = "serde"))]
 mod de_proptest;
 
+#[cfg(test)]
+mod param_proptest;
+
 pub use param::{to_cypher_param, FalkorParams, IntoFalkorParam, IntoFalkorParams, RawParam};
 
 #[cfg(feature = "serde")]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -12,6 +12,7 @@ use vec32::Vec32;
 
 pub(crate) mod config;
 pub(crate) mod graph_entities;
+pub(crate) mod param;
 pub(crate) mod path;
 pub(crate) mod point;
 pub(crate) mod vec32;
@@ -21,6 +22,8 @@ mod de;
 
 #[cfg(all(test, feature = "serde"))]
 mod de_proptest;
+
+pub use param::{to_cypher_param, FalkorParams, IntoFalkorParam, IntoFalkorParams, RawParam};
 
 #[cfg(feature = "serde")]
 pub use de::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -1,0 +1,888 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Type-safe, injection-proof query parameters.
+//!
+//! FalkorDB does not bind parameters server-side; the client prepends a `CYPHER name=value …`
+//! preamble to the query text and the server parses each `value` as a Cypher literal. This module
+//! encodes Rust values into exactly those literals (with correct escaping), so callers never have
+//! to hand-quote strings or risk Cypher injection.
+//!
+//! Use [`QueryBuilder::with_param`](crate::QueryBuilder::with_param) /
+//! [`with_params`](crate::QueryBuilder::with_params), or the lower-level [`to_cypher_param`].
+
+use crate::value::point::Point;
+use crate::value::vec32::Vec32;
+use crate::{FalkorDBError, FalkorResult, FalkorValue};
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Write;
+
+mod sealed {
+    pub trait Sealed {}
+    pub trait SealedParams {}
+}
+
+/// A Rust value that can be encoded as a single FalkorDB/Cypher query-parameter literal.
+///
+/// This trait is **sealed**: the crate guarantees that every implementation emits exactly one
+/// safe Cypher literal, which is what makes parameters injection-proof. To pass a value whose
+/// type does not implement it, either convert it to a supported type (for example a map or a
+/// list) or use [`QueryBuilder::with_raw_param`](crate::QueryBuilder::with_raw_param) for a raw,
+/// already-valid Cypher expression.
+///
+/// Encoding is fallible: a few values have no Cypher representation — non-finite floats, strings
+/// containing a NUL byte, integers outside the `i64` range, map keys containing a backtick, and
+/// the `Node`/`Edge`/`Path` graph-entity [`FalkorValue`] variants.
+pub trait IntoFalkorParam: sealed::Sealed {
+    /// Append the Cypher literal for `self` to `out`.
+    #[doc(hidden)]
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()>;
+}
+
+/// Encode a single value as a Cypher parameter literal.
+///
+/// This is the building block behind [`QueryBuilder::with_param`](crate::QueryBuilder::with_param);
+/// it is exposed for testing and advanced use.
+///
+/// # Examples
+///
+/// ```
+/// let s = falkordb::to_cypher_param(&"it's").unwrap();
+/// assert_eq!(s, "'it\\'s'");
+///
+/// let s = falkordb::to_cypher_param(&[1, 2, 3]).unwrap();
+/// assert_eq!(s, "[1, 2, 3]");
+/// ```
+///
+/// # Errors
+///
+/// Returns [`FalkorDBError::ParamEncoding`] if the value has no Cypher representation.
+pub fn to_cypher_param<V: IntoFalkorParam + ?Sized>(value: &V) -> FalkorResult<String> {
+    let mut out = String::new();
+    value.encode_param(&mut out)?;
+    Ok(out)
+}
+
+fn param_err(message: impl Into<String>) -> FalkorDBError {
+    FalkorDBError::ParamEncoding {
+        parameter: None,
+        message: message.into(),
+    }
+}
+
+/// Attach a parameter name to an encoding error (the per-value encoders don't know the name).
+fn with_param_name(
+    err: FalkorDBError,
+    name: &str,
+) -> FalkorDBError {
+    match err {
+        FalkorDBError::ParamEncoding { message, .. } => FalkorDBError::ParamEncoding {
+            parameter: Some(name.to_string()),
+            message,
+        },
+        other => other,
+    }
+}
+
+/// Reconstruct a stored encoding error by value (FalkorDBError is not `Clone`).
+fn clone_param_err(err: &FalkorDBError) -> FalkorDBError {
+    match err {
+        FalkorDBError::ParamEncoding { parameter, message } => FalkorDBError::ParamEncoding {
+            parameter: parameter.clone(),
+            message: message.clone(),
+        },
+        other => param_err(other.to_string()),
+    }
+}
+
+/// Validate a parameter name. Names are referenced as `$name` in the query, so they must be Cypher
+/// identifiers; this also stops the name itself from breaking the `CYPHER name=value` preamble.
+pub(crate) fn validate_param_name(name: &str) -> FalkorResult<()> {
+    let mut chars = name.chars();
+    let valid = matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if valid {
+        Ok(())
+    } else {
+        Err(FalkorDBError::ParamEncoding {
+            parameter: Some(name.to_string()),
+            message: "parameter name must be a Cypher identifier ([A-Za-z_][A-Za-z0-9_]*)"
+                .to_string(),
+        })
+    }
+}
+
+/// Encode a string as a single-quoted Cypher string literal.
+///
+/// Verified against FalkorDB: only `\\ \' \n \r \t \b \f` are interpreted as escapes, `\uXXXX`
+/// is *not*, and a NUL byte is rejected. Every other code point (including non-ASCII) is emitted
+/// raw as UTF-8.
+fn encode_str(
+    s: &str,
+    out: &mut String,
+) -> FalkorResult<()> {
+    out.push('\'');
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\'' => out.push_str("\\'"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            '\0' => {
+                return Err(param_err(
+                    "string contains a NUL byte, which FalkorDB cannot encode",
+                ))
+            }
+            _ => out.push(ch),
+        }
+    }
+    out.push('\'');
+    Ok(())
+}
+
+fn is_bare_identifier(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Encode a map key. Cypher map keys must be identifiers; non-identifier keys are backtick-quoted.
+/// Keys containing a backtick can't be encoded (verified: the server rejects the doubled-backtick
+/// escape in a parameter value), and empty keys are invalid.
+fn encode_map_key(
+    key: &str,
+    out: &mut String,
+) -> FalkorResult<()> {
+    if key.is_empty() {
+        return Err(param_err("map parameter has an empty key"));
+    }
+    if key.contains('`') {
+        return Err(param_err(
+            "map parameter key contains a backtick, which FalkorDB cannot encode",
+        ));
+    }
+    if is_bare_identifier(key) {
+        out.push_str(key);
+    } else {
+        out.push('`');
+        out.push_str(key);
+        out.push('`');
+    }
+    Ok(())
+}
+
+fn encode_list<T: IntoFalkorParam>(
+    items: &[T],
+    out: &mut String,
+) -> FalkorResult<()> {
+    out.push('[');
+    for (idx, item) in items.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        item.encode_param(out)?;
+    }
+    out.push(']');
+    Ok(())
+}
+
+fn encode_map<'a, K, V, I>(
+    entries: I,
+    out: &mut String,
+) -> FalkorResult<()>
+where
+    K: AsRef<str> + 'a,
+    V: IntoFalkorParam + 'a,
+    I: Iterator<Item = (&'a K, &'a V)>,
+{
+    out.push('{');
+    for (idx, (key, value)) in entries.enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        encode_map_key(key.as_ref(), out)?;
+        out.push_str(": ");
+        value.encode_param(out)?;
+    }
+    out.push('}');
+    Ok(())
+}
+
+// ---- scalar impls ---------------------------------------------------------------------------
+
+macro_rules! impl_int_param {
+    ($($t:ty),* $(,)?) => {$(
+        impl sealed::Sealed for $t {}
+        impl IntoFalkorParam for $t {
+            fn encode_param(&self, out: &mut String) -> FalkorResult<()> {
+                let _ = write!(out, "{self}");
+                Ok(())
+            }
+        }
+    )*};
+}
+impl_int_param!(i8, i16, i32, i64, u8, u16, u32);
+
+macro_rules! impl_big_int_param {
+    ($($t:ty),* $(,)?) => {$(
+        impl sealed::Sealed for $t {}
+        impl IntoFalkorParam for $t {
+            fn encode_param(&self, out: &mut String) -> FalkorResult<()> {
+                let value = i64::try_from(*self).map_err(|_| {
+                    param_err(format!("integer {self} is outside FalkorDB's i64 range"))
+                })?;
+                let _ = write!(out, "{value}");
+                Ok(())
+            }
+        }
+    )*};
+}
+impl_big_int_param!(u64, u128, i128, usize, isize);
+
+macro_rules! impl_float_param {
+    ($($t:ty),* $(,)?) => {$(
+        impl sealed::Sealed for $t {}
+        impl IntoFalkorParam for $t {
+            fn encode_param(&self, out: &mut String) -> FalkorResult<()> {
+                if !self.is_finite() {
+                    return Err(param_err(format!(
+                        "float {self} is not finite; FalkorDB has no literal for NaN/Infinity"
+                    )));
+                }
+                // `{:?}` is the shortest round-trippable form and always keeps a decimal point,
+                // so the value stays a float (e.g. `1.0`, not `1`).
+                let _ = write!(out, "{:?}", *self);
+                Ok(())
+            }
+        }
+    )*};
+}
+impl_float_param!(f32, f64);
+
+impl sealed::Sealed for bool {}
+impl IntoFalkorParam for bool {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        out.push_str(if *self { "true" } else { "false" });
+        Ok(())
+    }
+}
+
+// ---- string impls ---------------------------------------------------------------------------
+
+impl sealed::Sealed for str {}
+impl IntoFalkorParam for str {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_str(self, out)
+    }
+}
+
+impl sealed::Sealed for String {}
+impl IntoFalkorParam for String {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_str(self, out)
+    }
+}
+
+impl sealed::Sealed for Cow<'_, str> {}
+impl IntoFalkorParam for Cow<'_, str> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_str(self, out)
+    }
+}
+
+impl sealed::Sealed for char {}
+impl IntoFalkorParam for char {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        let mut buf = [0u8; 4];
+        encode_str(self.encode_utf8(&mut buf), out)
+    }
+}
+
+// ---- reference / smart-pointer impls --------------------------------------------------------
+
+impl<T: sealed::Sealed + ?Sized> sealed::Sealed for &T {}
+impl<T: IntoFalkorParam + ?Sized> IntoFalkorParam for &T {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        (**self).encode_param(out)
+    }
+}
+
+impl<T: sealed::Sealed + ?Sized> sealed::Sealed for Box<T> {}
+impl<T: IntoFalkorParam + ?Sized> IntoFalkorParam for Box<T> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        (**self).encode_param(out)
+    }
+}
+
+// ---- option / unit --------------------------------------------------------------------------
+
+impl<T: sealed::Sealed> sealed::Sealed for Option<T> {}
+impl<T: IntoFalkorParam> IntoFalkorParam for Option<T> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        match self {
+            Some(value) => value.encode_param(out),
+            None => {
+                out.push_str("null");
+                Ok(())
+            }
+        }
+    }
+}
+
+impl sealed::Sealed for () {}
+impl IntoFalkorParam for () {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        out.push_str("null");
+        Ok(())
+    }
+}
+
+// ---- collections ----------------------------------------------------------------------------
+
+impl<T: sealed::Sealed> sealed::Sealed for Vec<T> {}
+impl<T: IntoFalkorParam> IntoFalkorParam for Vec<T> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_list(self, out)
+    }
+}
+
+impl<T: sealed::Sealed> sealed::Sealed for [T] {}
+impl<T: IntoFalkorParam> IntoFalkorParam for [T] {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_list(self, out)
+    }
+}
+
+impl<T: sealed::Sealed, const N: usize> sealed::Sealed for [T; N] {}
+impl<T: IntoFalkorParam, const N: usize> IntoFalkorParam for [T; N] {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_list(self, out)
+    }
+}
+
+impl<K: AsRef<str>, V: sealed::Sealed> sealed::Sealed for HashMap<K, V> {}
+impl<K: AsRef<str>, V: IntoFalkorParam> IntoFalkorParam for HashMap<K, V> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_map(self.iter(), out)
+    }
+}
+
+impl<K: AsRef<str>, V: sealed::Sealed> sealed::Sealed for BTreeMap<K, V> {}
+impl<K: AsRef<str>, V: IntoFalkorParam> IntoFalkorParam for BTreeMap<K, V> {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_map(self.iter(), out)
+    }
+}
+
+macro_rules! impl_tuple_param {
+    ($($name:ident),+) => {
+        impl<$($name: sealed::Sealed),+> sealed::Sealed for ($($name,)+) {}
+        impl<$($name: IntoFalkorParam),+> IntoFalkorParam for ($($name,)+) {
+            #[allow(non_snake_case)]
+            fn encode_param(&self, out: &mut String) -> FalkorResult<()> {
+                let ($($name,)+) = self;
+                out.push('[');
+                let mut first = true;
+                $(
+                    if !first { out.push_str(", "); }
+                    first = false;
+                    $name.encode_param(out)?;
+                )+
+                let _ = first;
+                out.push(']');
+                Ok(())
+            }
+        }
+    };
+}
+impl_tuple_param!(A);
+impl_tuple_param!(A, B);
+impl_tuple_param!(A, B, C);
+impl_tuple_param!(A, B, C, D);
+impl_tuple_param!(A, B, C, D, E);
+impl_tuple_param!(A, B, C, D, E, F);
+
+// ---- domain types ---------------------------------------------------------------------------
+
+impl sealed::Sealed for Point {}
+impl IntoFalkorParam for Point {
+    /// Encodes as the map `{latitude: …, longitude: …}`. FalkorDB cannot bind a point directly,
+    /// so wrap the parameter with `point($p)` in your query.
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        out.push_str("{latitude: ");
+        self.latitude.encode_param(out)?;
+        out.push_str(", longitude: ");
+        self.longitude.encode_param(out)?;
+        out.push('}');
+        Ok(())
+    }
+}
+
+impl sealed::Sealed for Vec32 {}
+impl IntoFalkorParam for Vec32 {
+    /// Encodes as a float list. FalkorDB cannot bind a vector directly, so wrap the parameter
+    /// with `vecf32($v)` in your query.
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        encode_list(&self.values, out)
+    }
+}
+
+impl sealed::Sealed for FalkorValue {}
+impl IntoFalkorParam for FalkorValue {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        match self {
+            FalkorValue::I64(value) => value.encode_param(out),
+            FalkorValue::F64(value) => value.encode_param(out),
+            FalkorValue::Bool(value) => value.encode_param(out),
+            FalkorValue::String(value) => value.encode_param(out),
+            FalkorValue::None => {
+                out.push_str("null");
+                Ok(())
+            }
+            FalkorValue::Array(values) => encode_list(values, out),
+            FalkorValue::Map(map) => encode_map(map.iter(), out),
+            FalkorValue::Point(point) => point.encode_param(out),
+            FalkorValue::Vec32(vec) => vec.encode_param(out),
+            FalkorValue::Node(_) => Err(param_err("a Node cannot be used as a query parameter")),
+            FalkorValue::Edge(_) => Err(param_err("an Edge cannot be used as a query parameter")),
+            FalkorValue::Path(_) => Err(param_err("a Path cannot be used as a query parameter")),
+            FalkorValue::Unparseable(_) => Err(param_err(
+                "an unparseable value cannot be used as a query parameter",
+            )),
+        }
+    }
+}
+
+/// A raw, already-valid Cypher expression to use as a parameter value, **without any escaping**.
+///
+/// This is the explicit escape hatch behind
+/// [`QueryBuilder::with_raw_param`](crate::QueryBuilder::with_raw_param). The parameter *name* is
+/// still validated, but the value is your responsibility — prefer the typed values whenever
+/// possible, as a malformed expression can reintroduce Cypher injection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawParam(pub String);
+
+impl sealed::Sealed for RawParam {}
+impl IntoFalkorParam for RawParam {
+    fn encode_param(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        out.push_str(&self.0);
+        Ok(())
+    }
+}
+
+// ---- the parameter set ----------------------------------------------------------------------
+
+/// An ordered, name-deduplicated set of query parameters.
+///
+/// This is what [`QueryBuilder::with_params`](crate::QueryBuilder::with_params) accepts (via
+/// [`IntoFalkorParams`]). Each value is encoded eagerly when added; if a value cannot be encoded,
+/// the error is stored and surfaced when the query is executed. Inserting a name that already
+/// exists replaces its value ("last write wins").
+#[derive(Debug, Default)]
+pub struct FalkorParams {
+    entries: Vec<(String, FalkorResult<String>)>,
+}
+
+impl FalkorParams {
+    /// Create an empty parameter set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn set(
+        &mut self,
+        name: &str,
+        encoded: FalkorResult<String>,
+    ) {
+        if let Some(slot) = self
+            .entries
+            .iter_mut()
+            .find(|(existing, _)| existing == name)
+        {
+            slot.1 = encoded;
+        } else {
+            self.entries.push((name.to_string(), encoded));
+        }
+    }
+
+    pub(crate) fn add_param<V: IntoFalkorParam>(
+        &mut self,
+        name: &str,
+        value: V,
+    ) {
+        let encoded = validate_param_name(name)
+            .and_then(|()| to_cypher_param(&value).map_err(|err| with_param_name(err, name)));
+        self.set(name, encoded);
+    }
+
+    pub(crate) fn add_raw(
+        &mut self,
+        name: &str,
+        raw_cypher: String,
+    ) {
+        let encoded = validate_param_name(name).map(|()| raw_cypher);
+        self.set(name, encoded);
+    }
+
+    pub(crate) fn merge(
+        &mut self,
+        other: FalkorParams,
+    ) {
+        for (name, encoded) in other.entries {
+            self.set(&name, encoded);
+        }
+    }
+
+    /// Returns whether there are no parameters.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub(crate) fn first_error(&self) -> Option<FalkorDBError> {
+        self.entries
+            .iter()
+            .find_map(|(_, encoded)| encoded.as_ref().err().map(clone_param_err))
+    }
+
+    /// Append the `CYPHER name=value …` preamble (with a trailing space) to `out`, or nothing if
+    /// there are no parameters. Returns the first parameter encoding error, if any.
+    pub(crate) fn encode_preamble(
+        &self,
+        out: &mut String,
+    ) -> FalkorResult<()> {
+        if self.entries.is_empty() {
+            return Ok(());
+        }
+        out.push_str("CYPHER ");
+        for (name, encoded) in &self.entries {
+            let value = encoded.as_ref().map_err(clone_param_err)?;
+            out.push_str(name);
+            out.push('=');
+            out.push_str(value);
+            out.push(' ');
+        }
+        Ok(())
+    }
+}
+
+/// A collection that can be turned into a set of query parameters for
+/// [`QueryBuilder::with_params`](crate::QueryBuilder::with_params).
+///
+/// Implemented for [`FalkorParams`], `()` (no parameters), `Vec<(K, V)>`, `[(K, V); N]`, and
+/// `HashMap`/`BTreeMap<K, V>`, where `K: AsRef<str>` and `V: IntoFalkorParam`.
+pub trait IntoFalkorParams: sealed::SealedParams {
+    /// Encode all entries into a [`FalkorParams`].
+    #[doc(hidden)]
+    fn into_falkor_params(self) -> FalkorParams;
+}
+
+impl sealed::SealedParams for FalkorParams {}
+impl sealed::SealedParams for () {}
+impl<K: AsRef<str>, V: IntoFalkorParam> sealed::SealedParams for Vec<(K, V)> {}
+impl<K: AsRef<str>, V: IntoFalkorParam, const N: usize> sealed::SealedParams for [(K, V); N] {}
+impl<K: AsRef<str>, V: IntoFalkorParam> sealed::SealedParams for HashMap<K, V> {}
+impl<K: AsRef<str>, V: IntoFalkorParam> sealed::SealedParams for BTreeMap<K, V> {}
+
+impl IntoFalkorParams for FalkorParams {
+    fn into_falkor_params(self) -> FalkorParams {
+        self
+    }
+}
+
+impl IntoFalkorParams for () {
+    fn into_falkor_params(self) -> FalkorParams {
+        FalkorParams::new()
+    }
+}
+
+impl<K: AsRef<str>, V: IntoFalkorParam> IntoFalkorParams for Vec<(K, V)> {
+    fn into_falkor_params(self) -> FalkorParams {
+        let mut params = FalkorParams::new();
+        for (key, value) in self {
+            params.add_param(key.as_ref(), value);
+        }
+        params
+    }
+}
+
+impl<K: AsRef<str>, V: IntoFalkorParam, const N: usize> IntoFalkorParams for [(K, V); N] {
+    fn into_falkor_params(self) -> FalkorParams {
+        let mut params = FalkorParams::new();
+        for (key, value) in self {
+            params.add_param(key.as_ref(), value);
+        }
+        params
+    }
+}
+
+impl<K: AsRef<str>, V: IntoFalkorParam> IntoFalkorParams for HashMap<K, V> {
+    fn into_falkor_params(self) -> FalkorParams {
+        let mut params = FalkorParams::new();
+        for (key, value) in self {
+            params.add_param(key.as_ref(), value);
+        }
+        params
+    }
+}
+
+impl<K: AsRef<str>, V: IntoFalkorParam> IntoFalkorParams for BTreeMap<K, V> {
+    fn into_falkor_params(self) -> FalkorParams {
+        let mut params = FalkorParams::new();
+        for (key, value) in self {
+            params.add_param(key.as_ref(), value);
+        }
+        params
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enc<V: IntoFalkorParam>(value: V) -> String {
+        to_cypher_param(&value).expect("should encode")
+    }
+
+    #[test]
+    fn test_encode_scalars() {
+        assert_eq!(enc(42i64), "42");
+        assert_eq!(enc(-7i32), "-7");
+        assert_eq!(enc(255u8), "255");
+        assert_eq!(enc(true), "true");
+        assert_eq!(enc(false), "false");
+        assert_eq!(enc(Option::<i64>::None), "null");
+        assert_eq!(enc(Some(5i64)), "5");
+        assert_eq!(enc(()), "null");
+    }
+
+    #[test]
+    fn test_encode_floats() {
+        assert_eq!(enc(1.0f64), "1.0");
+        assert_eq!(enc(2.75f64), "2.75");
+        assert_eq!(enc(-0.0f64), "-0.0");
+        assert_eq!(enc(1.5f32), "1.5");
+    }
+
+    #[test]
+    fn test_encode_non_finite_float_is_error() {
+        assert!(to_cypher_param(&f64::NAN).is_err());
+        assert!(to_cypher_param(&f64::INFINITY).is_err());
+        assert!(to_cypher_param(&f32::NEG_INFINITY).is_err());
+    }
+
+    #[test]
+    fn test_encode_strings() {
+        assert_eq!(enc("hello"), "'hello'");
+        assert_eq!(enc("it's"), "'it\\'s'");
+        assert_eq!(enc("a\\b"), "'a\\\\b'");
+        assert_eq!(enc("line1\nline2"), "'line1\\nline2'");
+        assert_eq!(enc("tab\tend"), "'tab\\tend'");
+        assert_eq!(enc("café ☕"), "'café ☕'");
+        assert_eq!(enc('x'), "'x'");
+    }
+
+    #[test]
+    fn test_encode_string_injection_is_neutralized() {
+        // The classic break-out attempt becomes one inert string literal.
+        let payload = "'; MATCH (n) DETACH DELETE n //";
+        assert_eq!(enc(payload), "'\\'; MATCH (n) DETACH DELETE n //'");
+    }
+
+    #[test]
+    fn test_encode_nul_string_is_error() {
+        assert!(to_cypher_param(&"a\0b").is_err());
+    }
+
+    #[test]
+    fn test_encode_big_int_range() {
+        assert_eq!(enc(i64::MAX as u64), "9223372036854775807");
+        assert!(to_cypher_param(&(i64::MAX as u64 + 1)).is_err());
+        assert!(to_cypher_param(&u128::MAX).is_err());
+    }
+
+    #[test]
+    fn test_encode_lists() {
+        assert_eq!(enc(vec![1i64, 2, 3]), "[1, 2, 3]");
+        assert_eq!(enc([1i64, 2]), "[1, 2]");
+        assert_eq!(enc(Vec::<i64>::new()), "[]");
+        assert_eq!(enc(vec!["a", "b"]), "['a', 'b']");
+        assert_eq!(enc((1i64, "two", true)), "[1, 'two', true]");
+    }
+
+    #[test]
+    fn test_encode_map() {
+        let mut map = BTreeMap::new();
+        map.insert("age", 30i64);
+        map.insert("name_key", 1i64);
+        // BTreeMap ⇒ deterministic key order.
+        assert_eq!(enc(map), "{age: 30, name_key: 1}");
+    }
+
+    #[test]
+    fn test_encode_map_quotes_non_identifier_keys() {
+        let mut map = BTreeMap::new();
+        map.insert("weird key", 1i64);
+        assert_eq!(enc(map), "{`weird key`: 1}");
+    }
+
+    #[test]
+    fn test_encode_map_backtick_key_is_error() {
+        let mut map = BTreeMap::new();
+        map.insert("a`b", 1i64);
+        assert!(to_cypher_param(&map).is_err());
+    }
+
+    #[test]
+    fn test_encode_nested() {
+        let mut inner = BTreeMap::new();
+        inner.insert("inner", vec![1i64, 2]);
+        let outer = vec![inner];
+        assert_eq!(enc(outer), "[{inner: [1, 2]}]");
+    }
+
+    #[test]
+    fn test_encode_point_and_vector() {
+        let point = Point {
+            latitude: 1.5,
+            longitude: 2.5,
+        };
+        assert_eq!(enc(point), "{latitude: 1.5, longitude: 2.5}");
+        let vec = Vec32 {
+            values: vec![1.0, 2.0],
+        };
+        assert_eq!(enc(vec), "[1.0, 2.0]");
+    }
+
+    #[test]
+    fn test_encode_falkor_value_unsupported_variants_error() {
+        use crate::value::graph_entities::Node;
+        let node = FalkorValue::Node(Node::default());
+        assert!(to_cypher_param(&node).is_err());
+        let path = FalkorValue::Path(crate::value::path::Path::default());
+        assert!(to_cypher_param(&path).is_err());
+    }
+
+    #[test]
+    fn test_raw_param_is_verbatim() {
+        assert_eq!(
+            enc(RawParam("point({latitude: 1, longitude: 2})".to_string())),
+            "point({latitude: 1, longitude: 2})"
+        );
+    }
+
+    #[test]
+    fn test_validate_param_name() {
+        assert!(validate_param_name("age").is_ok());
+        assert!(validate_param_name("_x1").is_ok());
+        assert!(validate_param_name("").is_err());
+        assert!(validate_param_name("1x").is_err());
+        assert!(validate_param_name("a b").is_err());
+        assert!(validate_param_name("a=1").is_err());
+        assert!(validate_param_name("$x").is_err());
+        assert!(validate_param_name("`x`").is_err());
+    }
+
+    #[test]
+    fn test_params_preamble_and_dedup() {
+        let mut params = FalkorParams::new();
+        params.add_param("a", 1i64);
+        params.add_param("b", "x");
+        params.add_param("a", 2i64); // last write wins
+        let mut out = String::new();
+        params.encode_preamble(&mut out).unwrap();
+        assert_eq!(out, "CYPHER a=2 b='x' ");
+    }
+
+    #[test]
+    fn test_params_invalid_name_surfaces_error() {
+        let mut params = FalkorParams::new();
+        params.add_param("bad name", 1i64);
+        let err = params.first_error().expect("should have an error");
+        assert!(matches!(err, FalkorDBError::ParamEncoding { .. }));
+        assert!(params.encode_preamble(&mut String::new()).is_err());
+    }
+
+    #[test]
+    fn test_params_error_carries_name() {
+        let mut params = FalkorParams::new();
+        params.add_param("score", f64::NAN);
+        match params.first_error() {
+            Some(FalkorDBError::ParamEncoding { parameter, .. }) => {
+                assert_eq!(parameter.as_deref(), Some("score"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_empty_params_no_preamble() {
+        let params = FalkorParams::new();
+        assert!(params.is_empty());
+        let mut out = String::new();
+        params.encode_preamble(&mut out).unwrap();
+        assert_eq!(out, "");
+    }
+}

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -885,4 +885,124 @@ mod tests {
         params.encode_preamble(&mut out).unwrap();
         assert_eq!(out, "");
     }
+
+    #[test]
+    fn test_encode_misc_value_types() {
+        assert_eq!(enc(Cow::Borrowed("hi")), "'hi'");
+        assert_eq!(enc(Cow::<str>::Owned("hi".to_string())), "'hi'");
+        assert_eq!(enc(Box::new(5i64)), "5");
+        assert_eq!(enc(42usize), "42");
+        assert_eq!(enc(7isize), "7");
+    }
+
+    #[test]
+    fn test_encode_tuples_of_various_arities() {
+        assert_eq!(enc((1i64,)), "[1]");
+        assert_eq!(enc((1i64, 2i64)), "[1, 2]");
+        assert_eq!(enc((1i64, 2i64, 3i64, 4i64)), "[1, 2, 3, 4]");
+        assert_eq!(enc((1i64, 2i64, 3i64, 4i64, 5i64)), "[1, 2, 3, 4, 5]");
+        assert_eq!(
+            enc((1i64, 2i64, 3i64, 4i64, 5i64, 6i64)),
+            "[1, 2, 3, 4, 5, 6]"
+        );
+    }
+
+    #[test]
+    fn test_encode_hashmap() {
+        let mut map = HashMap::new();
+        map.insert("only", 1i64);
+        assert_eq!(enc(map), "{only: 1}");
+    }
+
+    #[test]
+    fn test_encode_falkor_value_variants() {
+        assert_eq!(enc(FalkorValue::I64(5)), "5");
+        assert_eq!(enc(FalkorValue::F64(2.5)), "2.5");
+        assert_eq!(enc(FalkorValue::Bool(true)), "true");
+        assert_eq!(enc(FalkorValue::String("x".to_string())), "'x'");
+        assert_eq!(enc(FalkorValue::None), "null");
+        assert_eq!(
+            enc(FalkorValue::Array(vec![
+                FalkorValue::I64(1),
+                FalkorValue::I64(2)
+            ])),
+            "[1, 2]"
+        );
+        let mut map = HashMap::new();
+        map.insert("k".to_string(), FalkorValue::I64(9));
+        assert_eq!(enc(FalkorValue::Map(map)), "{k: 9}");
+        assert_eq!(
+            enc(FalkorValue::Point(Point {
+                latitude: 1.0,
+                longitude: 2.0
+            })),
+            "{latitude: 1.0, longitude: 2.0}"
+        );
+        assert_eq!(
+            enc(FalkorValue::Vec32(Vec32 { values: vec![1.0] })),
+            "[1.0]"
+        );
+    }
+
+    #[test]
+    fn test_encode_falkor_value_edge_and_unparseable_error() {
+        use crate::value::graph_entities::Edge;
+        assert!(to_cypher_param(&FalkorValue::Edge(Edge::default())).is_err());
+        assert!(to_cypher_param(&FalkorValue::Unparseable("boom".to_string())).is_err());
+    }
+
+    fn preamble_of(params: FalkorParams) -> String {
+        let mut out = String::new();
+        params.encode_preamble(&mut out).expect("should encode");
+        out
+    }
+
+    #[test]
+    fn test_into_falkor_params_impls() {
+        assert_eq!(
+            preamble_of(vec![("a", 1i64), ("b", 2i64)].into_falkor_params()),
+            "CYPHER a=1 b=2 "
+        );
+        assert_eq!(
+            preamble_of([("a", 1i64)].into_falkor_params()),
+            "CYPHER a=1 "
+        );
+        assert_eq!(
+            preamble_of(BTreeMap::from([("a", 1i64)]).into_falkor_params()),
+            "CYPHER a=1 "
+        );
+        assert_eq!(
+            preamble_of(HashMap::from([("a", 1i64)]).into_falkor_params()),
+            "CYPHER a=1 "
+        );
+        assert!(().into_falkor_params().is_empty());
+        let mut identity = FalkorParams::new();
+        identity.add_param("a", 1i64);
+        assert!(!identity.into_falkor_params().is_empty());
+    }
+
+    #[test]
+    fn test_params_add_raw_and_merge() {
+        let mut raw = FalkorParams::new();
+        raw.add_raw("expr", "point({latitude: 1, longitude: 2})".to_string());
+        assert_eq!(
+            preamble_of(raw),
+            "CYPHER expr=point({latitude: 1, longitude: 2}) "
+        );
+
+        let mut base = FalkorParams::new();
+        base.add_param("a", 1i64);
+        let mut extra = FalkorParams::new();
+        extra.add_param("a", 9i64); // overrides on merge
+        extra.add_param("b", 2i64);
+        base.merge(extra);
+        assert_eq!(preamble_of(base), "CYPHER a=9 b=2 ");
+    }
+
+    #[test]
+    fn test_add_raw_validates_name() {
+        let mut params = FalkorParams::new();
+        params.add_raw("bad name", "1".to_string());
+        assert!(params.first_error().is_some());
+    }
 }

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -170,6 +170,11 @@ fn encode_map_key(
             "map parameter key contains a backtick, which FalkorDB cannot encode",
         ));
     }
+    if key.contains('\0') {
+        return Err(param_err(
+            "map parameter key contains a NUL byte, which FalkorDB cannot encode",
+        ));
+    }
     if is_bare_identifier(key) {
         out.push_str(key);
     } else {
@@ -1004,5 +1009,60 @@ mod tests {
         let mut params = FalkorParams::new();
         params.add_raw("bad name", "1".to_string());
         assert!(params.first_error().is_some());
+    }
+
+    #[test]
+    fn test_encode_map_key_nul_is_error() {
+        let mut map = BTreeMap::new();
+        map.insert("a\0b", 1i64);
+        assert!(to_cypher_param(&map).is_err());
+    }
+
+    #[test]
+    fn test_encode_f32_uses_shortest_form() {
+        // f32 is encoded as its shortest round-trippable decimal (matching serde_json), so
+        // `0.1f32` becomes `0.1` rather than the widened `0.10000000149...`.
+        assert_eq!(enc(0.1f32), "0.1");
+        assert_eq!(enc(2.0f32), "2.0");
+    }
+
+    #[test]
+    fn test_encode_map_keyword_keys_stay_bare() {
+        // Cypher keywords are valid bare map keys (verified against the server).
+        let mut map = BTreeMap::new();
+        map.insert("match", 2i64);
+        map.insert("true", 1i64);
+        assert_eq!(enc(map), "{match: 2, true: 1}");
+    }
+
+    #[test]
+    fn test_nested_nul_propagates_error() {
+        assert!(to_cypher_param(&vec!["ok", "a\0b"]).is_err());
+        assert!(to_cypher_param(&("ok", "a\0b")).is_err());
+        let mut map = BTreeMap::new();
+        map.insert("k", "a\0b");
+        assert!(to_cypher_param(&map).is_err());
+        let array = FalkorValue::Array(vec![FalkorValue::String("a\0b".to_string())]);
+        assert!(to_cypher_param(&array).is_err());
+    }
+
+    #[test]
+    fn test_nested_non_finite_float_propagates_error() {
+        assert!(to_cypher_param(&vec![1.0f64, f64::NAN]).is_err());
+        let mut map = BTreeMap::new();
+        map.insert("k", f64::INFINITY);
+        assert!(to_cypher_param(&map).is_err());
+    }
+
+    #[test]
+    fn test_nested_error_carries_param_name() {
+        let mut params = FalkorParams::new();
+        params.add_param("coords", vec![1.0f64, f64::NAN]); // error nested inside a list
+        match params.first_error() {
+            Some(FalkorDBError::ParamEncoding { parameter, .. }) => {
+                assert_eq!(parameter.as_deref(), Some("coords"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/src/value/param_proptest.rs
+++ b/src/value/param_proptest.rs
@@ -1,0 +1,138 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Property-based tests for query-parameter encoding ([`to_cypher_param`]).
+//!
+//! These complement the golden unit tests in [`super::param`] with:
+//! - **no-panic robustness**: encoding an arbitrary [`FalkorValue`] (every variant, arbitrary
+//!   strings with control bytes/NUL, non-finite floats) always returns `Ok`/`Err`;
+//! - **lossless string escaping**: reversing the documented escapes reproduces the input;
+//! - **NUL rejection** and **float finiteness** invariants.
+
+use crate::value::graph_entities::{Edge, Node};
+use crate::value::path::Path;
+use crate::value::point::Point;
+use crate::value::vec32::Vec32;
+use crate::{to_cypher_param, FalkorValue};
+use proptest::collection::{hash_map, vec};
+use proptest::prelude::*;
+
+/// An arbitrary [`FalkorValue`] spanning every variant, with deliberately adversarial leaves
+/// (arbitrary strings incl. control bytes/NUL, non-finite floats) to stress the encoders.
+fn falkor_value_strategy() -> impl Strategy<Value = FalkorValue> {
+    let leaf = prop_oneof![
+        Just(FalkorValue::None),
+        any::<bool>().prop_map(FalkorValue::Bool),
+        any::<i64>().prop_map(FalkorValue::I64),
+        any::<f64>().prop_map(FalkorValue::F64),
+        ".*".prop_map(FalkorValue::String),
+        ".*".prop_map(FalkorValue::Unparseable),
+        vec(any::<f32>(), 0..5).prop_map(|values| FalkorValue::Vec32(Vec32 { values })),
+        (any::<f64>(), any::<f64>()).prop_map(|(latitude, longitude)| {
+            FalkorValue::Point(Point {
+                latitude,
+                longitude,
+            })
+        }),
+        Just(FalkorValue::Path(Path::default())),
+    ];
+    leaf.prop_recursive(4, 48, 5, |inner| {
+        prop_oneof![
+            vec(inner.clone(), 0..5).prop_map(FalkorValue::Array),
+            // Map keys are arbitrary strings, so non-identifier / backtick / empty / NUL keys
+            // are exercised.
+            hash_map(".*", inner.clone(), 0..5).prop_map(FalkorValue::Map),
+            (
+                any::<i64>(),
+                vec("[a-z]{1,6}", 0..3),
+                hash_map("[a-z]{1,6}", inner.clone(), 0..3),
+            )
+                .prop_map(|(entity_id, labels, properties)| {
+                    FalkorValue::Node(Node {
+                        entity_id,
+                        labels,
+                        properties,
+                    })
+                }),
+            (
+                any::<i64>(),
+                "[a-z]{1,6}",
+                any::<i64>(),
+                any::<i64>(),
+                hash_map("[a-z]{1,6}", inner, 0..3),
+            )
+                .prop_map(
+                    |(entity_id, relationship_type, src_node_id, dst_node_id, properties)| {
+                        FalkorValue::Edge(Edge {
+                            entity_id,
+                            relationship_type,
+                            src_node_id,
+                            dst_node_id,
+                            properties,
+                        })
+                    }
+                ),
+        ]
+    })
+}
+
+/// Reverse the documented Cypher string escaping, to check `encode_str` is lossless.
+fn unescape_cypher_string(encoded: &str) -> String {
+    let inner = &encoded[1..encoded.len() - 1]; // strip the surrounding single quotes
+    let mut out = String::new();
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('\'') => out.push('\''),
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some('t') => out.push('\t'),
+                Some('b') => out.push('\u{08}'),
+                Some('f') => out.push('\u{0C}'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+proptest! {
+    /// Encoding any value returns `Ok`/`Err` but never panics or aborts.
+    #[test]
+    fn prop_to_cypher_param_never_panics(value in falkor_value_strategy()) {
+        let _ = to_cypher_param(&value);
+    }
+
+    /// A string without a NUL byte encodes losslessly: reversing the escaping yields the input,
+    /// and the result is a single-quoted literal.
+    #[test]
+    fn prop_string_escaping_is_lossless(s in "(?s).*") {
+        prop_assume!(!s.contains('\0'));
+        let encoded = to_cypher_param(&s).expect("non-NUL strings always encode");
+        prop_assert!(encoded.starts_with('\'') && encoded.ends_with('\''));
+        prop_assert_eq!(unescape_cypher_string(&encoded), s);
+    }
+
+    /// A string containing a NUL byte cannot be encoded.
+    #[test]
+    fn prop_nul_string_is_rejected(prefix in "(?s).*", suffix in "(?s).*") {
+        let s = format!("{prefix}\0{suffix}");
+        prop_assert!(to_cypher_param(&s).is_err());
+    }
+
+    /// A float encodes if and only if it is finite.
+    #[test]
+    fn prop_float_finiteness(f in any::<f64>()) {
+        prop_assert_eq!(to_cypher_param(&f).is_ok(), f.is_finite());
+    }
+}

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -30,7 +30,6 @@
 
 #![cfg(feature = "embedded")]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -123,10 +122,9 @@ fn test_embedded_sync_full_surface() {
         .expect("write query should succeed");
 
     // Parameterized read.
-    let params = HashMap::from([("min_age".to_string(), "35".to_string())]);
     let mut res = graph
         .query("MATCH (p:Person) WHERE p.age >= $min_age RETURN p.age")
-        .with_params(&params)
+        .with_param("min_age", 35)
         .execute()
         .expect("parameterized query should succeed");
     let ages: Vec<i64> = res
@@ -223,10 +221,9 @@ mod async_flavours {
                 .await
                 .expect("write query should succeed");
 
-            let params = HashMap::from([("threshold".to_string(), "5".to_string())]);
             let mut res = graph
                 .query("MATCH (n:N) WHERE n.v > $threshold RETURN count(n)")
-                .with_params(&params)
+                .with_param("threshold", 5)
                 .execute()
                 .await
                 .expect("parameterized query should succeed");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -444,6 +444,44 @@ mod typed_params {
         assert_eq!(value, Some(7));
         let _ = graph.delete();
     }
+
+    #[test]
+    fn test_with_param_last_wins_and_clears_error() {
+        let Some(mut graph) = graph_for("test_params_lastwins") else {
+            return;
+        };
+        // The last value for a key wins, and a later valid value clears an earlier encoding
+        // error for the same key.
+        let mut result = graph
+            .query("RETURN $x")
+            .with_param("x", f64::NAN) // would error
+            .with_param("x", 7i64) // overrides → valid
+            .execute()
+            .expect("the override should clear the earlier error");
+        let value = result
+            .data
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .and_then(|v| v.to_i64());
+        assert_eq!(value, Some(7));
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_with_params_invalid_value_fails_at_execute() {
+        let Some(mut graph) = graph_for("test_params_invalid_collection") else {
+            return;
+        };
+        let result = graph
+            .query("RETURN $x")
+            .with_params([("x", f64::NAN)])
+            .execute();
+        assert!(matches!(
+            result,
+            Err(falkordb::FalkorDBError::ParamEncoding { .. })
+        ));
+        let _ = graph.delete();
+    }
 }
 
 #[cfg(feature = "tokio")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -376,6 +376,74 @@ mod typed_params {
         );
         let _ = graph.delete();
     }
+
+    #[test]
+    fn test_with_params_collection() {
+        let Some(mut graph) = graph_for("test_params_collection") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN $a + $b")
+            .with_params([("a", 10i64), ("b", 32i64)])
+            .execute()
+            .expect("query should succeed");
+        let value = result
+            .data
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .and_then(|v| v.to_i64());
+        assert_eq!(value, Some(42));
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_with_raw_param() {
+        let Some(mut graph) = graph_for("test_params_raw") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN $v")
+            .with_raw_param("v", "[1, 2, 3]")
+            .execute()
+            .expect("query should succeed");
+        let row = result.data.next().expect("expected a row");
+        assert_eq!(
+            row.into_iter().next(),
+            Some(FalkorValue::Array(vec![
+                FalkorValue::I64(1),
+                FalkorValue::I64(2),
+                FalkorValue::I64(3),
+            ]))
+        );
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_try_with_param() {
+        let Some(mut graph) = graph_for("test_params_try") else {
+            return;
+        };
+        // A non-finite float fails eagerly, before building the query.
+        assert!(graph
+            .query("RETURN $x")
+            .try_with_param("x", f64::NAN)
+            .is_err());
+
+        // A valid value succeeds and executes.
+        let mut result = graph
+            .query("RETURN $x")
+            .try_with_param("x", 7i64)
+            .expect("valid param should be accepted")
+            .execute()
+            .expect("query should succeed");
+        let value = result
+            .data
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .and_then(|v| v.to_i64());
+        assert_eq!(value, Some(7));
+        let _ = graph.delete();
+    }
 }
 
 #[cfg(feature = "tokio")]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -246,6 +246,138 @@ fn test_list_graphs() {
     let _ = graph.delete();
 }
 
+mod typed_params {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{FalkorClientBuilder, FalkorValue};
+    use std::collections::BTreeMap;
+
+    fn graph_for(name: &str) -> Option<falkordb::SyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete();
+        Some(graph)
+    }
+
+    #[test]
+    fn test_with_param_scalars_round_trip() {
+        let Some(mut graph) = graph_for("test_params_scalars") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN $s, $i, $f, $b, $n")
+            .with_param("s", "it's a \"test\"")
+            .with_param("i", 42i64)
+            .with_param("f", 2.5f64)
+            .with_param("b", true)
+            .with_param("n", Option::<i64>::None)
+            .execute()
+            .expect("query should succeed");
+        let row = result.data.next().expect("expected a row");
+        assert_eq!(
+            row,
+            vec![
+                FalkorValue::String("it's a \"test\"".to_string()),
+                FalkorValue::I64(42),
+                FalkorValue::F64(2.5),
+                FalkorValue::Bool(true),
+                FalkorValue::None,
+            ]
+        );
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_with_param_injection_is_inert() {
+        let Some(mut graph) = graph_for("test_params_injection") else {
+            return;
+        };
+        let payload = "'; MATCH (n) DETACH DELETE n //";
+        graph
+            .query("CREATE (:Tag {name: $name})")
+            .with_param("name", payload)
+            .execute()
+            .expect("create should succeed");
+
+        // The payload must be stored verbatim, and nothing should have been deleted/executed.
+        let mut result = graph
+            .query("MATCH (t:Tag) RETURN t.name")
+            .execute()
+            .expect("read should succeed");
+        let row = result.data.next().expect("the node must still exist");
+        assert_eq!(
+            row.into_iter().next(),
+            Some(FalkorValue::String(payload.to_string()))
+        );
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_with_param_list_in_clause() {
+        let Some(mut graph) = graph_for("test_params_list") else {
+            return;
+        };
+        graph
+            .query("UNWIND [1, 2, 3, 4] AS v CREATE (:N {v: v})")
+            .execute()
+            .expect("create should succeed");
+        let mut result = graph
+            .query("MATCH (n:N) WHERE n.v IN $vals RETURN count(n)")
+            .with_param("vals", [2, 4])
+            .execute()
+            .expect("query should succeed");
+        let count = result
+            .data
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .and_then(|v| v.to_i64());
+        assert_eq!(count, Some(2));
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_with_param_map_and_point_workaround() {
+        let Some(mut graph) = graph_for("test_params_point") else {
+            return;
+        };
+        let coords = BTreeMap::from([("latitude", 32.07), ("longitude", 34.79)]);
+        let mut result = graph
+            .query("RETURN point($p)")
+            .with_param("p", coords)
+            .execute()
+            .expect("point($p) workaround should succeed");
+        let value = result
+            .data
+            .next()
+            .and_then(|row| row.into_iter().next())
+            .expect("expected a point");
+        assert!(matches!(value, FalkorValue::Point(_)));
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_invalid_param_name_errors_before_network() {
+        let Some(mut graph) = graph_for("test_params_bad_name") else {
+            return;
+        };
+        let result = graph
+            .query("RETURN $x")
+            .with_param("bad name", 1i64)
+            .execute();
+        assert!(
+            matches!(result, Err(falkordb::FalkorDBError::ParamEncoding { .. })),
+            "an invalid parameter name must fail with ParamEncoding"
+        );
+        let _ = graph.delete();
+    }
+}
+
 #[cfg(feature = "tokio")]
 mod async_tests {
     use super::*;

--- a/tests/multiplexing_parity.rs
+++ b/tests/multiplexing_parity.rs
@@ -124,10 +124,9 @@ async fn test_core_operations_under_all_strategies() {
             .expect("write query should succeed");
 
         // Parameterized read.
-        let params = std::collections::HashMap::from([("min_age".to_string(), "35".to_string())]);
         let mut res = graph
             .query("MATCH (p:Person) WHERE p.age >= $min_age RETURN p.age")
-            .with_params(&params)
+            .with_param("min_age", 35)
             .execute()
             .await
             .expect("parameterized query should succeed");


### PR DESCRIPTION
Implements **Idea 2 (type-safe, injection-proof query parameters)** from `next-steps.md`, replacing the error-prone `with_params(&HashMap<String, String>)` (which forced callers to hand-quote/escape values) with a typed API that encodes Rust values into escaped Cypher literals.

### After
```rust
graph.query("MATCH (m:Movie {title: $title, year: $year}) RETURN m")
    .with_param("title", "The Matrix")
    .with_param("year", 1999)
    .execute()?;
```

### What's included
- Sealed `IntoFalkorParam` / `IntoFalkorParams` traits + `to_cypher_param` helper. Encodes integers, floats, booleans, strings, `Option`, arrays/`Vec`, string-keyed maps, `Point`/`Vec32`, and `FalkorValue` as escaped Cypher literals. Fallible for values with no representation (non-finite floats, NUL strings, out-of-`i64` integers, graph entities).
- `QueryBuilder::with_param`, `try_with_param`, `with_params`, and the raw escape hatch `with_raw_param` (+ `RawParam`).
- **Parameter-name validation** (Cypher identifier) — closes a name-injection hole, not just value injection.
- `FalkorDBError::ParamEncoding { parameter, message }`; errors surface at `execute()` with the offending name.
- Procedure-call arguments routed through the same safe encoding.

### Grounded in verified FalkorDB behaviour
Validated against `falkordb:edge`: adversarial strings are inert, but `point(...)`/`vecf32(...)` cannot be bound as parameters (function calls are rejected) — so points/vectors encode to a map/list and you wrap them with `point($p)`/`vecf32($v)`. `\uXXXX` is not interpreted and NUL bytes are rejected, so string escaping uses only `\\ \' \n \r \t \b \f` + raw UTF-8.

### Design and review
A detailed design was prepared and passed through a rubber-duck review, which caught the parameter-name injection, the silent `HashMap<String, String>` semantic break (now a deliberate compile break + migration), lossy errors, duplicate-key handling, and the `FalkorValue` non-literal variants.

### Breaking change (targets 0.6.0)
`with_params` no longer takes `&HashMap<String, String>` of raw values; pass typed values, or `with_raw_param` for raw Cypher. String values are now encoded as quoted Cypher strings. See the CHANGELOG migration note.

### Testing
Golden unit tests (incl. adversarial/injection, NaN/NUL/overflow, name validation, dedup), server-backed integration tests (injection-is-inert verified, `WHERE x IN $list`, the `point($p)` workaround), a runnable `to_cypher_param` doc test, and `examples/typed_params.rs`. `clippy --all-targets`, `fmt`, `doc`, `deny` all green.
