### PR TITLE
feat!: header-aware Row API with fallible result iteration

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -139,3 +139,7 @@ WaitOptions
 ConstraintFailed
 Ok
 NUL
+accessors
+param
+BTreeMap
+coords

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `IntoFalkorParams` traits and the `to_cypher_param` helper. Values (integers, floats, boolean
   values, strings, `Option`, arrays/`Vec`, string-keyed maps, `Point`/`Vec32`, `FalkorValue`) are
   encoded as escaped Cypher literals, and parameter names are validated.
+- header-aware result rows: the default `QueryResult::data` now yields `FalkorResult<Row>`, where
+  a `Row` pairs the result header with that row's values. Columns can be read by name or index,
+  untyped (`get`, `get_at`, `get_all`) or typed (`try_get::<T>`, `try_get_at::<T>`), plus
+  `columns`, `len`, `is_empty`, `into_values`, `into_map`, and (with `serde`)
+  `Row::deserialize::<T>`. Duplicate column aliases are handled explicitly (first-match `get`,
+  every-match `get_all`, last-wins `into_map`).
+- `FromFalkorValue`: a trait for strict, fallible conversion of a `FalkorValue` into a Rust type
+  (scalars, graph entities, `Option<T>`, `Vec<T>`, `HashMap<String, T>`); the bound behind
+  `Row::try_get`. Conversions never coerce silently; the one lossless widening allowed is
+  `i64` → `f64` within `±2^53`.
+- `LazyResultSet::into_values_lossy`: opt-in escape hatch that reproduces the pre-0.7
+  `Iterator<Item = Vec<FalkorValue>>` behavior.
+- new `FalkorDBError` variants: `MissingColumn`, `ColumnIndexOutOfBounds`, `RowShapeMismatch`,
+  and `TypeError`.
 
 ### Changed
 
@@ -23,6 +37,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   escaped); numbers that used to be passed as strings (`"30"`) should be passed as numbers (`30`),
   and any value that was a raw Cypher expression should use `with_raw_param`. Procedure-call
   arguments are likewise encoded safely.
+- **Not backward compatible:** the default result iterator (`QueryResult::data`, i.e.
+  `LazyResultSet`) now yields `FalkorResult<Row>` instead of `Vec<FalkorValue>`. A row that fails
+  to parse is surfaced as an `Err` (which you can `?` or `collect::<FalkorResult<Vec<Row>>>()`)
+  rather than being silently swallowed into a `[FalkorValue::Unparseable]` row. `QueryResult::header`
+  is now `Arc<[String]>` (was `Vec<String>`), shared cheaply with every `Row`. Migration:
+
+  | Before (≤ 0.6) | After (0.7) |
+  | --- | --- |
+  | `for row in result.data { /* row: Vec<FalkorValue> */ }` | `for row in result.data { let row = row?; /* row: Row */ }` |
+  | `&row[i]` / `row.into_iter()` | `row.get_at(i)` / `row.into_values()` |
+  | align columns by header index by hand | `row.try_get::<T>("alias")` |
+  | a silently swallowed `Unparseable` row | a real `Err` you `?` or handle |
+  | the old lossy `Vec<FalkorValue>` rows | `result.data.into_values_lossy()` |
+  | `result.header: Vec<String>` | `result.header: Arc<[String]>` (`&result.header[..]` still works) |
 
 ## [0.5.0](https://github.com/FalkorDB/falkordb-rs/compare/v0.4.0...v0.5.0) - 2026-06-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,6 @@ required-features = ["serde"]
 
 [[example]]
 name = "typed_params"
+
+[[example]]
+name = "rows"

--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ access is **strict** — no silent lossy casts — via the [`FromFalkorValue`] c
 `collect` short-circuits on the first `Err`, a whole result set can be gathered with
 `result.data.collect::<falkordb::FalkorResult<Vec<_>>>()`.
 
-Duplicate column aliases (`RETURN a AS x, b AS x`) are handled explicitly: `get`/`try_get` return
-the first match, `get_all` returns every match, and `into_map` keeps the last. To opt back into the
-pre-0.7 behavior (bare `Vec<FalkorValue>` rows, parse errors collapsed to
+FalkorDB rejects a query whose result columns are not uniquely named, so rows from a query always
+have distinct columns; if a `Row` ever does hold duplicates, the access paths are still defined
+(`get`/`try_get` return the first match, `get_all` returns every match, `into_map` keeps the last).
+To opt back into the pre-0.7 behavior (bare `Vec<FalkorValue>` rows, parse errors collapsed to
 `FalkorValue::Unparseable`), call `result.data.into_values_lossy()`. A runnable version lives in
 [`examples/rows.rs`](examples/rows.rs). Upgrading from 0.6? See the
 [0.7 migration guide](docs/migrating-to-0.7.md).

--- a/README.md
+++ b/README.md
@@ -55,13 +55,57 @@ let mut nodes = graph.query("UNWIND range(0, 100) AS i CREATE (n { v:1 }) RETURN
             .execute()
             .expect("Failed executing query");
 
-// Can also be collected, like any other iterator
-while let Some(node) = nodes.data.next() {
-   println ! ("{:?}", node);
+// Each item is a `FalkorResult<Row>`; read columns by index or name.
+while let Some(row) = nodes.data.next() {
+   let row = row.expect("row failed to parse");
+   println!("{:?}", row.get_at(0));
 }
 ```
 
 ## Features
+
+### Header-aware result rows
+
+`QueryResult::data` iterates the result set as `FalkorResult<Row>`. Each `Row` pairs the query
+header (the column aliases) with that row's values, so you read columns by **name or index** and a
+row that fails to parse surfaces as an `Err` instead of being silently swallowed:
+
+```rust,no_run
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo};
+
+let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()
+    .expect("Invalid connection info");
+let client = FalkorClientBuilder::new()
+    .with_connection_info(connection_info)
+    .build()
+    .expect("Failed to build client");
+let mut graph = client.select_graph("imdb");
+
+let mut result = graph
+    .query("MATCH (m:Movie) RETURN m.title AS title, m.year AS year")
+    .execute()
+    .expect("Failed executing query");
+
+for row in result.data.by_ref() {
+    let row = row.expect("row failed to parse");
+    // Read a column by alias and convert it in one step (strictly, via `FromFalkorValue`).
+    let title: String = row.try_get("title").expect("title column");
+    let year: i64 = row.try_get("year").expect("year column");
+    println!("{title} ({year})");
+}
+```
+
+`Row` offers borrowing accessors (`get`, `get_at`, `get_all`), typed accessors
+(`try_get::<T>`, `try_get_at::<T>`), and consuming conversions (`into_values`, `into_map`). Typed
+access is **strict** — no silent lossy casts — via the [`FromFalkorValue`] conversion trait. Because
+`collect` short-circuits on the first `Err`, a whole result set can be gathered with
+`result.data.collect::<falkordb::FalkorResult<Vec<_>>>()`.
+
+Duplicate column aliases (`RETURN a AS x, b AS x`) are handled explicitly: `get`/`try_get` return
+the first match, `get_all` returns every match, and `into_map` keeps the last. To opt back into the
+pre-0.7 behavior (bare `Vec<FalkorValue>` rows, parse errors collapsed to
+`FalkorValue::Unparseable`), call `result.data.into_values_lossy()`. A runnable version lives in
+[`examples/rows.rs`](examples/rows.rs).
 
 ### Type-safe query parameters
 
@@ -213,8 +257,9 @@ let mut nodes = graph.query("UNWIND range(0, 100) AS i CREATE (n { v:1 }) RETURN
             .expect("Failed executing query");
 
 // Graph operations are asynchronous, but parsing is still concurrent:
-while let Some(node) = nodes.data.next() {
-     println ! ("{:?}", node);
+while let Some(row) = nodes.data.next() {
+     let row = row.expect("row failed to parse");
+     println!("{:?}", row.get_at(0));
 }
 ```
 
@@ -422,6 +467,7 @@ let mut graph = client.select_graph("imdb");
 let mut result = graph.query("MATCH (m:Movie) RETURN m").execute()
     .expect("Failed executing query");
 for row in result.data.by_ref() {
+    let row = row.expect("row failed to parse");
     if let Some(node) = row.into_iter().next() {
         let movie: Movie = node.deserialize_into().expect("Failed to map node");
         println!("{} ({})", movie.title, movie.year);

--- a/docs/migrating-to-0.7.md
+++ b/docs/migrating-to-0.7.md
@@ -169,10 +169,11 @@ can also deserialize a single row on demand with `row.deserialize::<T>()`.
 
 ## Duplicate column names
 
-The server rejects a query that returns two columns with the same name, so in practice a `Row` has
-unique columns. The API still defines the behavior for completeness: `get` / `try_get` return the
-**first** match, `get_all` returns **every** match, and `into_map` keeps the **last**. Prefer
-distinct aliases.
+FalkorDB rejects a query whose result columns are not uniquely named, so a `Row` returned from a
+query always has distinct columns. The API still defines the behavior for the case where a `Row`
+holds duplicates anyway (for example one built by hand from `(column, value)` pairs): `get` /
+`try_get` return the **first** match, `get_all` returns **every** match, and `into_map` keeps the
+**last**.
 
 ## Coming from 0.6 or earlier
 

--- a/examples/multiplexed_async.rs
+++ b/examples/multiplexed_async.rs
@@ -10,7 +10,7 @@
 //! Run a FalkorDB instance first (e.g. `docker run -p 6379:6379 falkordb/falkordb`), then
 //! `cargo run --example multiplexed_async --features tokio`.
 
-use falkordb::{ConnectionStrategy, FalkorClientBuilder, FalkorResult, FalkorValue};
+use falkordb::{ConnectionStrategy, FalkorClientBuilder, FalkorResult};
 use std::num::NonZeroU8;
 use std::sync::Arc;
 use tokio::task::JoinSet;
@@ -48,7 +48,7 @@ async fn main() -> FalkorResult<()> {
             let value = res
                 .data
                 .next()
-                .and_then(|row| row.first().and_then(FalkorValue::to_i64));
+                .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()));
             FalkorResult::Ok((i, value))
         });
     }

--- a/examples/rows.rs
+++ b/examples/rows.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Header-aware result rows: reading columns by name or index, with strict typed access.
+//!
+//! Run with: `cargo run --example rows`
+//!
+//! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
+
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorValue};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()?;
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info)
+        .build()?;
+
+    let mut graph = client.select_graph("rows_example");
+
+    // Start from a clean slate so the example is idempotent across runs.
+    let _ = graph.delete();
+
+    graph
+        .query(
+            "CREATE (:Movie {title: 'The Matrix', year: 1999, rating: 8.7}),
+                    (:Movie {title: 'Heat', year: 1995, rating: 8.3})",
+        )
+        .execute()?;
+
+    // ── Read columns by alias, converted to the type you ask for ────────────
+    let mut result = graph
+        .query(
+            "MATCH (m:Movie)
+             RETURN m.title AS title, m.year AS year, m.rating AS rating
+             ORDER BY m.year",
+        )
+        .execute()?;
+
+    // `data` yields `FalkorResult<Row>`, so a row that fails to parse is a real `Err` you can `?`.
+    for row in result.data.by_ref() {
+        let row = row?;
+        let title: String = row.try_get("title")?;
+        let year: i64 = row.try_get("year")?;
+        let rating: f64 = row.try_get("rating")?;
+        println!("{title} ({year}) — rated {rating}");
+    }
+
+    // ── Read by index, and borrow the raw value without converting ──────────
+    let mut counted = graph.query("MATCH (m:Movie) RETURN count(m)").execute()?;
+    if let Some(row) = counted.data.next() {
+        let row = row?;
+        let count: i64 = row.try_get_at(0)?;
+        println!("movies: {count}");
+        // `get_at` borrows the underlying `FalkorValue` without converting or cloning.
+        assert_eq!(row.get_at(0), Some(&FalkorValue::I64(count)));
+    }
+
+    // ── Collect a whole result set; `collect` short-circuits on the first error ──
+    let titles: Vec<String> = graph
+        .query("MATCH (m:Movie) RETURN m.title AS title ORDER BY m.title")
+        .execute()?
+        .data
+        .map(|row| row?.try_get::<String>("title"))
+        .collect::<Result<_, _>>()?;
+    println!("titles: {titles:?}");
+
+    // ── Turn a row into a column -> value map ───────────────────────────────
+    let mut as_map = graph
+        .query("MATCH (m:Movie) RETURN m.title AS title, m.year AS year ORDER BY m.year LIMIT 1")
+        .execute()?;
+    if let Some(row) = as_map.data.next() {
+        let map = row?.into_map();
+        println!("oldest movie as a map: {map:?}");
+    }
+
+    graph.delete()?;
+    Ok(())
+}

--- a/examples/typed_mapping.rs
+++ b/examples/typed_mapping.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // With the `serde` feature, deserialize a single returned value into a struct:
     let mut result = graph.query("MATCH (m:Movie) RETURN m").execute()?;
     for row in result.data.by_ref() {
-        if let Some(node) = row.into_iter().next() {
+        if let Some(node) = row?.into_iter().next() {
             let movie: Movie = node.deserialize_into()?;
             println!(
                 "value:   {} ({}) rating={:?}",

--- a/examples/typed_params.rs
+++ b/examples/typed_params.rs
@@ -9,7 +9,7 @@
 //!
 //! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
 
-use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorValue};
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo};
 use std::collections::BTreeMap;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -46,13 +46,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Collections work too: `WHERE x IN $list`.
     let mut titles = graph
-        .query("MATCH (m:Movie) WHERE m.year IN $years RETURN m.title ORDER BY m.year")
+        .query("MATCH (m:Movie) WHERE m.year IN $years RETURN m.title AS title ORDER BY m.year")
         .with_param("years", [1999, 2003])
         .execute()?;
     for row in titles.data.by_ref() {
-        if let Some(FalkorValue::String(title)) = row.into_iter().next() {
-            println!("matched: {title}");
-        }
+        // Read the column by its alias and convert it in one step.
+        let title: String = row?.try_get("title")?;
+        println!("matched: {title}");
     }
 
     // Points can't be bound directly — pass the components as a map and wrap with `point()`.
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_param("p", coords)
         .execute()?;
     if let Some(row) = located.data.next() {
-        println!("point: {:?}", row.into_iter().next());
+        println!("point: {:?}", row?.get_at(0));
     }
 
     graph.delete()?;

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -654,9 +654,10 @@ mod tests {
             .query("MATCH (p:Document) RETURN p")
             .execute()
             .expect("Could not get document");
-        for falkor_value in res.data.by_ref() {
+        for row in res.data.by_ref() {
+            let row = row.expect("row should parse into a Row");
             // iterate on a node value
-            for value in falkor_value {
+            for value in row {
                 if let Node(node) = value {
                     if let FalkorValue::Vec32(embedding) = &node.properties["embedding"] {
                         assert_eq!(embedding.values.len(), 3);

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -164,6 +164,36 @@ pub enum FalkorDBError {
         /// A human-readable description of why encoding failed.
         message: String,
     },
+    /// A result row did not contain a column with the requested name.
+    #[error("result row has no column named '{name}'")]
+    MissingColumn {
+        /// The requested column name.
+        name: String,
+    },
+    /// A result row was indexed past its number of columns.
+    #[error("column index {index} is out of bounds for a row with {len} column(s)")]
+    ColumnIndexOutOfBounds {
+        /// The requested column index.
+        index: usize,
+        /// The number of columns in the row.
+        len: usize,
+    },
+    /// A result row's value count did not match the result header's column count.
+    #[error("result row shape mismatch: header has {header_len} column(s) but the row has {value_len} value(s)")]
+    RowShapeMismatch {
+        /// The number of columns in the header.
+        header_len: usize,
+        /// The number of values in the row.
+        value_len: usize,
+    },
+    /// A [`crate::FalkorValue`] could not be converted into the requested Rust type.
+    #[error("expected a value of type {expected}, but got {got}")]
+    TypeError {
+        /// The Rust type that was requested.
+        expected: &'static str,
+        /// The [`crate::FalkorValue`] variant that was found.
+        got: &'static str,
+    },
 }
 
 #[cfg(feature = "serde")]

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -5,10 +5,11 @@
 
 use crate::{
     graph::HasGraphSchema,
-    parser::{redis_value_as_vec, SchemaParsable},
+    parser::{parse_header, redis_value_as_vec, SchemaParsable},
     Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult,
     IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, SyncGraph,
 };
+use std::sync::Arc;
 use std::{
     fmt::{Display, Write},
     marker::PhantomData,
@@ -154,11 +155,13 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
                     ),
                 )?;
 
-                QueryResult::from_response(
-                    None,
-                    LazyResultSet::new(Default::default(), self.graph.get_graph_schema_mut()),
-                    stats,
-                )
+                let header: Arc<[String]> = Vec::new().into();
+                let data = LazyResultSet::new(
+                    Arc::clone(&header),
+                    Default::default(),
+                    self.graph.get_graph_schema_mut(),
+                );
+                QueryResult::from_response(header, data, stats)
             }
             2 => {
                 let [header, stats]: [redis::Value; 2] = res.try_into().map_err(|_| {
@@ -167,11 +170,13 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
                     )
                 })?;
 
-                QueryResult::from_response(
-                    Some(header),
-                    LazyResultSet::new(Default::default(), self.graph.get_graph_schema_mut()),
-                    stats,
-                )
+                let header: Arc<[String]> = parse_header(header)?.into();
+                let data = LazyResultSet::new(
+                    Arc::clone(&header),
+                    Default::default(),
+                    self.graph.get_graph_schema_mut(),
+                );
+                QueryResult::from_response(header, data, stats)
             }
             3 => {
                 let [header, data, stats]: [redis::Value; 3] = res.try_into().map_err(|_| {
@@ -180,14 +185,14 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
                     )
                 })?;
 
-                QueryResult::from_response(
-                    Some(header),
-                    LazyResultSet::new(
-                        redis_value_as_vec(data)?,
-                        self.graph.get_graph_schema_mut(),
-                    ),
-                    stats,
-                )
+                let header: Arc<[String]> = parse_header(header)?.into();
+                let rows = redis_value_as_vec(data)?;
+                let data = LazyResultSet::new(
+                    Arc::clone(&header),
+                    rows,
+                    self.graph.get_graph_schema_mut(),
+                );
+                QueryResult::from_response(header, data, stats)
             }
             _ => Err(FalkorDBError::ParsingArrayToStructElementCount(
                 "Invalid number of elements returned from query",
@@ -493,8 +498,9 @@ impl<'a, Out, G: HasGraphSchema> ProcedureQueryBuilder<'a, Out, G> {
                 })
             })?;
 
+        let header: Arc<[String]> = parse_header(header)?.into();
         QueryResult::from_response(
-            Some(header),
+            header,
             redis_value_as_vec(indices).map(|indices| {
                 indices
                     .into_iter()

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -45,7 +45,7 @@ fn dispatch_query_response<'g>(
                 res.into_iter()
                     .next()
                     .ok_or(FalkorDBError::ParsingArrayToStructElementCount(
-                        "One element exist but using next() failed",
+                        "One element exists but using next() failed",
                     ))?;
 
             build_lazy_query_result(Vec::new().into(), Vec::new(), stats, graph_schema)

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -6,7 +6,7 @@
 use crate::{
     graph::HasGraphSchema,
     parser::{parse_header, redis_value_as_vec, SchemaParsable},
-    Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult,
+    Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult, GraphSchema,
     IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, SyncGraph,
 };
 use std::sync::Arc;
@@ -20,6 +20,57 @@ use crate::AsyncGraph;
 
 #[cfg(feature = "serde")]
 use crate::TypedLazyResultSet;
+
+/// Builds a [`QueryResult`] over a [`LazyResultSet`] from an already-parsed header and the raw row
+/// values, sharing one `Arc` header with the result set.
+fn build_lazy_query_result<'g>(
+    header: Arc<[String]>,
+    rows: Vec<redis::Value>,
+    stats: redis::Value,
+    graph_schema: &'g mut GraphSchema,
+) -> FalkorResult<QueryResult<LazyResultSet<'g>>> {
+    let data = LazyResultSet::new(Arc::clone(&header), rows, graph_schema);
+    QueryResult::from_response(header, data, stats)
+}
+
+/// Turns the top-level query response array into a [`QueryResult`]: one element is stats only, two
+/// is a header with no rows, three is header + rows + stats. Any other length is malformed.
+fn dispatch_query_response<'g>(
+    res: Vec<redis::Value>,
+    graph_schema: &'g mut GraphSchema,
+) -> FalkorResult<QueryResult<LazyResultSet<'g>>> {
+    match res.len() {
+        1 => {
+            let stats =
+                res.into_iter()
+                    .next()
+                    .ok_or(FalkorDBError::ParsingArrayToStructElementCount(
+                        "One element exist but using next() failed",
+                    ))?;
+
+            build_lazy_query_result(Vec::new().into(), Vec::new(), stats, graph_schema)
+        }
+        2 => {
+            // The match arm guarantees the length, so the fixed-size conversion cannot fail.
+            let [header, stats]: [redis::Value; 2] =
+                res.try_into().expect("length checked to be exactly two");
+
+            let header: Arc<[String]> = parse_header(header)?.into();
+            build_lazy_query_result(header, Vec::new(), stats, graph_schema)
+        }
+        3 => {
+            let [header, data, stats]: [redis::Value; 3] =
+                res.try_into().expect("length checked to be exactly three");
+
+            let header: Arc<[String]> = parse_header(header)?.into();
+            let rows = redis_value_as_vec(data)?;
+            build_lazy_query_result(header, rows, stats, graph_schema)
+        }
+        _ => Err(FalkorDBError::ParsingArrayToStructElementCount(
+            "Invalid number of elements returned from query",
+        )),
+    }
+}
 
 #[cfg_attr(
     feature = "tracing",
@@ -146,58 +197,7 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
         }
 
         let res = redis_value_as_vec(value)?;
-
-        match res.len() {
-            1 => {
-                let stats = res.into_iter().next().ok_or(
-                    FalkorDBError::ParsingArrayToStructElementCount(
-                        "One element exist but using next() failed",
-                    ),
-                )?;
-
-                let header: Arc<[String]> = Vec::new().into();
-                let data = LazyResultSet::new(
-                    Arc::clone(&header),
-                    Default::default(),
-                    self.graph.get_graph_schema_mut(),
-                );
-                QueryResult::from_response(header, data, stats)
-            }
-            2 => {
-                let [header, stats]: [redis::Value; 2] = res.try_into().map_err(|_| {
-                    FalkorDBError::ParsingArrayToStructElementCount(
-                        "Two elements exist but couldn't be parsed to an array",
-                    )
-                })?;
-
-                let header: Arc<[String]> = parse_header(header)?.into();
-                let data = LazyResultSet::new(
-                    Arc::clone(&header),
-                    Default::default(),
-                    self.graph.get_graph_schema_mut(),
-                );
-                QueryResult::from_response(header, data, stats)
-            }
-            3 => {
-                let [header, data, stats]: [redis::Value; 3] = res.try_into().map_err(|_| {
-                    FalkorDBError::ParsingArrayToStructElementCount(
-                        "3 elements exist but couldn't be parsed to an array",
-                    )
-                })?;
-
-                let header: Arc<[String]> = parse_header(header)?.into();
-                let rows = redis_value_as_vec(data)?;
-                let data = LazyResultSet::new(
-                    Arc::clone(&header),
-                    rows,
-                    self.graph.get_graph_schema_mut(),
-                );
-                QueryResult::from_response(header, data, stats)
-            }
-            _ => Err(FalkorDBError::ParsingArrayToStructElementCount(
-                "Invalid number of elements returned from query",
-            ))?,
-        }
+        dispatch_query_response(res, self.graph.get_graph_schema_mut())
     }
 }
 
@@ -648,6 +648,54 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<Constraint>>, AsyncGraph> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+
+    /// A header `redis::Value` describing a single column named `name`.
+    fn header_with_one_column(name: &str) -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(1),
+            redis::Value::BulkString(name.as_bytes().to_vec()),
+        ])])
+    }
+
+    #[test]
+    fn dispatch_one_element_is_stats_only() {
+        let mut schema = GraphSchema::new("test_dispatch_one", create_empty_inner_sync_client());
+        let mut result =
+            dispatch_query_response(vec![redis::Value::Array(vec![])], &mut schema).unwrap();
+        assert!(result.header.is_empty());
+        assert!(result.data.next().is_none());
+    }
+
+    #[test]
+    fn dispatch_two_elements_is_header_without_rows() {
+        let mut schema = GraphSchema::new("test_dispatch_two", create_empty_inner_sync_client());
+        let res = vec![header_with_one_column("col"), redis::Value::Array(vec![])];
+        let mut result = dispatch_query_response(res, &mut schema).unwrap();
+        assert_eq!(result.header.len(), 1);
+        assert_eq!(result.header[0], "col");
+        assert!(result.data.next().is_none());
+    }
+
+    #[test]
+    fn dispatch_three_elements_has_header_and_rows() {
+        let mut schema = GraphSchema::new("test_dispatch_three", create_empty_inner_sync_client());
+        let res = vec![
+            header_with_one_column("col"),
+            redis::Value::Array(vec![]), // zero data rows
+            redis::Value::Array(vec![]), // stats
+        ];
+        let mut result = dispatch_query_response(res, &mut schema).unwrap();
+        assert_eq!(result.header.len(), 1);
+        assert_eq!(result.header[0], "col");
+        assert!(result.data.next().is_none());
+    }
+
+    #[test]
+    fn dispatch_invalid_length_is_error() {
+        let mut schema = GraphSchema::new("test_dispatch_bad", create_empty_inner_sync_client());
+        assert!(dispatch_query_response(vec![redis::Value::Nil; 4], &mut schema).is_err());
+    }
 
     #[test]
     fn test_generate_procedure_call_no_args_no_yields() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub use response::{
     execution_plan::ExecutionPlan,
     index::{FalkorIndex, IndexStatus, IndexType},
     lazy_result_set::LazyResultSet,
+    row::Row,
     slowlog_entry::SlowlogEntry,
     QueryResult,
 };
@@ -48,7 +49,8 @@ pub use value::{
     graph_entities::{Edge, EntityType, Node},
     path::Path,
     point::Point,
-    to_cypher_param, FalkorParams, FalkorValue, IntoFalkorParam, IntoFalkorParams, RawParam,
+    to_cypher_param, FalkorParams, FalkorValue, FromFalkorValue, IntoFalkorParam, IntoFalkorParams,
+    RawParam,
 };
 
 #[cfg(feature = "serde")]
@@ -138,8 +140,8 @@ pub(crate) mod test_utils {
         result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|value| value.to_i64())
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok())
             .expect("imdb actor count query returned an unexpected shape")
     }
 
@@ -166,8 +168,8 @@ pub(crate) mod test_utils {
         let count = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|value| value.to_i64())
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok())
             .expect("imdb actor count query returned an unexpected shape");
         assert!(count > 0, "{IMDB_FIXTURE_HINT}");
         client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,10 @@ pub(crate) mod test_utils {
         result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok())
-            .expect("imdb actor count query returned an unexpected shape")
+            .expect("imdb actor count query returned no rows")
+            .expect("imdb actor count row failed to parse")
+            .try_get_at::<i64>(0)
+            .expect("imdb actor count column was not an i64")
     }
 
     /// Create a sync client and assert the shared `imdb` fixture is populated, so every
@@ -168,9 +169,10 @@ pub(crate) mod test_utils {
         let count = result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok())
-            .expect("imdb actor count query returned an unexpected shape");
+            .expect("imdb actor count query returned no rows")
+            .expect("imdb actor count row failed to parse")
+            .try_get_at::<i64>(0)
+            .expect("imdb actor count column was not an i64");
         assert!(count > 0, "{IMDB_FIXTURE_HINT}");
         client
     }

--- a/src/response/lazy_result_set.rs
+++ b/src/response/lazy_result_set.rs
@@ -181,16 +181,13 @@ mod tests {
         let mut result_set =
             LazyResultSet::new(header, vec![node_row()], graph.get_graph_schema_mut());
 
-        match result_set.next() {
+        assert_eq!(
+            result_set.next(),
             Some(Err(FalkorDBError::RowShapeMismatch {
-                header_len,
-                value_len,
-            })) => {
-                assert_eq!(header_len, 2);
-                assert_eq!(value_len, 1);
-            }
-            other => panic!("expected RowShapeMismatch, got {other:?}"),
-        }
+                header_len: 2,
+                value_len: 1
+            }))
+        );
     }
 
     #[test]

--- a/src/response/lazy_result_set.rs
+++ b/src/response/lazy_result_set.rs
@@ -4,22 +4,29 @@
  */
 
 use crate::parser::ParserTypeMarker;
-use crate::{parser::parse_type, FalkorValue, GraphSchema};
+use crate::{parser::parse_type, FalkorDBError, FalkorResult, FalkorValue, GraphSchema, Row};
 use std::collections::VecDeque;
+use std::sync::Arc;
 
-/// A wrapper around the returned raw data, allowing parsing on demand of each result
-/// This implements Iterator, so can simply be collect()'ed into any desired container
+/// A wrapper around the returned raw data, parsing each row on demand into a header-aware [`Row`].
+///
+/// This implements [`Iterator`] with `Item = FalkorResult<Row>`, so a row that fails to parse
+/// surfaces as an [`Err`] (rather than being swallowed) and can be short-circuited with
+/// `collect::<FalkorResult<Vec<Row>>>()` or handled per row with `?`.
 pub struct LazyResultSet<'a> {
+    header: Arc<[String]>,
     data: VecDeque<redis::Value>,
     graph_schema: &'a mut GraphSchema,
 }
 
 impl<'a> LazyResultSet<'a> {
     pub(crate) fn new(
+        header: Arc<[String]>,
         data: Vec<redis::Value>,
         graph_schema: &'a mut GraphSchema,
     ) -> Self {
         Self {
+            header,
             data: data.into(),
             graph_schema,
         }
@@ -34,21 +41,47 @@ impl<'a> LazyResultSet<'a> {
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
+
+    /// Iterates the rows as bare `Vec<FalkorValue>`, reproducing the pre-0.7 behavior in which a
+    /// row that fails to parse is yielded as a single `[FalkorValue::Unparseable]` element instead
+    /// of surfacing the error.
+    ///
+    /// This is an opt-in escape hatch for code that cannot adopt the fallible, header-aware
+    /// iteration yet. Prefer the default `Iterator<Item = FalkorResult<Row>>`, which lets you `?`
+    /// real parse errors and read columns by name.
+    pub fn into_values_lossy(mut self) -> impl Iterator<Item = Vec<FalkorValue>> + 'a {
+        std::iter::from_fn(move || {
+            self.data.pop_front().map(|current_result| {
+                parse_type(ParserTypeMarker::Array, current_result, self.graph_schema)
+                    .and_then(FalkorValue::into_vec)
+                    .unwrap_or_else(|err| vec![FalkorValue::Unparseable(err.to_string())])
+            })
+        })
+    }
 }
 
 impl Iterator for LazyResultSet<'_> {
-    type Item = Vec<FalkorValue>;
+    type Item = FalkorResult<Row>;
 
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "Parse Next Result", skip_all)
     )]
     fn next(&mut self) -> Option<Self::Item> {
-        self.data.pop_front().map(|current_result| {
-            parse_type(ParserTypeMarker::Array, current_result, self.graph_schema)
-                .and_then(FalkorValue::into_vec)
-                .unwrap_or_else(|err| vec![FalkorValue::Unparseable(err.to_string())])
-        })
+        let current_result = self.data.pop_front()?;
+        let parsed = parse_type(ParserTypeMarker::Array, current_result, self.graph_schema)
+            .and_then(FalkorValue::into_vec);
+        Some(parsed.and_then(|values| {
+            // The server returns exactly one value per header column; a mismatch means a malformed
+            // result, so reject it loudly rather than silently zipping to the shorter length.
+            if values.len() != self.header.len() {
+                return Err(FalkorDBError::RowShapeMismatch {
+                    header_len: self.header.len(),
+                    value_len: values.len(),
+                });
+            }
+            Ok(Row::new(Arc::clone(&self.header), values))
+        }))
     }
 }
 
@@ -56,92 +89,119 @@ impl Iterator for LazyResultSet<'_> {
 mod tests {
     use crate::graph::HasGraphSchema;
     use crate::test_utils::imdb_test_client;
-    use crate::{Edge, FalkorValue, LazyResultSet, Node};
+    use crate::{Edge, FalkorDBError, FalkorResult, FalkorValue, LazyResultSet, Node, Row};
     use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn node_row() -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(8),
+            redis::Value::Array(vec![
+                redis::Value::Int(203),
+                redis::Value::Array(vec![redis::Value::Int(0)]),
+                redis::Value::Array(vec![redis::Value::Array(vec![
+                    redis::Value::Int(1),
+                    redis::Value::Int(2),
+                    redis::Value::BulkString("FirstNode".to_string().into_bytes()),
+                ])]),
+            ]),
+        ])])
+    }
+
+    fn edge_row() -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(7),
+            redis::Value::Array(vec![
+                redis::Value::Int(100),
+                redis::Value::Int(0),
+                redis::Value::Int(203),
+                redis::Value::Int(204),
+                redis::Value::Array(vec![redis::Value::Array(vec![
+                    redis::Value::Int(1),
+                    redis::Value::Int(2),
+                    redis::Value::BulkString("Edge".to_string().into_bytes()),
+                ])]),
+            ]),
+        ])])
+    }
+
+    fn expected_node() -> FalkorValue {
+        FalkorValue::Node(Node {
+            entity_id: 203,
+            labels: vec!["actor".to_string()],
+            properties: HashMap::from([(
+                "name".to_string(),
+                FalkorValue::String("FirstNode".to_string()),
+            )]),
+        })
+    }
+
+    fn expected_edge() -> FalkorValue {
+        FalkorValue::Edge(Edge {
+            entity_id: 100,
+            relationship_type: "act".to_string(),
+            src_node_id: 203,
+            dst_node_id: 204,
+            properties: HashMap::from([(
+                "name".to_string(),
+                FalkorValue::String("Edge".to_string()),
+            )]),
+        })
+    }
 
     #[test]
     fn test_lazy_result_set() {
         let client = imdb_test_client();
         let mut graph = client.select_graph("imdb");
 
+        let header: Arc<[String]> = Arc::from(vec!["entity".to_string()]);
         let mut result_set = LazyResultSet::new(
-            vec![
-                redis::Value::Array(vec![redis::Value::Array(vec![
-                    redis::Value::Int(8),
-                    redis::Value::Array(vec![
-                        redis::Value::Int(203),
-                        redis::Value::Array(vec![redis::Value::Int(0)]),
-                        redis::Value::Array(vec![redis::Value::Array(vec![
-                            redis::Value::Int(1),
-                            redis::Value::Int(2),
-                            redis::Value::BulkString("FirstNode".to_string().into_bytes()),
-                        ])]),
-                    ]),
-                ])]),
-                redis::Value::Array(vec![redis::Value::Array(vec![
-                    redis::Value::Int(8),
-                    redis::Value::Array(vec![
-                        redis::Value::Int(203),
-                        redis::Value::Array(vec![redis::Value::Int(0)]),
-                        redis::Value::Array(vec![redis::Value::Array(vec![
-                            redis::Value::Int(1),
-                            redis::Value::Int(2),
-                            redis::Value::BulkString("FirstNode".to_string().into_bytes()),
-                        ])]),
-                    ]),
-                ])]),
-                redis::Value::Array(vec![redis::Value::Array(vec![
-                    redis::Value::Int(7),
-                    redis::Value::Array(vec![
-                        redis::Value::Int(100),
-                        redis::Value::Int(0),
-                        redis::Value::Int(203),
-                        redis::Value::Int(204),
-                        redis::Value::Array(vec![redis::Value::Array(vec![
-                            redis::Value::Int(1),
-                            redis::Value::Int(2),
-                            redis::Value::BulkString("Edge".to_string().into_bytes()),
-                        ])]),
-                    ]),
-                ])]),
-            ],
+            header,
+            vec![node_row(), node_row(), edge_row()],
             graph.get_graph_schema_mut(),
         );
 
-        assert_eq!(
-            result_set.next(),
-            Some(vec![FalkorValue::Node(Node {
-                entity_id: 203,
-                labels: vec!["actor".to_string()],
-                properties: HashMap::from([(
-                    "name".to_string(),
-                    FalkorValue::String("FirstNode".to_string())
-                )]),
-            })])
-        );
+        let first = result_set.next().unwrap().unwrap();
+        assert_eq!(first.get("entity"), Some(&expected_node()));
+        assert_eq!(first.get_at(0), Some(&expected_node()));
 
-        assert_eq!(
-            result_set.collect::<Vec<_>>(),
-            vec![
-                vec![FalkorValue::Node(Node {
-                    entity_id: 203,
-                    labels: vec!["actor".to_string()],
-                    properties: HashMap::from([(
-                        "name".to_string(),
-                        FalkorValue::String("FirstNode".to_string())
-                    )]),
-                })],
-                vec![FalkorValue::Edge(Edge {
-                    entity_id: 100,
-                    relationship_type: "act".to_string(),
-                    src_node_id: 203,
-                    dst_node_id: 204,
-                    properties: HashMap::from([(
-                        "name".to_string(),
-                        FalkorValue::String("Edge".to_string())
-                    )]),
-                })]
-            ],
-        );
+        let rows = result_set.collect::<FalkorResult<Vec<Row>>>().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get_at(0), Some(&expected_node()));
+        assert_eq!(rows[1].get_at(0), Some(&expected_edge()));
+    }
+
+    #[test]
+    fn shape_mismatch_surfaces_error() {
+        let client = imdb_test_client();
+        let mut graph = client.select_graph("imdb");
+
+        // The row parses to a single value, but the header claims two columns.
+        let header: Arc<[String]> = Arc::from(vec!["a".to_string(), "b".to_string()]);
+        let mut result_set =
+            LazyResultSet::new(header, vec![node_row()], graph.get_graph_schema_mut());
+
+        match result_set.next() {
+            Some(Err(FalkorDBError::RowShapeMismatch {
+                header_len,
+                value_len,
+            })) => {
+                assert_eq!(header_len, 2);
+                assert_eq!(value_len, 1);
+            }
+            other => panic!("expected RowShapeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn into_values_lossy_yields_bare_rows() {
+        let client = imdb_test_client();
+        let mut graph = client.select_graph("imdb");
+
+        let header: Arc<[String]> = Arc::from(vec!["entity".to_string()]);
+        let result_set = LazyResultSet::new(header, vec![node_row()], graph.get_graph_schema_mut());
+
+        let rows: Vec<Vec<FalkorValue>> = result_set.into_values_lossy().collect();
+        assert_eq!(rows, vec![vec![expected_node()]]);
     }
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -170,7 +170,7 @@ impl<'a> QueryResult<crate::LazyResultSet<'a>> {
     ///
     /// The [`header`](Self::header) and [`stats`](Self::stats) are preserved; only `data` is
     /// replaced by a [`TypedLazyResultSet`](crate::TypedLazyResultSet) that maps each row with
-    /// [`from_falkor_row`](crate::from_falkor_row).
+    /// [`Row::deserialize`](crate::Row::deserialize).
     pub(crate) fn into_typed<T>(self) -> QueryResult<typed_result_set::TypedLazyResultSet<'a, T>> {
         QueryResult {
             data: typed_result_set::TypedLazyResultSet::new(self.data),

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -3,16 +3,17 @@
  * Licensed under the MIT License.
  */
 
-use crate::{
-    parser::{parse_header, redis_value_as_untyped_string_vec},
-    FalkorResult,
-};
+use crate::{parser::redis_value_as_untyped_string_vec, FalkorResult};
 use std::str::FromStr;
+use std::sync::Arc;
 
 pub(crate) mod constraint;
 pub(crate) mod execution_plan;
 pub(crate) mod index;
 pub(crate) mod lazy_result_set;
+pub(crate) mod row;
+#[cfg(test)]
+mod row_proptest;
 pub(crate) mod slowlog_entry;
 #[cfg(feature = "serde")]
 pub(crate) mod typed_result_set;
@@ -48,8 +49,9 @@ enum StatisticType {
 /// A response struct which also contains the returned header and stats data
 #[derive(Clone, Debug, Default)]
 pub struct QueryResult<T> {
-    /// Header for the result data, usually contains the scalar aliases for the columns
-    pub header: Vec<String>,
+    /// Header for the result data: the column aliases, shared cheaply with each
+    /// [`Row`](crate::Row) the result set yields.
+    pub header: Arc<[String]>,
     /// The actual data returned from the database
     pub data: T,
     /// Various statistics regarding the request, such as execution time and number of successful operations
@@ -57,10 +59,10 @@ pub struct QueryResult<T> {
 }
 
 impl<T> QueryResult<T> {
-    /// Creates a [`QueryResult`] from the specified data, and raw stats, where raw headers are optional
+    /// Creates a [`QueryResult`] from the specified data, an already-parsed `header`, and raw stats.
     ///
     /// # Arguments
-    /// * `headers`: a [`redis::Value`] that is expected to be of variant [`redis::Value::Array`], where each element is expected to be of variant [`redis::Value::BulkString`], [`redis::Value::VerbatimString`] or [`redis::Value::SimpleString`]
+    /// * `header`: the column aliases, parsed once and shared with the result set's rows
     /// * `data`: The actual data
     /// * `stats`: a [`redis::Value`] that is expected to be of variant [`redis::Value::Array`], where each element is expected to be of variant [`redis::Value::BulkString`], [`redis::Value::VerbatimString`] or [`redis::Value::SimpleString`]
     #[cfg_attr(
@@ -68,15 +70,12 @@ impl<T> QueryResult<T> {
         tracing::instrument(name = "New Falkor Response", skip_all, level = "trace")
     )]
     pub fn from_response(
-        headers: Option<redis::Value>,
+        header: Arc<[String]>,
         data: T,
         stats: redis::Value,
     ) -> FalkorResult<Self> {
         Ok(Self {
-            header: match headers {
-                Some(headers) => parse_header(headers)?,
-                None => vec![],
-            },
+            header,
             data,
             stats: redis_value_as_untyped_string_vec(stats)?,
         })
@@ -173,9 +172,8 @@ impl<'a> QueryResult<crate::LazyResultSet<'a>> {
     /// replaced by a [`TypedLazyResultSet`](crate::TypedLazyResultSet) that maps each row with
     /// [`from_falkor_row`](crate::from_falkor_row).
     pub(crate) fn into_typed<T>(self) -> QueryResult<typed_result_set::TypedLazyResultSet<'a, T>> {
-        let header: std::sync::Arc<[String]> = std::sync::Arc::from(self.header.as_slice());
         QueryResult {
-            data: typed_result_set::TypedLazyResultSet::new(header, self.data),
+            data: typed_result_set::TypedLazyResultSet::new(self.data),
             header: self.header,
             stats: self.stats,
         }
@@ -244,7 +242,7 @@ mod tests {
     #[test]
     fn test_query_result_clone() {
         let result = QueryResult {
-            header: vec!["col1".to_string()],
+            header: vec!["col1".to_string()].into(),
             data: vec!["value1".to_string()],
             stats: vec!["Nodes created: 5".to_string()],
         };
@@ -258,7 +256,7 @@ mod tests {
     #[test]
     fn test_query_result_debug() {
         let result = QueryResult {
-            header: vec!["name".to_string()],
+            header: vec!["name".to_string()].into(),
             data: vec!["Alice".to_string()],
             stats: vec!["Query internal execution time: 0.5 milliseconds".to_string()],
         };
@@ -271,7 +269,7 @@ mod tests {
     #[test]
     fn test_get_labels_added() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Labels added: 10".to_string()],
         };
@@ -281,7 +279,7 @@ mod tests {
     #[test]
     fn test_get_labels_removed() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Labels removed: 5".to_string()],
         };
@@ -291,7 +289,7 @@ mod tests {
     #[test]
     fn test_get_nodes_created() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Nodes created: 20".to_string()],
         };
@@ -301,7 +299,7 @@ mod tests {
     #[test]
     fn test_get_nodes_deleted() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Nodes deleted: 8".to_string()],
         };
@@ -311,7 +309,7 @@ mod tests {
     #[test]
     fn test_get_properties_set() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Properties set: 15".to_string()],
         };
@@ -321,7 +319,7 @@ mod tests {
     #[test]
     fn test_get_properties_removed() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Properties removed: 3".to_string()],
         };
@@ -331,7 +329,7 @@ mod tests {
     #[test]
     fn test_get_indices_created() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Indices created: 2".to_string()],
         };
@@ -341,7 +339,7 @@ mod tests {
     #[test]
     fn test_get_indices_deleted() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Indices deleted: 1".to_string()],
         };
@@ -351,7 +349,7 @@ mod tests {
     #[test]
     fn test_get_relationship_created() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Relationships created: 12".to_string()],
         };
@@ -361,7 +359,7 @@ mod tests {
     #[test]
     fn test_get_relationship_deleted() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Relationships deleted: 7".to_string()],
         };
@@ -371,7 +369,7 @@ mod tests {
     #[test]
     fn test_get_internal_execution_time() {
         let result = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Query internal execution time: 1.234 milliseconds".to_string()],
         };
@@ -381,7 +379,7 @@ mod tests {
     #[test]
     fn test_get_statistics_none() {
         let result: QueryResult<()> = QueryResult {
-            header: vec![],
+            header: Vec::new().into(),
             data: (),
             stats: vec!["Some other stat: 100".to_string()],
         };

--- a/src/response/row.rs
+++ b/src/response/row.rs
@@ -104,15 +104,12 @@ impl Row {
     /// for the common unique-column case prefer [`get`](Self::get).
     pub fn get_all<'s>(
         &'s self,
-        column: &str,
+        column: &'s str,
     ) -> impl Iterator<Item = &'s FalkorValue> + 's {
-        let indices: Vec<usize> = self
-            .header
+        self.header
             .iter()
-            .enumerate()
-            .filter_map(|(index, name)| (name == column).then_some(index))
-            .collect();
-        indices.into_iter().map(move |index| &self.values[index])
+            .zip(&self.values)
+            .filter_map(move |(name, value)| (name == column).then_some(value))
     }
 
     /// Extracts and converts the value in the column named `column`.

--- a/src/response/row.rs
+++ b/src/response/row.rs
@@ -33,14 +33,13 @@ use std::sync::Arc;
 ///
 /// # Duplicate column names
 ///
-/// A query like `RETURN a AS x, b AS x` produces two columns both named `x`. To keep every access
-/// path predictable:
+/// FalkorDB rejects a query whose result columns are not uniquely named, so a `Row` returned from a
+/// query always has distinct columns. A `Row` built by hand from `(column, value)` pairs (via
+/// [`FromIterator`]) can still hold duplicates, so the access paths are defined for that case:
 ///
 /// - [`get`](Self::get) / [`try_get`](Self::try_get) return the **first** match.
 /// - [`get_all`](Self::get_all) returns **every** match, in column order.
 /// - [`into_map`](Self::into_map) keeps the **last** value for a duplicated name.
-///
-/// Prefer distinct aliases to avoid the ambiguity entirely.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Row {
     header: Arc<[String]>,
@@ -100,8 +99,8 @@ impl Row {
 
     /// References to every value whose column is named `column`, in column order.
     ///
-    /// This is the explicit way to handle the rare duplicate-column case (`RETURN a AS x, b AS x`);
-    /// for the common unique-column case prefer [`get`](Self::get).
+    /// This is the explicit way to handle the rare duplicate-column case (see the type docs); for
+    /// the common unique-column case prefer [`get`](Self::get).
     pub fn get_all<'s>(
         &'s self,
         column: &'s str,

--- a/src/response/row.rs
+++ b/src/response/row.rs
@@ -262,10 +262,12 @@ mod tests {
     fn try_get_missing_vs_null() {
         let row = sample();
         // absent column -> MissingColumn, even for Option
-        match row.try_get::<Option<String>>("nope") {
-            Err(FalkorDBError::MissingColumn { name }) => assert_eq!(name, "nope"),
-            other => panic!("unexpected: {other:?}"),
-        }
+        assert_eq!(
+            row.try_get::<Option<String>>("nope"),
+            Err(FalkorDBError::MissingColumn {
+                name: "nope".to_string()
+            })
+        );
         // present-but-null -> Ok(None)
         assert_eq!(row.try_get::<Option<String>>("sequel").unwrap(), None);
     }
@@ -273,25 +275,22 @@ mod tests {
     #[test]
     fn try_get_type_error() {
         let row = sample();
-        match row.try_get::<i64>("title") {
-            Err(FalkorDBError::TypeError { expected, got }) => {
-                assert_eq!(expected, "i64");
-                assert_eq!(got, "String");
-            }
-            other => panic!("unexpected: {other:?}"),
-        }
+        assert_eq!(
+            row.try_get::<i64>("title"),
+            Err(FalkorDBError::TypeError {
+                expected: "i64",
+                got: "String"
+            })
+        );
     }
 
     #[test]
     fn try_get_at_out_of_bounds() {
         let row = sample();
-        match row.try_get_at::<i64>(10) {
-            Err(FalkorDBError::ColumnIndexOutOfBounds { index, len }) => {
-                assert_eq!(index, 10);
-                assert_eq!(len, 4);
-            }
-            other => panic!("unexpected: {other:?}"),
-        }
+        assert_eq!(
+            row.try_get_at::<i64>(10),
+            Err(FalkorDBError::ColumnIndexOutOfBounds { index: 10, len: 4 })
+        );
     }
 
     #[test]

--- a/src/response/row.rs
+++ b/src/response/row.rs
@@ -1,0 +1,324 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! A single, header-aware result row.
+
+use crate::{FalkorDBError, FalkorResult, FalkorValue, FromFalkorValue};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A single result row: the query's column names (the *header*) paired with this row's values.
+///
+/// `Row` is what the default [`LazyResultSet`](crate::LazyResultSet) backing `QueryResult::data`
+/// yields (as `FalkorResult<Row>`, so a parse error surfaces instead of being swallowed). Columns
+/// can be read by name or by index, untyped (borrowing) or typed (converting):
+///
+/// ```
+/// # use falkordb::{FalkorValue, Row};
+/// # fn main() -> Result<(), falkordb::FalkorDBError> {
+/// let row = Row::from_iter([
+///     ("title".to_string(), FalkorValue::from("Dune")),
+///     ("year".to_string(), FalkorValue::I64(1965)),
+/// ]);
+///
+/// let title: String = row.try_get("title")?;
+/// let year: i64 = row.try_get("year")?;
+/// assert_eq!(title, "Dune");
+/// assert_eq!(year, 1965);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Duplicate column names
+///
+/// A query like `RETURN a AS x, b AS x` produces two columns both named `x`. To keep every access
+/// path predictable:
+///
+/// - [`get`](Self::get) / [`try_get`](Self::try_get) return the **first** match.
+/// - [`get_all`](Self::get_all) returns **every** match, in column order.
+/// - [`into_map`](Self::into_map) keeps the **last** value for a duplicated name.
+///
+/// Prefer distinct aliases to avoid the ambiguity entirely.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Row {
+    header: Arc<[String]>,
+    values: Vec<FalkorValue>,
+}
+
+impl Row {
+    /// Builds a row from an already-validated header and value vector.
+    ///
+    /// The two are guaranteed equal in length by the caller ([`LazyResultSet`](crate::LazyResultSet)
+    /// validates the row shape), so this constructor performs no check.
+    pub(crate) fn new(
+        header: Arc<[String]>,
+        values: Vec<FalkorValue>,
+    ) -> Self {
+        Self { header, values }
+    }
+
+    fn index_of(
+        &self,
+        column: &str,
+    ) -> Option<usize> {
+        self.header.iter().position(|name| name == column)
+    }
+
+    /// The column names of this row, in order.
+    pub fn columns(&self) -> &[String] {
+        &self.header
+    }
+
+    /// The number of columns in this row.
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Whether this row has no columns.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    /// A reference to the value in the column named `column`, or [`None`] if there is no such
+    /// column. For duplicate column names this returns the **first** match (see the type docs).
+    pub fn get(
+        &self,
+        column: &str,
+    ) -> Option<&FalkorValue> {
+        self.index_of(column).map(|index| &self.values[index])
+    }
+
+    /// A reference to the value at `index`, or [`None`] if `index` is out of bounds.
+    pub fn get_at(
+        &self,
+        index: usize,
+    ) -> Option<&FalkorValue> {
+        self.values.get(index)
+    }
+
+    /// References to every value whose column is named `column`, in column order.
+    ///
+    /// This is the explicit way to handle the rare duplicate-column case (`RETURN a AS x, b AS x`);
+    /// for the common unique-column case prefer [`get`](Self::get).
+    pub fn get_all<'s>(
+        &'s self,
+        column: &str,
+    ) -> impl Iterator<Item = &'s FalkorValue> + 's {
+        let indices: Vec<usize> = self
+            .header
+            .iter()
+            .enumerate()
+            .filter_map(|(index, name)| (name == column).then_some(index))
+            .collect();
+        indices.into_iter().map(move |index| &self.values[index])
+    }
+
+    /// Extracts and converts the value in the column named `column`.
+    ///
+    /// Conversions are strict (see [`FromFalkorValue`]). Use `try_get::<Option<T>>` to distinguish a
+    /// `null` value (`Ok(None)`) from a missing column (`Err(MissingColumn)`).
+    ///
+    /// # Errors
+    ///
+    /// - [`FalkorDBError::MissingColumn`] if no column is named `column`.
+    /// - [`FalkorDBError::TypeError`] if the value is not the requested type.
+    pub fn try_get<T: FromFalkorValue>(
+        &self,
+        column: &str,
+    ) -> FalkorResult<T> {
+        let index = self
+            .index_of(column)
+            .ok_or_else(|| FalkorDBError::MissingColumn {
+                name: column.to_string(),
+            })?;
+        T::from_falkor_value(self.values[index].clone())
+    }
+
+    /// Extracts and converts the value at `index`.
+    ///
+    /// # Errors
+    ///
+    /// - [`FalkorDBError::ColumnIndexOutOfBounds`] if `index` is out of bounds.
+    /// - [`FalkorDBError::TypeError`] if the value is not the requested type.
+    pub fn try_get_at<T: FromFalkorValue>(
+        &self,
+        index: usize,
+    ) -> FalkorResult<T> {
+        let value = self
+            .values
+            .get(index)
+            .ok_or(FalkorDBError::ColumnIndexOutOfBounds {
+                index,
+                len: self.values.len(),
+            })?;
+        T::from_falkor_value(value.clone())
+    }
+
+    /// Consumes the row, returning its values in column order.
+    pub fn into_values(self) -> Vec<FalkorValue> {
+        self.values
+    }
+
+    /// Consumes the row into a `{ column => value }` map.
+    ///
+    /// If a column name is duplicated the **last** value wins (see the type docs).
+    ///
+    /// ```
+    /// # use falkordb::{FalkorValue, Row};
+    /// let row = Row::from_iter([
+    ///     ("name".to_string(), FalkorValue::from("Neo")),
+    ///     ("age".to_string(), FalkorValue::I64(30)),
+    /// ]);
+    /// let map = row.into_map();
+    /// assert_eq!(map.get("name"), Some(&FalkorValue::from("Neo")));
+    /// assert_eq!(map.get("age"), Some(&FalkorValue::I64(30)));
+    /// ```
+    pub fn into_map(self) -> HashMap<String, FalkorValue> {
+        self.header.iter().cloned().zip(self.values).collect()
+    }
+
+    /// Deserializes the whole row into `T` using `serde`.
+    ///
+    /// A single-column row deserializes as that column's value; a multi-column row deserializes as a
+    /// map from column name to value (for structs/maps) or a sequence (for tuples). This is the same
+    /// mapping used by [`QueryBuilder::query_as`](crate::QueryBuilder::query_as).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto `T`.
+    #[cfg(feature = "serde")]
+    pub fn deserialize<T: serde::de::DeserializeOwned>(self) -> FalkorResult<T> {
+        crate::from_falkor_row(&self.header, self.values)
+    }
+}
+
+impl IntoIterator for Row {
+    type Item = FalkorValue;
+    type IntoIter = std::vec::IntoIter<FalkorValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+/// Builds a [`Row`] from `(column, value)` pairs.
+///
+/// Useful for tests and for mapping data into a `Row` by hand. The header is taken from the keys in
+/// iteration order, so duplicate keys behave exactly as a row returned by the server would.
+impl FromIterator<(String, FalkorValue)> for Row {
+    fn from_iter<I: IntoIterator<Item = (String, FalkorValue)>>(iter: I) -> Self {
+        let (header, values): (Vec<String>, Vec<FalkorValue>) = iter.into_iter().unzip();
+        Self {
+            header: header.into(),
+            values,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> Row {
+        Row::from_iter([
+            ("title".to_string(), FalkorValue::from("Dune")),
+            ("year".to_string(), FalkorValue::I64(1965)),
+            ("rating".to_string(), FalkorValue::F64(8.2)),
+            ("sequel".to_string(), FalkorValue::None),
+        ])
+    }
+
+    #[test]
+    fn columns_len_is_empty() {
+        let row = sample();
+        assert_eq!(row.columns(), ["title", "year", "rating", "sequel"]);
+        assert_eq!(row.len(), 4);
+        assert!(!row.is_empty());
+
+        let empty = Row::from_iter([]);
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn get_and_get_at() {
+        let row = sample();
+        assert_eq!(row.get("year"), Some(&FalkorValue::I64(1965)));
+        assert_eq!(row.get("missing"), None);
+        assert_eq!(row.get_at(0), Some(&FalkorValue::from("Dune")));
+        assert_eq!(row.get_at(99), None);
+    }
+
+    #[test]
+    fn try_get_typed() {
+        let row = sample();
+        assert_eq!(row.try_get::<String>("title").unwrap(), "Dune");
+        assert_eq!(row.try_get::<i64>("year").unwrap(), 1965);
+        assert_eq!(row.try_get::<f64>("rating").unwrap(), 8.2);
+        // a null value as Option
+        assert_eq!(row.try_get::<Option<String>>("sequel").unwrap(), None);
+    }
+
+    #[test]
+    fn try_get_missing_vs_null() {
+        let row = sample();
+        // absent column -> MissingColumn, even for Option
+        match row.try_get::<Option<String>>("nope") {
+            Err(FalkorDBError::MissingColumn { name }) => assert_eq!(name, "nope"),
+            other => panic!("unexpected: {other:?}"),
+        }
+        // present-but-null -> Ok(None)
+        assert_eq!(row.try_get::<Option<String>>("sequel").unwrap(), None);
+    }
+
+    #[test]
+    fn try_get_type_error() {
+        let row = sample();
+        match row.try_get::<i64>("title") {
+            Err(FalkorDBError::TypeError { expected, got }) => {
+                assert_eq!(expected, "i64");
+                assert_eq!(got, "String");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_get_at_out_of_bounds() {
+        let row = sample();
+        match row.try_get_at::<i64>(10) {
+            Err(FalkorDBError::ColumnIndexOutOfBounds { index, len }) => {
+                assert_eq!(index, 10);
+                assert_eq!(len, 4);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_columns_first_wins_and_get_all() {
+        let row = Row::from_iter([
+            ("x".to_string(), FalkorValue::I64(1)),
+            ("x".to_string(), FalkorValue::I64(2)),
+            ("y".to_string(), FalkorValue::I64(3)),
+        ]);
+        // first wins
+        assert_eq!(row.get("x"), Some(&FalkorValue::I64(1)));
+        assert_eq!(row.try_get::<i64>("x").unwrap(), 1);
+        // get_all returns every match
+        let all: Vec<&FalkorValue> = row.get_all("x").collect();
+        assert_eq!(all, vec![&FalkorValue::I64(1), &FalkorValue::I64(2)]);
+        // into_map: last wins
+        let map = row.into_map();
+        assert_eq!(map.get("x"), Some(&FalkorValue::I64(2)));
+    }
+
+    #[test]
+    fn into_values_and_iter() {
+        let row = sample();
+        let collected: Vec<FalkorValue> = row.clone().into_iter().collect();
+        assert_eq!(collected, row.into_values());
+    }
+}

--- a/src/response/row_proptest.rs
+++ b/src/response/row_proptest.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Property-based tests for [`Row`].
+//!
+//! These complement the golden unit tests in [`super::row`] with invariants that must hold for an
+//! arbitrary row:
+//! - **no-panic robustness**: [`Row::try_get`]/[`Row::try_get_at`] always return `Ok`/`Err`,
+//!   whatever the column name, index, or target type;
+//! - **first-match / last-wins** duplicate-column semantics for [`Row::get`]/[`Row::into_map`];
+//! - **round-trip**: building a row from `(column, value)` pairs preserves columns and values.
+
+use crate::{FalkorValue, Row};
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+/// An arbitrary [`FalkorValue`]. Floats are kept finite so structural equality (used by the
+/// invariants below) is reflexive (`NaN != NaN` would otherwise spuriously fail comparisons).
+fn falkor_value_strategy() -> impl Strategy<Value = FalkorValue> {
+    let leaf = prop_oneof![
+        Just(FalkorValue::None),
+        any::<bool>().prop_map(FalkorValue::Bool),
+        any::<i64>().prop_map(FalkorValue::I64),
+        (-1.0e12f64..1.0e12).prop_map(FalkorValue::F64),
+        ".*".prop_map(FalkorValue::String),
+    ];
+    leaf.prop_recursive(2, 8, 4, |inner| {
+        vec(inner, 0..4).prop_map(FalkorValue::Array)
+    })
+}
+
+/// A short column name, biased towards collisions (and the empty string) so the duplicate-column
+/// rules are exercised.
+fn column_strategy() -> impl Strategy<Value = String> {
+    prop_oneof![Just(String::new()), "[a-c]{0,3}"]
+}
+
+prop_compose! {
+    fn row_strategy()(
+        pairs in vec((column_strategy(), falkor_value_strategy()), 0..6)
+    ) -> (Vec<(String, FalkorValue)>, Row) {
+        let row = Row::from_iter(pairs.clone());
+        (pairs, row)
+    }
+}
+
+proptest! {
+    /// Typed extraction never panics, whatever the row and the requested column / index / type.
+    #[test]
+    fn prop_try_get_never_panics(
+        (_, row) in row_strategy(),
+        name in column_strategy(),
+        index in 0usize..8,
+    ) {
+        let _ = row.try_get::<i64>(&name);
+        let _ = row.try_get::<f64>(&name);
+        let _ = row.try_get::<bool>(&name);
+        let _ = row.try_get::<String>(&name);
+        let _ = row.try_get::<Option<i64>>(&name);
+        let _ = row.try_get::<Vec<i64>>(&name);
+        let _ = row.try_get::<FalkorValue>(&name);
+        let _ = row.try_get_at::<i64>(index);
+        let _ = row.try_get_at::<FalkorValue>(index);
+    }
+
+    /// `get` returns the value at the first index whose column matches (the documented dup rule).
+    #[test]
+    fn prop_get_returns_first_match((pairs, row) in row_strategy()) {
+        for (name, _) in &pairs {
+            let first = pairs.iter().find(|(column, _)| column == name).map(|(_, value)| value);
+            prop_assert_eq!(row.get(name), first);
+        }
+    }
+
+    /// `get_at` and `try_get_at` agree, and are `Some`/`Ok` exactly within bounds.
+    #[test]
+    fn prop_get_at_in_bounds((pairs, row) in row_strategy(), index in 0usize..8) {
+        let expected = pairs.get(index).map(|(_, value)| value);
+        prop_assert_eq!(row.get_at(index), expected);
+        match row.try_get_at::<FalkorValue>(index) {
+            Ok(value) => prop_assert_eq!(Some(&value), expected),
+            Err(_) => prop_assert!(expected.is_none()),
+        }
+    }
+
+    /// `get_all` returns exactly the values whose column matches, in order.
+    #[test]
+    fn prop_get_all_matches((pairs, row) in row_strategy(), name in column_strategy()) {
+        let expected: Vec<&FalkorValue> = pairs
+            .iter()
+            .filter(|(column, _)| *column == name)
+            .map(|(_, value)| value)
+            .collect();
+        let actual: Vec<&FalkorValue> = row.get_all(&name).collect();
+        prop_assert_eq!(actual, expected);
+    }
+
+    /// `into_map` keeps the last value for a duplicated column name.
+    #[test]
+    fn prop_into_map_last_wins((pairs, row) in row_strategy()) {
+        let map = row.into_map();
+        prop_assert_eq!(map.len(), pairs.iter().map(|(column, _)| column).collect::<std::collections::HashSet<_>>().len());
+        for (name, _) in &pairs {
+            let last = pairs.iter().rev().find(|(column, _)| column == name).map(|(_, value)| value);
+            prop_assert_eq!(map.get(name), last);
+        }
+    }
+
+    /// Building from `(column, value)` pairs preserves columns and values in order.
+    #[test]
+    fn prop_columns_values_roundtrip((pairs, row) in row_strategy()) {
+        let columns: Vec<String> = pairs.iter().map(|(column, _)| column.clone()).collect();
+        let values: Vec<FalkorValue> = pairs.iter().map(|(_, value)| value.clone()).collect();
+        prop_assert_eq!(row.columns(), columns.as_slice());
+        prop_assert_eq!(row.len(), values.len());
+        prop_assert_eq!(row.into_values(), values);
+    }
+}

--- a/src/response/typed_result_set.rs
+++ b/src/response/typed_result_set.rs
@@ -5,11 +5,9 @@
 
 //! Typed iteration over a query result set, available with the `serde` feature.
 
-use crate::value::from_falkor_row;
-use crate::{FalkorResult, LazyResultSet};
+use crate::{FalkorResult, LazyResultSet, Row};
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 /// A typed view over a [`LazyResultSet`] that deserializes each row into `T` on demand.
 ///
@@ -22,22 +20,17 @@ use std::sync::Arc;
 /// let movies: Vec<Movie> = result.data.collect::<Result<_, _>>()?;
 /// ```
 ///
-/// Each row is mapped with [`from_falkor_row`]: a single-column row deserializes as that
-/// column's value (so `RETURN m` maps the node and `RETURN n.name` maps the scalar), while a
-/// multi-column row deserializes as a map from column name to value, or as a sequence.
+/// Each row is mapped with [`Row::deserialize`]: a single-column row deserializes as that column's
+/// value (so `RETURN m` maps the node and `RETURN n.name` maps the scalar), while a multi-column row
+/// deserializes as a map from column name to value, or as a sequence.
 pub struct TypedLazyResultSet<'a, T> {
-    header: Arc<[String]>,
     inner: LazyResultSet<'a>,
     _marker: PhantomData<fn() -> T>,
 }
 
 impl<'a, T> TypedLazyResultSet<'a, T> {
-    pub(crate) fn new(
-        header: Arc<[String]>,
-        inner: LazyResultSet<'a>,
-    ) -> Self {
+    pub(crate) fn new(inner: LazyResultSet<'a>) -> Self {
         Self {
-            header,
             inner,
             _marker: PhantomData,
         }
@@ -67,6 +60,6 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
-            .map(|row| from_falkor_row(&self.header, row))
+            .map(|row| row.and_then(Row::deserialize::<T>))
     }
 }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -60,9 +60,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto the target type, or if
-/// a multi-column row's `values` length does not match the `header` length (a malformed result
-/// shape that would otherwise be silently truncated by the header/value zip).
+/// Returns [`FalkorDBError::SerdeError`] if the row cannot be mapped onto the target type, or if the
+/// `values` length does not match the `header` length (a malformed result shape that would otherwise
+/// be silently truncated by the header/value zip).
 pub fn from_falkor_row<T>(
     header: &[String],
     mut values: Vec<FalkorValue>,
@@ -70,20 +70,23 @@ pub fn from_falkor_row<T>(
 where
     T: serde::de::DeserializeOwned,
 {
-    // A single value (the common case, and also how a failed row parse is reported, as a lone
-    // `Unparseable`) is mapped on its own so the parse error surfaces with its real message.
-    if values.len() == 1 {
-        let value = values.pop().expect("length checked to be exactly one");
-        return T::deserialize(value.into_deserializer());
-    }
-    // Otherwise the row is zipped with the header by name, so a length mismatch would silently
-    // drop columns or values; reject it instead of deserializing a truncated row.
+    // The row is zipped with the header by name, so a length mismatch would silently drop columns
+    // or values; reject it before deserializing. (Checked up front so the single-column fast path
+    // below cannot mask a mismatch where the header claims a different number of columns.)
     if header.len() != values.len() {
         return Err(FalkorDBError::SerdeError(format!(
             "result row shape mismatch: header has {} column(s) but the row has {} value(s)",
             header.len(),
             values.len(),
         )));
+    }
+    // A single-column row is mapped on its own (so `RETURN m` maps the node and `RETURN n.name` maps
+    // the scalar). Keyed on the header length, not merely the value count, so the shape is trusted.
+    if header.len() == 1 {
+        let value = values
+            .pop()
+            .expect("length checked to equal a header length of one");
+        return T::deserialize(value.into_deserializer());
     }
     T::deserialize(RowDeserializer { header, values })
 }

--- a/src/value/de_proptest.rs
+++ b/src/value/de_proptest.rs
@@ -156,19 +156,21 @@ proptest! {
         let _: Result<Sample, _> = from_falkor_value(value);
     }
 
-    /// #3a — a single-column row maps exactly like the lone value; the header is irrelevant.
+    /// #3a — a single-column row maps exactly like the lone value.
     #[test]
-    fn prop_single_column_row_matches_value(header in vec(".*", 0..5), value in falkor_strategy()) {
+    fn prop_single_column_row_matches_value(column in ".*", value in falkor_strategy()) {
+        let header = vec![column];
         let from_row: Option<Json> = from_falkor_row(&header, vec![value.clone()]).ok();
         let from_value: Option<Json> = from_falkor_value(value).ok();
         prop_assert_eq!(from_row, from_value);
     }
 
-    /// #3b — a multi-column row whose length disagrees with the header is always rejected.
+    /// #3b — a row whose value count disagrees with the header length is always rejected,
+    /// including the single-value case when the header does not also have exactly one column.
     #[test]
     fn prop_length_mismatch_is_rejected(
         (header_len, values_len) in (0usize..6, 0usize..6)
-            .prop_filter("multi-column with mismatched lengths", |(h, v)| *v != 1 && h != v)
+            .prop_filter("mismatched lengths", |(h, v)| h != v)
     ) {
         let header: Vec<String> = (0..header_len).map(|i| format!("c{i}")).collect();
         let values: Vec<FalkorValue> = (0..values_len).map(|i| FalkorValue::I64(i as i64)).collect();

--- a/src/value/from_value.rs
+++ b/src/value/from_value.rs
@@ -1,0 +1,279 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Converting a [`FalkorValue`] into a Rust type.
+//!
+//! This powers [`Row::try_get`](crate::Row::try_get): a value-by-value, strict (no silent lossy
+//! casts) conversion that returns [`FalkorDBError::TypeError`] on a mismatch.
+
+use crate::value::graph_entities::{Edge, Node};
+use crate::value::path::Path;
+use crate::value::point::Point;
+use crate::value::vec32::Vec32;
+use crate::{FalkorDBError, FalkorResult, FalkorValue};
+use std::collections::HashMap;
+
+/// The largest magnitude integer for which every smaller-or-equal integer is exactly representable
+/// as an `f64` (`2^53`). `i64` values within `±F64_EXACT_INT_LIMIT` widen to `f64` losslessly.
+const F64_EXACT_INT_LIMIT: i64 = 1 << 53;
+
+/// A type that can be extracted from a [`FalkorValue`].
+///
+/// Implemented for the scalar types ([`i64`], [`f64`], [`bool`], [`String`]), the graph entity
+/// types ([`Node`], [`Edge`], [`Point`], [`Path`], `Vec32`), smaller integers ([`i32`], [`u32`],
+/// [`u64`], `usize`, range-checked), `Option<T>` (a `null` value becomes `None`), `Vec<T>`,
+/// `HashMap<String, T>`, and [`FalkorValue`] itself (the identity).
+///
+/// Conversions are **strict**: a string `"true"` does not become a `bool`, an `F64` does not become
+/// an `i64`, and out-of-range integers fail rather than silently truncating. The one widening
+/// allowed is `i64` → `f64` when the integer is exactly representable (magnitude up to `2^53`).
+pub trait FromFalkorValue: Sized {
+    /// Convert `value` into `Self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FalkorDBError::TypeError`] if `value` is not the expected type (or, for the
+    /// narrower integer types, is out of range).
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self>;
+}
+
+/// The name of a [`FalkorValue`] variant, for error messages.
+pub(crate) fn variant_name(value: &FalkorValue) -> &'static str {
+    match value {
+        FalkorValue::Node(_) => "Node",
+        FalkorValue::Edge(_) => "Edge",
+        FalkorValue::Array(_) => "Array",
+        FalkorValue::Map(_) => "Map",
+        FalkorValue::Vec32(_) => "Vec32",
+        FalkorValue::String(_) => "String",
+        FalkorValue::Bool(_) => "Bool",
+        FalkorValue::I64(_) => "I64",
+        FalkorValue::F64(_) => "F64",
+        FalkorValue::Point(_) => "Point",
+        FalkorValue::Path(_) => "Path",
+        FalkorValue::None => "None",
+        FalkorValue::Unparseable(_) => "Unparseable",
+    }
+}
+
+fn type_error<T>(
+    expected: &'static str,
+    got: &FalkorValue,
+) -> FalkorResult<T> {
+    Err(FalkorDBError::TypeError {
+        expected,
+        got: variant_name(got),
+    })
+}
+
+impl FromFalkorValue for FalkorValue {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        Ok(value)
+    }
+}
+
+impl FromFalkorValue for i64 {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::I64(int) => Ok(int),
+            other => type_error("i64", &other),
+        }
+    }
+}
+
+macro_rules! impl_narrow_int_from_value {
+    ($($t:ty),* $(,)?) => {$(
+        impl FromFalkorValue for $t {
+            fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+                match value {
+                    FalkorValue::I64(int) => <$t>::try_from(int).map_err(|_| FalkorDBError::TypeError {
+                        expected: stringify!($t),
+                        got: "I64",
+                    }),
+                    other => type_error(stringify!($t), &other),
+                }
+            }
+        }
+    )*};
+}
+impl_narrow_int_from_value!(i8, i16, i32, u8, u16, u32, u64, usize, isize);
+
+impl FromFalkorValue for f64 {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::F64(float) => Ok(float),
+            // An i64 with magnitude up to 2^53 is exactly representable as f64, so widening it is
+            // lossless; larger integers would lose precision and are rejected instead.
+            FalkorValue::I64(int)
+                if (-F64_EXACT_INT_LIMIT..=F64_EXACT_INT_LIMIT).contains(&int) =>
+            {
+                Ok(int as f64)
+            }
+            other => type_error("f64", &other),
+        }
+    }
+}
+
+impl FromFalkorValue for bool {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::Bool(boolean) => Ok(boolean),
+            other => type_error("bool", &other),
+        }
+    }
+}
+
+impl FromFalkorValue for String {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::String(string) => Ok(string),
+            other => type_error("String", &other),
+        }
+    }
+}
+
+macro_rules! impl_entity_from_value {
+    ($($t:ty => $variant:ident => $name:literal),* $(,)?) => {$(
+        impl FromFalkorValue for $t {
+            fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+                match value {
+                    FalkorValue::$variant(entity) => Ok(entity),
+                    other => type_error($name, &other),
+                }
+            }
+        }
+    )*};
+}
+impl_entity_from_value!(
+    Node => Node => "Node",
+    Edge => Edge => "Edge",
+    Point => Point => "Point",
+    Path => Path => "Path",
+    Vec32 => Vec32 => "Vec32",
+);
+
+impl<T: FromFalkorValue> FromFalkorValue for Option<T> {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::None => Ok(None),
+            other => T::from_falkor_value(other).map(Some),
+        }
+    }
+}
+
+impl<T: FromFalkorValue> FromFalkorValue for Vec<T> {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::Array(items) => items.into_iter().map(T::from_falkor_value).collect(),
+            other => type_error("Vec", &other),
+        }
+    }
+}
+
+impl<T: FromFalkorValue> FromFalkorValue for HashMap<String, T> {
+    fn from_falkor_value(value: FalkorValue) -> FalkorResult<Self> {
+        match value {
+            FalkorValue::Map(map) => map
+                .into_iter()
+                .map(|(key, value)| Ok((key, T::from_falkor_value(value)?)))
+                .collect(),
+            other => type_error("Map", &other),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn convert<T: FromFalkorValue>(value: FalkorValue) -> FalkorResult<T> {
+        T::from_falkor_value(value)
+    }
+
+    #[test]
+    fn test_scalar_conversions() {
+        assert_eq!(convert::<i64>(FalkorValue::I64(7)).unwrap(), 7);
+        assert_eq!(convert::<f64>(FalkorValue::F64(2.5)).unwrap(), 2.5);
+        assert!(convert::<bool>(FalkorValue::Bool(true)).unwrap());
+        assert_eq!(
+            convert::<String>(FalkorValue::String("hi".into())).unwrap(),
+            "hi"
+        );
+        // identity
+        assert_eq!(
+            convert::<FalkorValue>(FalkorValue::I64(1)).unwrap(),
+            FalkorValue::I64(1)
+        );
+    }
+
+    #[test]
+    fn test_strict_no_coercion() {
+        // "true" is not a bool, F64 is not an i64.
+        assert!(convert::<bool>(FalkorValue::String("true".into())).is_err());
+        assert!(convert::<i64>(FalkorValue::F64(1.0)).is_err());
+    }
+
+    #[test]
+    fn test_f64_from_i64_lossless_only() {
+        // Exactly representable integers widen to f64...
+        assert_eq!(convert::<f64>(FalkorValue::I64(1)).unwrap(), 1.0);
+        assert_eq!(
+            convert::<f64>(FalkorValue::I64(F64_EXACT_INT_LIMIT)).unwrap(),
+            F64_EXACT_INT_LIMIT as f64
+        );
+        // ...but integers beyond 2^53 would lose precision and are rejected.
+        assert!(convert::<f64>(FalkorValue::I64(F64_EXACT_INT_LIMIT + 1)).is_err());
+        assert!(convert::<f64>(FalkorValue::I64(i64::MAX)).is_err());
+    }
+
+    #[test]
+    fn test_narrow_int_range_checked() {
+        assert_eq!(convert::<i32>(FalkorValue::I64(5)).unwrap(), 5);
+        assert_eq!(convert::<u32>(FalkorValue::I64(5)).unwrap(), 5);
+        assert!(convert::<i32>(FalkorValue::I64(i64::MAX)).is_err());
+        assert!(convert::<u32>(FalkorValue::I64(-1)).is_err());
+    }
+
+    #[test]
+    fn test_option_and_vec() {
+        assert_eq!(convert::<Option<i64>>(FalkorValue::None).unwrap(), None);
+        assert_eq!(
+            convert::<Option<i64>>(FalkorValue::I64(3)).unwrap(),
+            Some(3)
+        );
+        assert_eq!(
+            convert::<Vec<i64>>(FalkorValue::Array(vec![
+                FalkorValue::I64(1),
+                FalkorValue::I64(2)
+            ]))
+            .unwrap(),
+            vec![1, 2]
+        );
+        // element type mismatch propagates
+        assert!(convert::<Vec<i64>>(FalkorValue::Array(vec![FalkorValue::Bool(true)])).is_err());
+    }
+
+    #[test]
+    fn test_map_and_entities() {
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), FalkorValue::I64(1));
+        let converted: HashMap<String, i64> = convert(FalkorValue::Map(map)).unwrap();
+        assert_eq!(converted.get("a"), Some(&1));
+
+        assert!(convert::<Node>(FalkorValue::Node(Node::default())).is_ok());
+        assert!(convert::<Node>(FalkorValue::I64(1)).is_err());
+    }
+
+    #[test]
+    fn test_type_error_reports_variant() {
+        match convert::<i64>(FalkorValue::Bool(true)) {
+            Err(FalkorDBError::TypeError { expected, got }) => {
+                assert_eq!(expected, "i64");
+                assert_eq!(got, "Bool");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/src/value/from_value.rs
+++ b/src/value/from_value.rs
@@ -234,6 +234,14 @@ mod tests {
         assert_eq!(convert::<u32>(FalkorValue::I64(5)).unwrap(), 5);
         assert!(convert::<i32>(FalkorValue::I64(i64::MAX)).is_err());
         assert!(convert::<u32>(FalkorValue::I64(-1)).is_err());
+        // a non-integer value is a type error rather than a range error
+        assert_eq!(
+            convert::<u32>(FalkorValue::String("x".into())),
+            Err(FalkorDBError::TypeError {
+                expected: "u32",
+                got: "String"
+            })
+        );
     }
 
     #[test]
@@ -262,18 +270,54 @@ mod tests {
         let converted: HashMap<String, i64> = convert(FalkorValue::Map(map)).unwrap();
         assert_eq!(converted.get("a"), Some(&1));
 
+        // a non-map value reports the requested Rust type
+        assert_eq!(
+            convert::<HashMap<String, i64>>(FalkorValue::I64(1)),
+            Err(FalkorDBError::TypeError {
+                expected: "HashMap",
+                got: "I64"
+            })
+        );
+
         assert!(convert::<Node>(FalkorValue::Node(Node::default())).is_ok());
         assert!(convert::<Node>(FalkorValue::I64(1)).is_err());
     }
 
     #[test]
     fn test_type_error_reports_variant() {
-        match convert::<i64>(FalkorValue::Bool(true)) {
-            Err(FalkorDBError::TypeError { expected, got }) => {
-                assert_eq!(expected, "i64");
-                assert_eq!(got, "Bool");
-            }
-            other => panic!("unexpected: {other:?}"),
+        assert_eq!(
+            convert::<i64>(FalkorValue::Bool(true)),
+            Err(FalkorDBError::TypeError {
+                expected: "i64",
+                got: "Bool"
+            })
+        );
+    }
+
+    #[test]
+    fn test_variant_name_covers_every_variant() {
+        use crate::value::graph_entities::{Edge, Node};
+        use crate::value::path::Path;
+        use crate::value::point::Point;
+        use crate::value::vec32::Vec32;
+
+        let cases: [(FalkorValue, &str); 13] = [
+            (FalkorValue::Node(Node::default()), "Node"),
+            (FalkorValue::Edge(Edge::default()), "Edge"),
+            (FalkorValue::Array(vec![]), "Array"),
+            (FalkorValue::Map(HashMap::new()), "Map"),
+            (FalkorValue::Vec32(Vec32 { values: vec![] }), "Vec32"),
+            (FalkorValue::String(String::new()), "String"),
+            (FalkorValue::Bool(true), "Bool"),
+            (FalkorValue::I64(0), "I64"),
+            (FalkorValue::F64(0.0), "F64"),
+            (FalkorValue::Point(Point::default()), "Point"),
+            (FalkorValue::Path(Path::default()), "Path"),
+            (FalkorValue::None, "None"),
+            (FalkorValue::Unparseable(String::new()), "Unparseable"),
+        ];
+        for (value, name) in cases {
+            assert_eq!(variant_name(&value), name);
         }
     }
 }

--- a/src/value/from_value.rs
+++ b/src/value/from_value.rs
@@ -179,7 +179,7 @@ impl<T: FromFalkorValue> FromFalkorValue for HashMap<String, T> {
                 .into_iter()
                 .map(|(key, value)| Ok((key, T::from_falkor_value(value)?)))
                 .collect(),
-            other => type_error("Map", &other),
+            other => type_error("HashMap", &other),
         }
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -11,6 +11,7 @@ use std::{collections::HashMap, fmt::Debug};
 use vec32::Vec32;
 
 pub(crate) mod config;
+pub(crate) mod from_value;
 pub(crate) mod graph_entities;
 pub(crate) mod param;
 pub(crate) mod path;
@@ -27,6 +28,8 @@ mod de_proptest;
 mod param_proptest;
 
 pub use param::{to_cypher_param, FalkorParams, IntoFalkorParam, IntoFalkorParams, RawParam};
+
+pub use from_value::FromFalkorValue;
 
 #[cfg(feature = "serde")]
 pub use de::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -35,7 +35,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use falkordb::{
     EmbeddedConfig, EmbeddedServer, EntityType, FalkorClientBuilder, FalkorConnectionInfo,
-    FalkorValue, IndexType,
+    IndexType,
 };
 
 /// Common locations the module may live in, mirroring the client's own search list.
@@ -130,7 +130,7 @@ fn test_embedded_sync_full_surface() {
     let ages: Vec<i64> = res
         .data
         .by_ref()
-        .filter_map(|row| row.first().and_then(FalkorValue::to_i64))
+        .filter_map(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
         .collect();
     assert_eq!(ages, vec![40]);
 
@@ -142,7 +142,7 @@ fn test_embedded_sync_full_surface() {
     assert_eq!(
         ro.data
             .next()
-            .and_then(|row| row.first().and_then(FalkorValue::to_i64)),
+            .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
         Some(2)
     );
 
@@ -230,7 +230,7 @@ mod async_flavours {
             assert_eq!(
                 res.data
                     .next()
-                    .and_then(|row| row.first().and_then(FalkorValue::to_i64)),
+                    .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
                 Some(5),
                 "strategy {strategy:?} parameterized count"
             );
@@ -243,7 +243,7 @@ mod async_flavours {
             assert_eq!(
                 ro.data
                     .next()
-                    .and_then(|row| row.first().and_then(FalkorValue::to_i64)),
+                    .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
                 Some(10),
                 "strategy {strategy:?} read-only count"
             );
@@ -284,7 +284,7 @@ mod async_flavours {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
-                        .and_then(|row| row.first().and_then(FalkorValue::to_i64))
+                        .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
                         .expect("scalar result")
                 })
             })

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -130,7 +130,11 @@ fn test_embedded_sync_full_surface() {
     let ages: Vec<i64> = res
         .data
         .by_ref()
-        .filter_map(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
+        .map(|row| {
+            row.expect("row should parse")
+                .try_get_at::<i64>(0)
+                .expect("column 0 should be an i64")
+        })
         .collect();
     assert_eq!(ages, vec![40]);
 
@@ -139,12 +143,14 @@ fn test_embedded_sync_full_surface() {
         .ro_query("MATCH (p:Person) RETURN count(p)")
         .execute()
         .expect("read-only query should succeed");
-    assert_eq!(
-        ro.data
-            .next()
-            .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
-        Some(2)
-    );
+    let count = ro
+        .data
+        .next()
+        .expect("expected a row")
+        .expect("row should parse")
+        .try_get_at::<i64>(0)
+        .expect("column 0 should be an i64");
+    assert_eq!(count, 2);
 
     // Index create + asynchronous listing.
     graph
@@ -227,26 +233,28 @@ mod async_flavours {
                 .execute()
                 .await
                 .expect("parameterized query should succeed");
-            assert_eq!(
-                res.data
-                    .next()
-                    .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
-                Some(5),
-                "strategy {strategy:?} parameterized count"
-            );
+            let count = res
+                .data
+                .next()
+                .expect("expected a row")
+                .expect("row should parse")
+                .try_get_at::<i64>(0)
+                .expect("column 0 should be an i64");
+            assert_eq!(count, 5, "strategy {strategy:?} parameterized count");
 
             let mut ro = graph
                 .ro_query("MATCH (n:N) RETURN count(n)")
                 .execute()
                 .await
                 .expect("read-only query should succeed");
-            assert_eq!(
-                ro.data
-                    .next()
-                    .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok())),
-                Some(10),
-                "strategy {strategy:?} read-only count"
-            );
+            let count = ro
+                .data
+                .next()
+                .expect("expected a row")
+                .expect("row should parse")
+                .try_get_at::<i64>(0)
+                .expect("column 0 should be an i64");
+            assert_eq!(count, 10, "strategy {strategy:?} read-only count");
 
             graph.delete().await.expect("cleanup");
         }
@@ -284,8 +292,10 @@ mod async_flavours {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
-                        .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
-                        .expect("scalar result")
+                        .expect("expected a row")
+                        .expect("row should parse")
+                        .try_get_at::<i64>(0)
+                        .expect("column 0 should be an i64")
                 })
             })
             .collect();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -343,9 +343,11 @@ mod typed_params {
         let count = result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok());
-        assert_eq!(count, Some(2));
+            .expect("expected a row")
+            .expect("row should parse")
+            .try_get_at::<i64>(0)
+            .expect("column 0 should be an i64");
+        assert_eq!(count, 2);
         let _ = graph.delete();
     }
 
@@ -399,9 +401,11 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok());
-        assert_eq!(value, Some(42));
+            .expect("expected a row")
+            .expect("row should parse")
+            .try_get_at::<i64>(0)
+            .expect("column 0 should be an i64");
+        assert_eq!(value, 42);
         let _ = graph.delete();
     }
 
@@ -452,9 +456,11 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok());
-        assert_eq!(value, Some(7));
+            .expect("expected a row")
+            .expect("row should parse")
+            .try_get_at::<i64>(0)
+            .expect("column 0 should be an i64");
+        assert_eq!(value, 7);
         let _ = graph.delete();
     }
 
@@ -474,9 +480,11 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.ok())
-            .and_then(|row| row.try_get_at::<i64>(0).ok());
-        assert_eq!(value, Some(7));
+            .expect("expected a row")
+            .expect("row should parse")
+            .try_get_at::<i64>(0)
+            .expect("column 0 should be an i64");
+        assert_eq!(value, 7);
         let _ = graph.delete();
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -279,9 +279,13 @@ mod typed_params {
             .with_param("n", Option::<i64>::None)
             .execute()
             .expect("query should succeed");
-        let row = result.data.next().expect("expected a row");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
         assert_eq!(
-            row,
+            row.into_values(),
             vec![
                 FalkorValue::String("it's a \"test\"".to_string()),
                 FalkorValue::I64(42),
@@ -310,7 +314,11 @@ mod typed_params {
             .query("MATCH (t:Tag) RETURN t.name")
             .execute()
             .expect("read should succeed");
-        let row = result.data.next().expect("the node must still exist");
+        let row = result
+            .data
+            .next()
+            .expect("the node must still exist")
+            .expect("row should parse");
         assert_eq!(
             row.into_iter().next(),
             Some(FalkorValue::String(payload.to_string()))
@@ -335,8 +343,8 @@ mod typed_params {
         let count = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|v| v.to_i64());
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok());
         assert_eq!(count, Some(2));
         let _ = graph.delete();
     }
@@ -352,11 +360,12 @@ mod typed_params {
             .with_param("p", coords)
             .execute()
             .expect("point($p) workaround should succeed");
-        let value = result
+        let row = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .expect("expected a point");
+            .expect("expected a row")
+            .expect("row should parse");
+        let value = row.into_iter().next().expect("expected a point");
         assert!(matches!(value, FalkorValue::Point(_)));
         let _ = graph.delete();
     }
@@ -390,8 +399,8 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|v| v.to_i64());
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok());
         assert_eq!(value, Some(42));
         let _ = graph.delete();
     }
@@ -406,7 +415,11 @@ mod typed_params {
             .with_raw_param("v", "[1, 2, 3]")
             .execute()
             .expect("query should succeed");
-        let row = result.data.next().expect("expected a row");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
         assert_eq!(
             row.into_iter().next(),
             Some(FalkorValue::Array(vec![
@@ -439,8 +452,8 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|v| v.to_i64());
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok());
         assert_eq!(value, Some(7));
         let _ = graph.delete();
     }
@@ -461,8 +474,8 @@ mod typed_params {
         let value = result
             .data
             .next()
-            .and_then(|row| row.into_iter().next())
-            .and_then(|v| v.to_i64());
+            .and_then(|row| row.ok())
+            .and_then(|row| row.try_get_at::<i64>(0).ok());
         assert_eq!(value, Some(7));
         let _ = graph.delete();
     }
@@ -480,6 +493,107 @@ mod typed_params {
             result,
             Err(falkordb::FalkorDBError::ParamEncoding { .. })
         ));
+        let _ = graph.delete();
+    }
+}
+
+mod header_aware_rows {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{FalkorClientBuilder, FalkorDBError, FalkorResult, FalkorValue, Row};
+
+    fn graph_for(name: &str) -> Option<falkordb::SyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete();
+        Some(graph)
+    }
+
+    #[test]
+    fn test_row_by_alias_and_index() {
+        let Some(mut graph) = graph_for("test_rows_by_alias") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN 'Trinity' AS name, 37 AS age")
+            .execute()
+            .expect("query should succeed");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
+
+        // Header is preserved and shared.
+        assert_eq!(row.columns(), ["name", "age"]);
+
+        // By alias, typed.
+        assert_eq!(row.try_get::<String>("name").unwrap(), "Trinity");
+        assert_eq!(row.try_get::<i64>("age").unwrap(), 37);
+
+        // By index, typed and borrowing.
+        assert_eq!(row.try_get_at::<i64>(1).unwrap(), 37);
+        assert_eq!(
+            row.get_at(0),
+            Some(&FalkorValue::String("Trinity".to_string()))
+        );
+
+        // A wrong type is a TypeError, not a silent coercion.
+        assert!(matches!(
+            row.try_get::<i64>("name"),
+            Err(FalkorDBError::TypeError { .. })
+        ));
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_row_missing_column_errors() {
+        let Some(mut graph) = graph_for("test_rows_missing_column") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN 1 AS x")
+            .execute()
+            .expect("query should succeed");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
+
+        match row.try_get::<i64>("does_not_exist") {
+            Err(FalkorDBError::MissingColumn { name }) => assert_eq!(name, "does_not_exist"),
+            other => panic!("expected MissingColumn, got {other:?}"),
+        }
+        let _ = graph.delete();
+    }
+
+    #[test]
+    fn test_collect_rows_short_circuits_into_result() {
+        let Some(mut graph) = graph_for("test_rows_collect") else {
+            return;
+        };
+        let result = graph
+            .query("UNWIND range(1, 5) AS i RETURN i AS n ORDER BY i")
+            .execute()
+            .expect("query should succeed");
+
+        // The whole set collects into a single `FalkorResult<Vec<Row>>` (short-circuiting on Err).
+        let rows: Vec<Row> = result
+            .data
+            .collect::<FalkorResult<Vec<Row>>>()
+            .expect("all rows should parse");
+        let values: Vec<i64> = rows
+            .iter()
+            .map(|row| row.try_get_at::<i64>(0).unwrap())
+            .collect();
+        assert_eq!(values, vec![1, 2, 3, 4, 5]);
         let _ = graph.delete();
     }
 }
@@ -645,7 +759,11 @@ mod serde_typed_mapping {
             .execute()
             .expect("query should succeed");
 
-        let row = result.data.next().expect("expected a row");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
         let node = row.into_iter().next().expect("expected a node column");
         let movie: Movie = node.deserialize_into().expect("deserialize should succeed");
 
@@ -688,7 +806,11 @@ mod serde_typed_mapping {
             .execute()
             .expect("query should succeed");
 
-        let row = result.data.next().expect("expected a row");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
         let value = row.into_iter().next().expect("expected a column");
         let number: i64 = value
             .deserialize_into()

--- a/tests/multiplexing_parity.rs
+++ b/tests/multiplexing_parity.rs
@@ -131,7 +131,11 @@ async fn test_core_operations_under_all_strategies() {
         let ages: Vec<i64> = res
             .data
             .by_ref()
-            .filter_map(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
+            .map(|row| {
+                row.expect("row should parse")
+                    .try_get_at::<i64>(0)
+                    .expect("column 0 should be an i64")
+            })
             .collect();
         assert_eq!(ages, vec![40], "strategy {strategy:?} parameterized read");
 
@@ -144,8 +148,10 @@ async fn test_core_operations_under_all_strategies() {
         let count = ro
             .data
             .next()
-            .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
-            .expect("count result");
+            .expect("expected a row")
+            .expect("row should parse")
+            .try_get_at::<i64>(0)
+            .expect("column 0 should be an i64");
         assert_eq!(count, 2, "strategy {strategy:?} read-only count");
 
         graph.delete().await.expect("cleanup");
@@ -182,8 +188,10 @@ async fn test_high_concurrency_no_response_mismatch() {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
-                        .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
-                        .expect("scalar result")
+                        .expect("expected a row")
+                        .expect("row should parse")
+                        .try_get_at::<i64>(0)
+                        .expect("column 0 should be an i64")
                 })
             })
             .collect();
@@ -228,8 +236,10 @@ async fn test_pooled_multiplexed_behavioral_equivalence() {
             let mut res = graph.query(query).execute().await.expect("query");
             res.data
                 .next()
-                .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
-                .expect("scalar")
+                .expect("expected a row")
+                .expect("row should parse")
+                .try_get_at::<i64>(0)
+                .expect("column 0 should be an i64")
         }
     };
 

--- a/tests/multiplexing_parity.rs
+++ b/tests/multiplexing_parity.rs
@@ -16,9 +16,7 @@
 
 #![cfg(feature = "tokio")]
 
-use falkordb::{
-    ConnectionStrategy, FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo, FalkorValue,
-};
+use falkordb::{ConnectionStrategy, FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo};
 use std::num::NonZeroU8;
 
 fn skip_if_no_server() -> bool {
@@ -133,7 +131,7 @@ async fn test_core_operations_under_all_strategies() {
         let ages: Vec<i64> = res
             .data
             .by_ref()
-            .filter_map(|row| row.first().and_then(FalkorValue::to_i64))
+            .filter_map(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
             .collect();
         assert_eq!(ages, vec![40], "strategy {strategy:?} parameterized read");
 
@@ -146,7 +144,7 @@ async fn test_core_operations_under_all_strategies() {
         let count = ro
             .data
             .next()
-            .and_then(|row| row.first().and_then(FalkorValue::to_i64))
+            .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
             .expect("count result");
         assert_eq!(count, 2, "strategy {strategy:?} read-only count");
 
@@ -184,7 +182,7 @@ async fn test_high_concurrency_no_response_mismatch() {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
-                        .and_then(|row| row.first().and_then(FalkorValue::to_i64))
+                        .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
                         .expect("scalar result")
                 })
             })
@@ -230,7 +228,7 @@ async fn test_pooled_multiplexed_behavioral_equivalence() {
             let mut res = graph.query(query).execute().await.expect("query");
             res.data
                 .next()
-                .and_then(|row| row.first().and_then(FalkorValue::to_i64))
+                .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()))
                 .expect("scalar")
         }
     };


### PR DESCRIPTION
## What & why

The default result iterator (`QueryResult::data` / `LazyResultSet`) used to yield bare `Vec<FalkorValue>` rows and **silently swallow** a parse failure into a fake `[FalkorValue::Unparseable(..)]` row, while column names lived separately in `QueryResult::header` (related to values only by index). This fixes both warts:

- **Fallible iteration** — `data` now yields `FalkorResult<Row>`, so a bad row surfaces as an `Err` you can `?` or short-circuit with `collect::<FalkorResult<Vec<Row>>>()`.
- **Header-aware rows** — each `Row` carries the header, so you read columns **by name or index**, untyped or typed.

This is a breaking change (the item type changes), hence `feat!` → targets **0.7.0**.

## API

- `Row { … }` with `get` / `get_at` / `get_all` (borrowing), `try_get::<T>` / `try_get_at::<T>` (typed), `columns` / `len` / `is_empty`, `into_values` / `into_map`, `#[cfg(serde)] deserialize::<T>`, `IntoIterator`, and a public `FromIterator<(String, FalkorValue)>` for mocking/tests.
- `FromFalkorValue` — strict, fallible conversion trait (scalars, graph entities, `Option<T>`, `Vec<T>`, `HashMap<String, T>`, identity). No silent lossy casts; the one widening allowed is `i64` → `f64` within `±2^53`. Mismatches return `TypeError { expected, got }`.
- `LazyResultSet::into_values_lossy()` — opt-in escape hatch reproducing the pre-0.7 `Vec<FalkorValue>` behavior.
- `QueryResult::header` is now `Arc<[String]>` (shared cheaply with every row).
- New `FalkorDBError` variants: `MissingColumn`, `ColumnIndexOutOfBounds`, `RowShapeMismatch`, `TypeError`.
- `query_as` converges on `Row::deserialize`; `from_falkor_row`'s single-column unwrap is keyed on header length so a shape mismatch can't be masked.

## Migration

| Before (≤ 0.6) | After (0.7) |
| --- | --- |
| `for row in result.data { /* Vec<FalkorValue> */ }` | `for row in result.data { let row = row?; /* Row */ }` |
| `&row[i]` / `row.into_iter()` | `row.get_at(i)` / `row.into_values()` |
| align by header index by hand | `row.try_get::<T>("alias")` |
| silently swallowed `Unparseable` | a real `Err` you `?`/handle |
| old lossy `Vec<FalkorValue>` rows | `result.data.into_values_lossy()` |
| `result.header: Vec<String>` | `result.header: Arc<[String]>` (`&result.header[..]` still works) |

## Tests & docs

- Unit tests for `Row` (accessors, dup-column first-wins/`get_all`/last-wins, missing-vs-null, type errors, bounds) and `FromFalkorValue` (every type, range-checked ints, lossless `f64`-from-`i64`).
- New `row_proptest` property tests (try_get never panics, first-match/last-wins, columns/values round-trip) + tightened `de_proptest`.
- Server-backed integration tests (`header_aware_rows`: by-alias/index, missing-column error, `collect` short-circuit) + sync/async `query_as` still pass.
- README "Header-aware result rows" section, runnable doc tests on a hand-built `Row`, `examples/rows.rs`, and CHANGELOG migration table.

Validated locally: `cargo fmt`, `clippy --all-targets --features tokio,embedded,serde -D warnings`, doc + doctests, `cargo deny`, spellcheck, full server-backed test suite, and all examples run.

🤖 Reviewed by a rubber-duck pass (no blocking issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Query results now support header-aware row parsing with typed column access by name and position.

* **Breaking Changes**
  * Query result iteration now returns fallible rows requiring explicit error handling.

* **Documentation**
  * Added version 0.7 migration guide for upgrading query result handling.
  * Updated examples demonstrating new result-access API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->