### PR TITLE
feat!: async-native streaming results (Stream<Item = FalkorResult<Row>>)

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -144,3 +144,4 @@ param
 BTreeMap
 coords
 dereferences
+combinators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [**breaking**] async-native streaming results: on the async client, `QueryResult::data` is now a
+  `RowStream` — an owned `Stream<Item = FalkorResult<Row>>` that is `Send + 'static`. It can be
+  moved into a spawned task and driven with the full `futures::StreamExt` / `TryStreamExt` toolbox
+  (`.next().await`, `.try_collect().await`, `.map(..).buffer_unordered(n)`, etc.). With `serde`,
+  `query_as::<T>()` yields a `TypedRowStream<T>` (a `Stream<Item = FalkorResult<T>>`).
+- `RowStream::into_values_lossy`: opt-in escape hatch yielding `Vec<FalkorValue>` rows (mirrors the
+  sync `LazyResultSet::into_values_lossy`).
+
+### Changed
+
+- **Not backward compatible (async only):** the async result iterator is now a `Stream`, not an
+  `Iterator`. Pulling rows requires `.await` plus the relevant extension trait in scope
+  (`use futures::StreamExt;` / `use futures::TryStreamExt;`). The synchronous client is unchanged
+  (`LazyResultSet` is still a fallible `Iterator`). See the
+  **[0.8 migration guide](docs/migrating-to-0.8.md)** for step-by-step upgrade instructions.
+  Quick reference:
+
+  | Before (≤ 0.7, async) | After (0.8, async) |
+  | --- | --- |
+  | `while let Some(row) = result.data.next() {` | `while let Some(row) = result.data.next().await {` (with `use futures::StreamExt;`) |
+  | `result.data.collect::<FalkorResult<Vec<_>>>()` | `result.data.try_collect::<Vec<_>>().await` (with `use futures::TryStreamExt;`) |
+  | wrap the graph in `Arc<Mutex<_>>` to share across tasks | clone the graph (cheap; shares the schema cache) |
+  | `let result = graph.query(..).execute().await?;` borrowed the graph for the result's lifetime | the `RowStream` is owned (`Send + 'static`); move it into a task freely |
+
+- **Not backward compatible (async only):** `AsyncGraph` now holds its schema cache behind a shared
+  handle, so cloning an `AsyncGraph` shares one schema cache (previously each clone was independent).
+  This makes concurrent streams from clones consistent and is what lets a cloned handle be used from
+  a spawned task without `Arc<Mutex<_>>`.
+
+
 ## [0.7.0](https://github.com/FalkorDB/falkordb-rs/compare/v0.6.0...v0.7.0) - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,8 @@ version = "0.7.0"
 dependencies = [
  "approx",
  "criterion",
+ "futures",
+ "futures-core",
  "libc",
  "parking_lot",
  "proptest",
@@ -490,6 +492,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -513,10 +516,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -536,9 +561,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 [lib]
 
 [dependencies]
+futures-core = { version = "0.3", default-features = false, optional = true }
 parking_lot = { version = "0.12.5", default-features = false }
 redis = { version = "1.2.2", default-features = false, features = ["sentinel"] }
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
@@ -31,6 +32,7 @@ which = { version = "8.0", optional = true }
 [dev-dependencies]
 approx = "0.5.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
+futures = "0.3"
 proptest = "1"
 serde_json = "1"
 
@@ -53,7 +55,7 @@ default = []
 native-tls = ["redis/tls-native-tls"]
 rustls = ["redis/tls-rustls"]
 
-tokio = ["dep:tokio", "redis/tokio-comp", "redis/connection-manager"]
+tokio = ["dep:tokio", "dep:futures-core", "redis/tokio-comp", "redis/connection-manager"]
 tokio-native-tls = ["tokio", "redis/tokio-native-tls-comp"]
 tokio-rustls = ["tokio", "redis/tokio-rustls-comp"]
 
@@ -70,6 +72,10 @@ name = "basic_usage"
 
 [[example]]
 name = "async_api"
+required-features = ["tokio"]
+
+[[example]]
+name = "async_stream"
 required-features = ["tokio"]
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The API uses an almost identical API, but the various functions need to be await
 
 ```rust,ignore
 use falkordb::{FalkorClientBuilder, FalkorConnectionInfo};
+use futures::StreamExt; // brings `.next().await` onto the result stream
 
 // Connect to FalkorDB
 let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()
@@ -258,16 +259,67 @@ let mut nodes = graph.query("UNWIND range(0, 100) AS i CREATE (n { v:1 }) RETURN
             .await
             .expect("Failed executing query");
 
-// Graph operations are asynchronous, but parsing is still concurrent:
-while let Some(row) = nodes.data.next() {
+// `nodes.data` is a `Stream<Item = FalkorResult<Row>>`; pull rows with `.next().await`:
+while let Some(row) = nodes.data.next().await {
      let row = row.expect("row failed to parse");
      println!("{:?}", row.get_at(0));
 }
 ```
 
-Note that thread safety is still up to the user to ensure, I.e. an `AsyncGraph` cannot simply be sent to a task spawned
-by tokio and expected to be used later,
-it must be wrapped in an Arc<Mutex<_>> or something similar.
+The result set (`nodes.data`) is an owned, `Send + 'static` `Stream`, so it can be moved into a
+spawned task and driven with the full `StreamExt` / `TryStreamExt` toolbox. The graph
+handle itself is `Send + Clone`: cloning is cheap and **shares one schema cache**, so to use a graph
+from several concurrent tasks you just clone it — no `Arc<Mutex<_>>` wrapping required.
+
+### Async streaming
+
+Because results are a `Stream`, the standard combinators just work. Import the extension traits
+(`use futures::{StreamExt, TryStreamExt};`) and:
+
+```rust,ignore
+use futures::{StreamExt, TryStreamExt};
+// Collect a typed stream in one line (errors short-circuit):
+let years: Vec<i64> = graph
+    .query("MATCH (m:Movie) RETURN m.year AS year ORDER BY year")
+    .execute()
+    .await?
+    .data
+    .map(|row| row?.try_get::<i64>("year"))
+    .try_collect()
+    .await?;
+// Move a result stream into its own task (it is `Send + 'static`):
+let mut stream = graph.query("MATCH (n) RETURN n").execute().await?.data;
+let count = tokio::spawn(async move {
+    let mut n = 0usize;
+    while let Some(row) = stream.next().await {
+        row?;
+        n += 1;
+    }
+    Ok::<_, falkordb::FalkorDBError>(n)
+})
+.await
+.unwrap()?;
+// Fan out a follow-up query per row with bounded concurrency, over cloned handles:
+let enriched: Vec<i64> = graph
+    .query("MATCH (m:Movie) RETURN m.year AS year")
+    .execute()
+    .await?
+    .data
+    .map(|row| {
+        let mut g = graph.clone(); // cheap; shares the schema cache
+        async move {
+            let year: i64 = row?.try_get("year")?;
+            let mut r = g.query(format!("RETURN {year} + 1 AS next")).execute().await?;
+            r.data.try_next().await?.expect("a row").try_get::<i64>("next")
+        }
+    })
+    .buffer_unordered(8)
+    .try_collect()
+    .await?;
+```
+
+A runnable version lives in [`examples/async_stream.rs`](examples/async_stream.rs).
+
 
 ### Connection Strategy and Multiplexing
 
@@ -285,7 +337,7 @@ The asynchronous client chooses how it manages its underlying Redis connections 
 
 Select or tune the strategy on the builder:
 
-```rust,no_run
+```no_run
 use falkordb::{ConnectionStrategy, FalkorClientBuilder};
 use std::num::NonZeroU8;
 

--- a/docs/migrating-to-0.8.md
+++ b/docs/migrating-to-0.8.md
@@ -88,7 +88,7 @@ let rows: Vec<Row> = result.data.try_collect().await?;
 Mapping each row to a typed value composes the same way:
 
 ```rust
-use futures::TryStreamExt;
+use futures::{StreamExt, TryStreamExt};
 
 let titles: Vec<String> = result
     .data
@@ -187,10 +187,8 @@ errors collapsed to a single `FalkorValue::Unparseable`) if you are not ready to
 `Row` values:
 
 ```rust
-use futures::StreamExt;
-
-let mut rows = result.data.into_values_lossy();
-while let Some(row) = rows.next().await {
+// `into_values_lossy()` returns a plain `Iterator`, so iterate it synchronously (no `.await`).
+for row in result.data.into_values_lossy() {
     // row: Vec<FalkorValue>
 }
 ```

--- a/docs/migrating-to-0.8.md
+++ b/docs/migrating-to-0.8.md
@@ -1,0 +1,206 @@
+# Migrating to 0.8
+
+Version 0.8 makes **async** query results stream-native. On the async client, `QueryResult::data`
+is now a `Stream` (`RowStream`) instead of an `Iterator`, so it composes with the
+`StreamExt` / `TryStreamExt` ecosystem, is `Send + 'static`, and can be moved into a
+spawned task. The **synchronous** client is unchanged.
+
+If you are upgrading from 0.6 or earlier you will also cross the 0.7 header-aware-row change; see
+[Coming from 0.7 or earlier](#coming-from-07-or-earlier) at the end.
+
+## Why it changed
+
+The async result set used to be an `Iterator`, which forced two awkward patterns:
+
+- **You could not use the async ecosystem.** Driving results meant a blocking-style `while let
+  Some(row) = data.next()` loop; you could not `.try_collect().await`, fan out with
+  `.buffer_unordered(n)`, or otherwise compose with `futures`/`tokio` combinators.
+- **Sharing a graph across tasks needed `Arc<Mutex<_>>`.** The result borrowed the graph, and an
+  `AsyncGraph` could not be moved into a spawned task, so concurrent work required wrapping the
+  handle in `Arc<Mutex<_>>`.
+
+Making `data` a `RowStream` (an owned `Stream<Item = FalkorResult<Row>>` that is `Send + 'static`)
+solves both: results compose with `StreamExt`/`TryStreamExt`, and because cloning an `AsyncGraph`
+now shares one schema cache, you clone the handle to use it from several tasks — no `Arc<Mutex<_>>`.
+
+## At a glance (async client)
+
+| Before (≤ 0.7, async) | After (0.8, async) |
+| --- | --- |
+| `while let Some(row) = result.data.next() {` | `while let Some(row) = result.data.next().await {` (with `use futures::StreamExt;`) |
+| `result.data.collect::<FalkorResult<Vec<_>>>()` | `result.data.try_collect::<Vec<_>>().await` (with `use futures::TryStreamExt;`) |
+| `result.data.map(..).collect::<Result<_,_>>()` | `result.data.map(..).try_collect().await` |
+| wrap the graph in `Arc<Mutex<_>>` to share across tasks | clone the graph (cheap; shares the schema cache) |
+| the result borrowed the graph for its lifetime | the `RowStream` is owned (`Send + 'static`); move it into a task |
+| async `query_as::<T>()` → typed `Iterator` | async `query_as::<T>()` → `TypedRowStream<T>` (a `Stream`) |
+
+> The synchronous client is **not** affected: `LazyResultSet` is still a fallible
+> `Iterator<Item = FalkorResult<Row>>`, and synchronous code needs no changes for 0.8.
+
+## 1. Iterating async results
+
+`data` is now a `Stream`, so pulling rows needs `.await` and the `StreamExt` extension trait in
+scope.
+
+Before:
+
+```rust
+let mut result = graph.query("MATCH (m:Movie) RETURN m.title AS title").execute().await?;
+while let Some(row) = result.data.next() {
+    let row = row?;
+    let title: String = row.try_get("title")?;
+    println!("{title}");
+}
+```
+
+After:
+
+```rust
+use futures::StreamExt; // brings `.next().await`
+
+let mut result = graph.query("MATCH (m:Movie) RETURN m.title AS title").execute().await?;
+while let Some(row) = result.data.next().await {
+    let row = row?;
+    let title: String = row.try_get("title")?;
+    println!("{title}");
+}
+```
+
+## 2. Collecting a whole async result set
+
+Use `TryStreamExt::try_collect`, which short-circuits on the first `Err` just like the old
+`collect::<FalkorResult<Vec<_>>>()`.
+
+Before:
+
+```rust
+let rows: Vec<Row> = result.data.collect::<FalkorResult<Vec<Row>>>()?;
+```
+
+After:
+
+```rust
+use futures::TryStreamExt;
+
+let rows: Vec<Row> = result.data.try_collect().await?;
+```
+
+Mapping each row to a typed value composes the same way:
+
+```rust
+use futures::TryStreamExt;
+
+let titles: Vec<String> = result
+    .data
+    .map(|row| row?.try_get::<String>("title"))
+    .try_collect()
+    .await?;
+```
+
+## 3. The result stream is owned and `Send + 'static`
+
+A `RowStream` no longer borrows the graph, so you can move it into a spawned task:
+
+```rust
+use futures::StreamExt;
+
+let mut stream = graph.query("MATCH (n) RETURN n").execute().await?.data;
+let count = tokio::spawn(async move {
+    let mut n = 0usize;
+    while let Some(row) = stream.next().await {
+        row?;
+        n += 1;
+    }
+    Ok::<_, falkordb::FalkorDBError>(n)
+})
+.await
+.unwrap()?;
+```
+
+## 4. Share a graph across tasks by cloning (no more `Arc<Mutex<_>>`)
+
+Cloning an `AsyncGraph` is cheap and **shares one schema cache**, so concurrent tasks stay
+consistent. Clone the handle into each unit of work instead of wrapping it in `Arc<Mutex<_>>`:
+
+```rust
+use futures::{StreamExt, TryStreamExt};
+
+let enriched: Vec<i64> = graph
+    .query("MATCH (m:Movie) RETURN m.year AS year")
+    .execute()
+    .await?
+    .data
+    .map(|row| {
+        let mut g = graph.clone(); // shares the schema cache
+        async move {
+            let year: i64 = row?.try_get("year")?;
+            let mut r = g.query(format!("RETURN {year} + 1 AS next")).execute().await?;
+            r.data.try_next().await?.expect("a row").try_get::<i64>("next")
+        }
+    })
+    .buffer_unordered(8)
+    .try_collect()
+    .await?;
+```
+
+Query methods still take `&mut self`, so a single task drives one query at a time on a given handle;
+concurrency comes from cloning the handle (each clone can run a query independently while sharing the
+schema cache). A runnable end-to-end example lives in
+[`examples/async_stream.rs`](../examples/async_stream.rs).
+
+## 5. Typed mapping with `serde` (`query_as`) is now a stream
+
+On the async client, `query_as::<T>()` yields a `TypedRowStream<T>` — a
+`Stream<Item = FalkorResult<T>>`. Collect it with `try_collect().await`:
+
+Before:
+
+```rust
+let movies: Vec<Movie> = graph
+    .query("MATCH (m:Movie) RETURN m")
+    .query_as::<Movie>()
+    .execute()
+    .await?
+    .data
+    .collect::<Result<_, _>>()?;
+```
+
+After:
+
+```rust
+use futures::TryStreamExt;
+
+let movies: Vec<Movie> = graph
+    .query("MATCH (m:Movie) RETURN m")
+    .query_as::<Movie>()
+    .execute()
+    .await?
+    .data
+    .try_collect()
+    .await?;
+```
+
+## 6. Keeping `Vec<FalkorValue>` rows (escape hatch)
+
+As with the sync client, `RowStream::into_values_lossy()` yields `Vec<FalkorValue>` rows (parse
+errors collapsed to a single `FalkorValue::Unparseable`) if you are not ready to adopt header-aware
+`Row` values:
+
+```rust
+use futures::StreamExt;
+
+let mut rows = result.data.into_values_lossy();
+while let Some(row) = rows.next().await {
+    // row: Vec<FalkorValue>
+}
+```
+
+Prefer migrating to `Row`; this is a temporary bridge.
+
+## Coming from 0.7 or earlier
+
+Upgrading from 0.6 or earlier also crosses the **0.7** header-aware-row change (`data` yields
+`FalkorResult<Row>` instead of `Vec<FalkorValue>`). The row-level steps are identical for the sync
+and async clients; only the iteration mechanism differs (async needs `.await` + `StreamExt`). See
+the **[0.7 migration guide](migrating-to-0.7.md)** for the row API, then apply the async changes
+above.

--- a/examples/async_api.rs
+++ b/examples/async_api.rs
@@ -4,8 +4,8 @@
  */
 
 use falkordb::{FalkorClientBuilder, FalkorResult};
-use std::sync::Arc;
-use tokio::{sync::Mutex, task::JoinSet};
+use futures::{StreamExt, TryStreamExt};
+use tokio::task::JoinSet;
 
 // Usage of the asynchronous client REQUIRES the multi-threaded rt
 #[tokio::main]
@@ -16,55 +16,41 @@ async fn main() -> FalkorResult<()> {
         .await?;
 
     let mut graph = client.select_graph("imdb");
-    let mut res = graph.query("MATCH (a:actor) return a").execute().await?;
+    let mut res = graph.query("MATCH (a:actor) RETURN a").execute().await?;
     assert_eq!(res.data.len(), 1317);
 
-    // Note that parsing is sync, even if a refresh of the graph schema was required, that refresh will happen in a blocking fashion
-    // The alternative is writing all the parsing functions to be async, all the way down
-    assert!(res.data.next().is_some());
-    let collected = res.data.collect::<Vec<_>>();
-
-    // One was already taken, so we should have one less now
+    // `res.data` is a `futures::Stream`. Take one row with `StreamExt::next`, then collect the
+    // rest. (Parsing is synchronous; if a cold schema refresh is needed it happens in a blocking
+    // fashion — see the `RowStream` docs. The alternative is async parsing all the way down.)
+    assert!(res.data.next().await.is_some());
+    let collected: Vec<_> = res.data.collect().await;
     assert_eq!(collected.len(), 1316);
 
-    // And now for something completely different:
-    // Add synchronization, if we want to reuse the graph later,
-    // Otherwise we can just move it into the scope
-    let graph_a = Arc::new(Mutex::new(client.copy_graph("imdb", "imdb_a").await?));
-    let graph_b = Arc::new(Mutex::new(client.copy_graph("imdb", "imdb_b").await?));
-    let graph_c = Arc::new(Mutex::new(client.copy_graph("imdb", "imdb_c").await?));
-    let graph_d = Arc::new(Mutex::new(client.copy_graph("imdb", "imdb_d").await?));
-
-    // Note that in each of the tasks, we have to consume the LazyResultSet somehow, and not return it, because it maintains a mutable reference to graph, and requires the lock guard to be alive
-    // By collecting it into a vec, we no longer need to maintain the lifetime, so we just get back our results
+    // The graph handle is `Send + Clone` and shares its schema cache, so concurrent tasks just take
+    // an owned copy — no `Arc<Mutex<_>>` needed. The owned `RowStream` result is `Send + 'static`,
+    // so it can be consumed (here folded into a count) entirely inside the spawned task.
     let mut join_set = JoinSet::new();
-    join_set.spawn({
-        let graph_a = graph_a.clone();
-        async move { graph_a.lock().await.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().await.map(|res| res.data.collect::<Vec<_>>()) }
-    });
-    join_set.spawn({
-        let graph_b = graph_b.clone();
-        async move { graph_b.lock().await.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().await.map(|res| res.data.collect::<Vec<_>>()) }
-    });
-    join_set.spawn({
-        let graph_c = graph_c.clone();
-        async move { graph_c.lock().await.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().await.map(|res| res.data.collect::<Vec<_>>()) }
-    });
-    join_set.spawn({
-        let graph_d = graph_d.clone();
-        async move { graph_d.lock().await.query("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().await.map(|res| res.data.collect::<Vec<_>>()) }
-    });
-
-    // Order is no longer guaranteed, as all these tasks were nonblocking
-    while let Some(Ok(res)) = join_set.join_next().await {
-        let actual_res = res?;
-        println!("{:?}", actual_res[0])
+    for suffix in ["a", "b", "c", "d"] {
+        let name = format!("imdb_{suffix}");
+        let mut copy = client.copy_graph("imdb", &name).await?;
+        join_set.spawn(async move {
+            let count = copy
+                .query("MATCH (a:actor) RETURN a LIMIT 100")
+                .execute()
+                .await?
+                .data
+                .try_fold(0usize, |acc, _row| async move { Ok(acc + 1) })
+                .await?;
+            copy.delete().await.ok();
+            FalkorResult::Ok((name, count))
+        });
     }
 
-    graph_a.lock().await.delete().await.ok();
-    graph_b.lock().await.delete().await.ok();
-    graph_c.lock().await.delete().await.ok();
-    graph_d.lock().await.delete().await.ok();
+    // Order is not guaranteed — the tasks ran concurrently over cloned handles.
+    while let Some(joined) = join_set.join_next().await {
+        let (name, count) = joined.expect("task should not panic")?;
+        println!("{name}: {count} actors");
+    }
 
     Ok(())
 }

--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Async streaming results with `futures::StreamExt` / `TryStreamExt`.
+//!
+//! Run with: `cargo run --example async_stream --features tokio`
+//!
+//! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
+
+use falkordb::{FalkorClientBuilder, FalkorResult};
+use futures::{StreamExt, TryStreamExt};
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> FalkorResult<()> {
+    let client = FalkorClientBuilder::new_async()
+        .with_connection_info("falkor://127.0.0.1:6379".try_into()?)
+        .build()
+        .await?;
+    let mut graph = client.select_graph("async_stream_example");
+    let _ = graph.delete().await;
+
+    graph
+        .query("UNWIND range(1, 5) AS i CREATE (:Movie {year: 1990 + i})")
+        .execute()
+        .await?;
+
+    // ── 1. Collect a whole typed stream in one line ─────────────────────────
+    // `data` is a `Stream`; map each row to a typed value and `try_collect`.
+    let years: Vec<i64> = graph
+        .query("MATCH (m:Movie) RETURN m.year AS year ORDER BY year")
+        .execute()
+        .await?
+        .data
+        .map(|row| row?.try_get::<i64>("year"))
+        .try_collect()
+        .await?;
+    println!("years: {years:?}");
+
+    // ── 2. Fan out a follow-up query per row, with bounded concurrency ──────
+    // The graph handle is `Send + Clone` (it shares one schema cache), so each unit of work just
+    // clones it. `buffer_unordered` keeps at most 8 follow-up queries in flight at once.
+    let mut next_years: Vec<i64> = graph
+        .query("MATCH (m:Movie) RETURN m.year AS year")
+        .execute()
+        .await?
+        .data
+        .map(|row| {
+            let mut g = graph.clone();
+            async move {
+                let year: i64 = row?.try_get("year")?;
+                let mut r = g
+                    .query(format!("RETURN {year} + 1 AS next"))
+                    .execute()
+                    .await?;
+                r.data
+                    .try_next()
+                    .await?
+                    .expect("a row")
+                    .try_get::<i64>("next")
+            }
+        })
+        .buffer_unordered(8)
+        .try_collect()
+        .await?;
+    next_years.sort_unstable();
+    println!("next years: {next_years:?}");
+
+    graph.delete().await?;
+    Ok(())
+}

--- a/examples/multiplexed_async.rs
+++ b/examples/multiplexed_async.rs
@@ -11,6 +11,7 @@
 //! `cargo run --example multiplexed_async --features tokio`.
 
 use falkordb::{ConnectionStrategy, FalkorClientBuilder, FalkorResult};
+use futures::StreamExt;
 use std::num::NonZeroU8;
 use std::sync::Arc;
 use tokio::task::JoinSet;
@@ -48,6 +49,7 @@ async fn main() -> FalkorResult<()> {
             let value = res
                 .data
                 .next()
+                .await
                 .and_then(|row| row.ok().and_then(|r| r.try_get_at::<i64>(0).ok()));
             FalkorResult::Ok((i, value))
         });

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -594,6 +594,7 @@ mod tests {
         },
         FalkorClientBuilder,
     };
+    use futures::StreamExt;
     use std::{
         mem,
         num::{NonZeroU8, NonZeroUsize},
@@ -643,7 +644,7 @@ mod tests {
             .await
             .expect("Could not read over the multiplexed client");
         assert!(
-            result.data.next().is_some(),
+            result.data.next().await.is_some(),
             "Expected the multiplexed read-only query to return a row"
         );
         graph.delete().await.ok();
@@ -827,7 +828,7 @@ mod tests {
             .await
             .expect("Could not read Jane via ro_query");
         assert!(
-            result.data.next().is_some(),
+            result.data.next().await.is_some(),
             "Expected the read-only query to return Jane"
         );
 
@@ -975,7 +976,7 @@ mod tests {
             .await
             .expect("Could not get actors from unmodified graph");
 
-        assert_eq!(res.data.collect::<Vec<_>>().len(), 1317);
+        assert_eq!(res.data.collect::<Vec<_>>().await.len(), 1317);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -990,7 +991,8 @@ mod tests {
             .await
             .expect("Could not get actors from unmodified graph")
             .data
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .await;
 
         // Ensure the copied graph is cleaned up even if an assertion panics,
         // so leftover state cannot interfere with other parallel tests.
@@ -1022,6 +1024,7 @@ mod tests {
                     .expect("Could not get actors from copied graph")
                     .data
                     .collect::<Vec<_>>()
+                    .await
             },
             |rows| rows == &expected,
         )
@@ -1041,7 +1044,8 @@ mod tests {
             .await
             .expect("Could not get actors from unmodified graph")
             .data
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .await;
 
         let _copy_guard = TestAsyncGraphHandle {
             inner: client.select_graph("imdb_op_copy_async_wait"),
@@ -1069,6 +1073,7 @@ mod tests {
                     .expect("Could not get actors from copied graph")
                     .data
                     .collect::<Vec<_>>()
+                    .await
             },
             |rows| rows == &expected,
         )
@@ -1103,7 +1108,8 @@ mod tests {
                         .execute()
                         .await?
                         .data
-                        .collect::<Vec<_>>(),
+                        .collect::<Vec<_>>()
+                        .await,
                 )
             },
             |rows| matches!(rows, Ok(rows) if !rows.is_empty()),

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -5,24 +5,24 @@
 
 use crate::{
     client::asynchronous::FalkorAsyncClientInner,
-    graph::HasGraphSchema,
     graph::{generate_create_index_query, generate_drop_index_query},
     parser::redis_value_as_vec,
     Constraint, ConstraintType, EntityType, ExecutionPlan, FalkorIndex, FalkorResult, GraphSchema,
-    IndexType, LazyResultSet, ProcedureQueryBuilder, QueryBuilder, QueryResult, SlowlogEntry,
+    IndexType, ProcedureQueryBuilder, QueryBuilder, QueryResult, RowStream, SlowlogEntry,
 };
+use parking_lot::RwLock;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 /// The main graph API, this allows the user to perform graph operations while exposing as little details as possible.
-/// # Thread Safety
-/// This struct is NOT thread safe, and synchronization is up to the user.
-/// It does, however, allow the user to perform nonblocking operations
-/// Graph schema is not shared between instances of AsyncGraph, even with the same name, but cloning will maintain the current schema
+/// # Cloning &amp; sharing
+/// `AsyncGraph` is a cheap `Send + Clone` handle: cloning bumps a few `Arc`s and **shares one
+/// schema cache** between the clones, so it is safe to `clone()` per task instead of wrapping the
+/// graph in an `Arc<Mutex<_>>`. Each clone still drives queries with `&mut self`.
 #[derive(Clone)]
 pub struct AsyncGraph {
     client: Arc<FalkorAsyncClientInner>,
     graph_name: String,
-    graph_schema: GraphSchema,
+    graph_schema: Arc<RwLock<GraphSchema>>,
 }
 
 impl AsyncGraph {
@@ -32,7 +32,7 @@ impl AsyncGraph {
     ) -> Self {
         Self {
             graph_name: graph_name.to_string(),
-            graph_schema: GraphSchema::new(graph_name, client.clone()), // Required for requesting refreshes
+            graph_schema: Arc::new(RwLock::new(GraphSchema::new(graph_name, client.clone()))), // Required for requesting refreshes
             client,
         }
     }
@@ -47,6 +47,12 @@ impl AsyncGraph {
 
     pub(crate) fn get_client(&self) -> &Arc<FalkorAsyncClientInner> {
         &self.client
+    }
+
+    /// A cheap clone of the shared schema-cache handle. Cloned `AsyncGraph`s share one cache, and
+    /// each query takes the write lock to parse its reply (and refresh the schema on a cache miss).
+    pub(crate) fn schema_handle(&self) -> Arc<RwLock<GraphSchema>> {
+        self.graph_schema.clone()
     }
 
     #[cfg_attr(
@@ -74,7 +80,7 @@ impl AsyncGraph {
     )]
     pub async fn delete(&mut self) -> FalkorResult<()> {
         self.execute_command("GRAPH.DELETE", None, None).await?;
-        self.graph_schema.clear();
+        self.graph_schema.write().clear();
         Ok(())
     }
 
@@ -146,7 +152,7 @@ impl AsyncGraph {
     pub fn query<T: Display>(
         &mut self,
         query_string: T,
-    ) -> QueryBuilder<QueryResult<LazyResultSet>, T, Self> {
+    ) -> QueryBuilder<QueryResult<RowStream>, T, Self> {
         QueryBuilder::new(self, "GRAPH.QUERY", query_string)
     }
 
@@ -162,7 +168,7 @@ impl AsyncGraph {
     pub fn ro_query<'a>(
         &'a mut self,
         query_string: &'a str,
-    ) -> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, &'a str, Self> {
+    ) -> QueryBuilder<'a, QueryResult<RowStream>, &'a str, Self> {
         QueryBuilder::new(self, "GRAPH.RO_QUERY", query_string)
     }
 
@@ -222,7 +228,7 @@ impl AsyncGraph {
     /// * `options`:
     ///
     /// # Returns
-    /// A [`LazyResultSet`] containing information on the created index
+    /// A [`RowStream`](crate::RowStream) containing information on the created index
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "Graph Create Index", skip_all, level = "info")
@@ -234,18 +240,14 @@ impl AsyncGraph {
         label: &str,
         properties: &[P],
         options: Option<&HashMap<String, String>>,
-    ) -> FalkorResult<QueryResult<LazyResultSet>> {
+    ) -> FalkorResult<QueryResult<RowStream>> {
         // Create index from these properties
         let query_str =
             generate_create_index_query(index_field_type, entity_type, label, properties, options);
 
-        QueryBuilder::<QueryResult<LazyResultSet>, String, Self>::new(
-            self,
-            "GRAPH.QUERY",
-            query_str,
-        )
-        .execute()
-        .await
+        QueryBuilder::<QueryResult<RowStream>, String, Self>::new(self, "GRAPH.QUERY", query_str)
+            .execute()
+            .await
     }
 
     /// Drop an existing index, by specifying its type, entity, label and specific properties
@@ -262,7 +264,7 @@ impl AsyncGraph {
         entity_type: EntityType,
         label: &str,
         properties: &[P],
-    ) -> FalkorResult<QueryResult<LazyResultSet>> {
+    ) -> FalkorResult<QueryResult<RowStream>> {
         let query_str = generate_drop_index_query(index_field_type, entity_type, label, properties);
         self.query(query_str).execute().await
     }
@@ -390,12 +392,6 @@ impl AsyncGraph {
 
         self.execute_command("GRAPH.CONSTRAINT", Some("DROP"), Some(params.as_slice()))
             .await
-    }
-}
-
-impl HasGraphSchema for AsyncGraph {
-    fn get_graph_schema_mut(&mut self) -> &mut GraphSchema {
-        &mut self.graph_schema
     }
 }
 

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     AsyncGraph, ConstraintType, EntityType, FalkorAsyncClient, FalkorResult, IndexType,
-    LazyResultSet, QueryResult,
+    QueryResult, RowStream,
 };
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -39,7 +39,7 @@ impl<'a> AsyncIndexOpBuilder<'a> {
     }
 
     /// Issues the index command without waiting (identical to the eager `create_index`/`drop_index`).
-    pub async fn execute(self) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+    pub async fn execute(self) -> FalkorResult<QueryResult<RowStream>> {
         run_index_command(self.graph, &self.op).await
     }
 
@@ -163,10 +163,10 @@ impl<'a> AsyncCopyGraphBuilder<'a> {
     }
 }
 
-async fn run_index_command<'a>(
-    graph: &'a mut AsyncGraph,
+async fn run_index_command(
+    graph: &mut AsyncGraph,
     op: &IndexOp,
-) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+) -> FalkorResult<QueryResult<RowStream>> {
     match op {
         IndexOp::Create {
             index_type,

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -572,16 +572,11 @@ fn parse_procedure_result<T: SchemaParsable>(
         })?;
 
     let header: Arc<[String]> = parse_header(header)?.into();
-    QueryResult::from_response(
-        header,
-        redis_value_as_vec(indices).map(|indices| {
-            indices
-                .into_iter()
-                .flat_map(|res| T::parse(res, graph_schema))
-                .collect()
-        })?,
-        stats,
-    )
+    let data = redis_value_as_vec(indices)?
+        .into_iter()
+        .map(|res| T::parse(res, graph_schema))
+        .collect::<FalkorResult<Vec<T>>>()?;
+    QueryResult::from_response(header, data, stats)
 }
 
 impl<'a, Out, G: HasGraphSchema> ProcedureQueryBuilder<'a, Out, G> {
@@ -805,6 +800,21 @@ mod tests {
             result,
             Err(FalkorDBError::ParsingArrayToStructElementCount(_))
         ));
+    }
+
+    #[test]
+    fn parse_procedure_result_propagates_row_parse_error() {
+        use crate::FalkorIndex;
+        let mut schema = GraphSchema::new("test_proc_bad_row", create_empty_inner_sync_client());
+        // A valid 3-element reply shape, but the single index row is malformed (not the 9-element
+        // array `FalkorIndex` expects), so its parse error must propagate instead of being dropped.
+        let res = redis::Value::Array(vec![
+            header_with_one_column("idx"),
+            redis::Value::Array(vec![redis::Value::Int(5)]),
+            redis::Value::Array(vec![]),
+        ]);
+        let result = parse_procedure_result::<FalkorIndex>(res, &mut schema);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -16,10 +16,12 @@ use std::{
 };
 
 #[cfg(feature = "tokio")]
-use crate::AsyncGraph;
+use crate::{AsyncGraph, RowStream};
 
 #[cfg(feature = "serde")]
 use crate::TypedLazyResultSet;
+#[cfg(all(feature = "serde", feature = "tokio"))]
+use crate::TypedRowStream;
 
 /// Builds a [`QueryResult`] over a [`LazyResultSet`] from an already-parsed header and the raw row
 /// values, sharing one `Arc` header with the result set.
@@ -33,12 +35,44 @@ fn build_lazy_query_result<'g>(
     QueryResult::from_response(header, data, stats)
 }
 
+/// Builds a [`QueryResult`] over an owned [`RowStream`] by eagerly parsing every row against
+/// `graph_schema`, so the result is decoupled from later changes to the graph's schema.
+#[cfg(feature = "tokio")]
+fn build_row_stream_result(
+    header: Arc<[String]>,
+    rows: Vec<redis::Value>,
+    stats: redis::Value,
+    graph_schema: &mut GraphSchema,
+) -> FalkorResult<QueryResult<crate::RowStream>> {
+    let data = crate::RowStream::parse(Arc::clone(&header), rows, graph_schema);
+    QueryResult::from_response(header, data, stats)
+}
+
+/// Unwraps a top-level query reply: a `ServerError` becomes a [`FalkorDBError::RedisError`],
+/// otherwise the reply is read as the response array.
+fn unwrap_query_response(value: redis::Value) -> FalkorResult<Vec<redis::Value>> {
+    if let redis::Value::ServerError(e) = value {
+        return Err(FalkorDBError::RedisError(
+            e.details().unwrap_or("Unknown error").to_string(),
+        ));
+    }
+    redis_value_as_vec(value)
+}
+
 /// Turns the top-level query response array into a [`QueryResult`]: one element is stats only, two
-/// is a header with no rows, three is header + rows + stats. Any other length is malformed.
-fn dispatch_query_response<'g>(
+/// is a header with no rows, three is header + rows + stats. Any other length is malformed. The
+/// `build` closure constructs the concrete result set (sync [`LazyResultSet`] or async
+/// [`RowStream`](crate::RowStream)) from the parsed header, rows, stats, and `schema` handle.
+fn dispatch_query_response<S, D>(
     res: Vec<redis::Value>,
-    graph_schema: &'g mut GraphSchema,
-) -> FalkorResult<QueryResult<LazyResultSet<'g>>> {
+    schema: S,
+    build: impl FnOnce(
+        Arc<[String]>,
+        Vec<redis::Value>,
+        redis::Value,
+        S,
+    ) -> FalkorResult<QueryResult<D>>,
+) -> FalkorResult<QueryResult<D>> {
     match res.len() {
         1 => {
             let stats =
@@ -48,7 +82,7 @@ fn dispatch_query_response<'g>(
                         "One element exists but using next() failed",
                     ))?;
 
-            build_lazy_query_result(Vec::new().into(), Vec::new(), stats, graph_schema)
+            build(Vec::new().into(), Vec::new(), stats, schema)
         }
         2 => {
             // The match arm guarantees the length, so the fixed-size conversion cannot fail.
@@ -56,7 +90,7 @@ fn dispatch_query_response<'g>(
                 res.try_into().expect("length checked to be exactly two");
 
             let header: Arc<[String]> = parse_header(header)?.into();
-            build_lazy_query_result(header, Vec::new(), stats, graph_schema)
+            build(header, Vec::new(), stats, schema)
         }
         3 => {
             let [header, data, stats]: [redis::Value; 3] =
@@ -64,7 +98,7 @@ fn dispatch_query_response<'g>(
 
             let header: Arc<[String]> = parse_header(header)?.into();
             let rows = redis_value_as_vec(data)?;
-            build_lazy_query_result(header, rows, stats, graph_schema)
+            build(header, rows, stats, schema)
         }
         _ => Err(FalkorDBError::ParsingArrayToStructElementCount(
             "Invalid number of elements returned from query",
@@ -87,7 +121,7 @@ pub(crate) fn construct_query<Q: Display>(
 }
 
 /// A Builder-pattern struct that allows creating and executing queries on a graph
-pub struct QueryBuilder<'a, Output, T: Display, G: HasGraphSchema> {
+pub struct QueryBuilder<'a, Output, T: Display, G> {
     _unused: PhantomData<Output>,
     graph: &'a mut G,
     command: &'a str,
@@ -96,7 +130,7 @@ pub struct QueryBuilder<'a, Output, T: Display, G: HasGraphSchema> {
     timeout: Option<i64>,
 }
 
-impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
+impl<'a, Output, T: Display, G> QueryBuilder<'a, Output, T, G> {
     pub(crate) fn new(
         graph: &'a mut G,
         command: &'a str,
@@ -185,19 +219,18 @@ impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
             ..self
         }
     }
+}
 
+impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
     fn generate_query_result_set(
         self,
         value: redis::Value,
     ) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
-        if let redis::Value::ServerError(e) = value {
-            return Err(FalkorDBError::RedisError(
-                e.details().unwrap_or("Unknown error").to_string(),
-            ));
-        }
-
-        let res = redis_value_as_vec(value)?;
-        dispatch_query_response(res, self.graph.get_graph_schema_mut())
+        dispatch_query_response(
+            unwrap_query_response(value)?,
+            self.graph.get_graph_schema_mut(),
+            build_lazy_query_result,
+        )
     }
 }
 
@@ -270,6 +303,22 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
             )
             .await
     }
+
+    /// Eagerly parses the reply into an owned [`RowStream`] under the schema write lock, so the
+    /// result outlives the borrow of the graph, is `Send + 'static`, and is decoupled from any
+    /// later change to the graph's schema.
+    fn generate_async_result_set(
+        self,
+        value: redis::Value,
+    ) -> FalkorResult<QueryResult<RowStream>> {
+        let schema = self.graph.schema_handle();
+        let mut guard = schema.write();
+        dispatch_query_response(
+            unwrap_query_response(value)?,
+            &mut *guard,
+            build_row_stream_result,
+        )
+    }
 }
 
 impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, SyncGraph> {
@@ -285,16 +334,17 @@ impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, SyncGra
 }
 
 #[cfg(feature = "tokio")]
-impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, AsyncGraph> {
-    /// Executes the query, retuning a [`QueryResult`], with a [`LazyResultSet`] as its `data` member
+impl<'a, T: Display> QueryBuilder<'a, QueryResult<RowStream>, T, AsyncGraph> {
+    /// Executes the query, returning a [`QueryResult`] whose `data` is an owned [`RowStream`] — a
+    /// `Send + 'static` [`futures_core::Stream`] of `FalkorResult<Row>`.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Lazy Result Set Query", skip_all, level = "info")
+        tracing::instrument(name = "Execute Row Stream Query", skip_all, level = "info")
     )]
-    pub async fn execute(mut self) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
+    pub async fn execute(mut self) -> FalkorResult<QueryResult<RowStream>> {
         self.common_execute_steps()
             .await
-            .and_then(|res| self.generate_query_result_set(res))
+            .and_then(|res| self.generate_async_result_set(res))
     }
 }
 
@@ -352,20 +402,40 @@ where
 }
 
 #[cfg(all(feature = "serde", feature = "tokio"))]
-impl<'a, T: Display, U> QueryBuilder<'a, QueryResult<TypedLazyResultSet<'a, U>>, T, AsyncGraph>
+impl<'a, T: Display> QueryBuilder<'a, QueryResult<RowStream>, T, AsyncGraph> {
+    /// Map each result row into `U` (the async counterpart of the sync `query_as`): the result of
+    /// [`execute`](Self::execute) becomes a `QueryResult<TypedRowStream<U>>`, a `Send + 'static`
+    /// stream of `FalkorResult<U>`. See [`from_falkor_row`](crate::from_falkor_row) for the mapping.
+    pub fn query_as<U>(self) -> QueryBuilder<'a, QueryResult<TypedRowStream<U>>, T, AsyncGraph>
+    where
+        U: serde::de::DeserializeOwned,
+    {
+        QueryBuilder {
+            _unused: PhantomData,
+            graph: self.graph,
+            command: self.command,
+            query_string: self.query_string,
+            params: self.params,
+            timeout: self.timeout,
+        }
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "tokio"))]
+impl<'a, T: Display, U> QueryBuilder<'a, QueryResult<TypedRowStream<U>>, T, AsyncGraph>
 where
     U: serde::de::DeserializeOwned,
 {
-    /// Executes the query, returning a [`QueryResult`] whose `data` is a
-    /// [`TypedLazyResultSet`] that deserializes each row into `U`.
+    /// Executes the query, returning a [`QueryResult`] whose `data` is a [`TypedRowStream`] that
+    /// deserializes each row into `U`.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Typed Query", skip_all, level = "info")
+        tracing::instrument(name = "Execute Typed Row Stream Query", skip_all, level = "info")
     )]
-    pub async fn execute(mut self) -> FalkorResult<QueryResult<TypedLazyResultSet<'a, U>>> {
+    pub async fn execute(mut self) -> FalkorResult<QueryResult<TypedRowStream<U>>> {
         self.common_execute_steps()
             .await
-            .and_then(|res| self.generate_query_result_set(res))
+            .and_then(|res| self.generate_async_result_set(res))
             .map(|result| result.into_typed::<U>())
     }
 }
@@ -418,7 +488,7 @@ pub(crate) fn generate_procedure_call(
 }
 
 /// A Builder-pattern struct that allows creating and executing procedure call on a graph
-pub struct ProcedureQueryBuilder<'a, Output, G: HasGraphSchema> {
+pub struct ProcedureQueryBuilder<'a, Output, G> {
     _unused: PhantomData<Output>,
     graph: &'a mut G,
     readonly: bool,
@@ -427,7 +497,7 @@ pub struct ProcedureQueryBuilder<'a, Output, G: HasGraphSchema> {
     yields: Option<&'a [&'a str]>,
 }
 
-impl<'a, Out, G: HasGraphSchema> ProcedureQueryBuilder<'a, Out, G> {
+impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
     pub(crate) fn new(
         graph: &'a mut G,
         procedure_name: &'a str,
@@ -484,31 +554,42 @@ impl<'a, Out, G: HasGraphSchema> ProcedureQueryBuilder<'a, Out, G> {
             ..self
         }
     }
+}
 
+/// Parses a 3-element `[header, rows, stats]` procedure reply into a `QueryResult<Vec<T>>`, using
+/// `graph_schema` to resolve compact ids. Shared by the sync and async procedure builders.
+fn parse_procedure_result<T: SchemaParsable>(
+    res: redis::Value,
+    graph_schema: &mut GraphSchema,
+) -> FalkorResult<QueryResult<Vec<T>>> {
+    let [header, indices, stats]: [redis::Value; 3] =
+        redis_value_as_vec(res).and_then(|res_vec| {
+            res_vec.try_into().map_err(|_| {
+                FalkorDBError::ParsingArrayToStructElementCount(
+                    "Expected exactly 3 elements in query response",
+                )
+            })
+        })?;
+
+    let header: Arc<[String]> = parse_header(header)?.into();
+    QueryResult::from_response(
+        header,
+        redis_value_as_vec(indices).map(|indices| {
+            indices
+                .into_iter()
+                .flat_map(|res| T::parse(res, graph_schema))
+                .collect()
+        })?,
+        stats,
+    )
+}
+
+impl<'a, Out, G: HasGraphSchema> ProcedureQueryBuilder<'a, Out, G> {
     fn parse_query_result_of_type<T: SchemaParsable>(
         &mut self,
         res: redis::Value,
     ) -> FalkorResult<QueryResult<Vec<T>>> {
-        let [header, indices, stats]: [redis::Value; 3] =
-            redis_value_as_vec(res).and_then(|res_vec| {
-                res_vec.try_into().map_err(|_| {
-                    FalkorDBError::ParsingArrayToStructElementCount(
-                        "Expected exactly 3 elements in query response",
-                    )
-                })
-            })?;
-
-        let header: Arc<[String]> = parse_header(header)?.into();
-        QueryResult::from_response(
-            header,
-            redis_value_as_vec(indices).map(|indices| {
-                indices
-                    .into_iter()
-                    .flat_map(|res| T::parse(res, self.graph.get_graph_schema_mut()))
-                    .collect()
-            })?,
-            stats,
-        )
+        parse_procedure_result(res, self.graph.get_graph_schema_mut())
     }
 }
 
@@ -611,9 +692,10 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<FalkorIndex>>, AsyncGraph> {
         tracing::instrument(name = "Execute FalkorIndex Query", skip_all, level = "info")
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<Vec<FalkorIndex>>> {
-        self.common_execute_steps()
-            .await
-            .and_then(|res| self.parse_query_result_of_type(res))
+        let res = self.common_execute_steps().await?;
+        let schema = self.graph.schema_handle();
+        let mut guard = schema.write();
+        parse_procedure_result(res, &mut guard)
     }
 }
 
@@ -639,9 +721,10 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<Constraint>>, AsyncGraph> {
         tracing::instrument(name = "Execute Constraint Procedure Call", skip_all, level = "info")
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<Vec<Constraint>>> {
-        self.common_execute_steps()
-            .await
-            .and_then(|res| self.parse_query_result_of_type(res))
+        let res = self.common_execute_steps().await?;
+        let schema = self.graph.schema_handle();
+        let mut guard = schema.write();
+        parse_procedure_result(res, &mut guard)
     }
 }
 
@@ -661,8 +744,12 @@ mod tests {
     #[test]
     fn dispatch_one_element_is_stats_only() {
         let mut schema = GraphSchema::new("test_dispatch_one", create_empty_inner_sync_client());
-        let mut result =
-            dispatch_query_response(vec![redis::Value::Array(vec![])], &mut schema).unwrap();
+        let mut result = dispatch_query_response(
+            vec![redis::Value::Array(vec![])],
+            &mut schema,
+            build_lazy_query_result,
+        )
+        .unwrap();
         assert!(result.header.is_empty());
         assert!(result.data.next().is_none());
     }
@@ -671,7 +758,8 @@ mod tests {
     fn dispatch_two_elements_is_header_without_rows() {
         let mut schema = GraphSchema::new("test_dispatch_two", create_empty_inner_sync_client());
         let res = vec![header_with_one_column("col"), redis::Value::Array(vec![])];
-        let mut result = dispatch_query_response(res, &mut schema).unwrap();
+        let mut result =
+            dispatch_query_response(res, &mut schema, build_lazy_query_result).unwrap();
         assert_eq!(result.header.len(), 1);
         assert_eq!(result.header[0], "col");
         assert!(result.data.next().is_none());
@@ -685,7 +773,8 @@ mod tests {
             redis::Value::Array(vec![]), // zero data rows
             redis::Value::Array(vec![]), // stats
         ];
-        let mut result = dispatch_query_response(res, &mut schema).unwrap();
+        let mut result =
+            dispatch_query_response(res, &mut schema, build_lazy_query_result).unwrap();
         assert_eq!(result.header.len(), 1);
         assert_eq!(result.header[0], "col");
         assert!(result.data.next().is_none());
@@ -694,7 +783,28 @@ mod tests {
     #[test]
     fn dispatch_invalid_length_is_error() {
         let mut schema = GraphSchema::new("test_dispatch_bad", create_empty_inner_sync_client());
-        assert!(dispatch_query_response(vec![redis::Value::Nil; 4], &mut schema).is_err());
+        assert!(dispatch_query_response(
+            vec![redis::Value::Nil; 4],
+            &mut schema,
+            build_lazy_query_result
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parse_procedure_result_rejects_wrong_element_count() {
+        use crate::FalkorIndex;
+        let mut schema = GraphSchema::new("test_proc_bad_len", create_empty_inner_sync_client());
+        // Two elements instead of the required three.
+        let res = redis::Value::Array(vec![
+            redis::Value::Array(vec![]),
+            redis::Value::Array(vec![]),
+        ]);
+        let result = parse_procedure_result::<FalkorIndex>(res, &mut schema);
+        assert!(matches!(
+            result,
+            Err(FalkorDBError::ParsingArrayToStructElementCount(_))
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,12 @@ pub use value::{
     RawParam,
 };
 
+#[cfg(feature = "tokio")]
+pub use response::row_stream::RowStream;
 #[cfg(feature = "serde")]
 pub use response::typed_result_set::TypedLazyResultSet;
+#[cfg(all(feature = "serde", feature = "tokio"))]
+pub use response::typed_row_stream::TypedRowStream;
 #[cfg(feature = "serde")]
 pub use value::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};
 
@@ -159,6 +163,7 @@ pub(crate) mod test_utils {
     /// Async counterpart of [`imdb_test_client`].
     #[cfg(feature = "tokio")]
     pub(crate) async fn imdb_async_test_client() -> FalkorAsyncClient {
+        use futures::StreamExt;
         let client = create_async_test_client().await;
         let mut graph = client.select_graph(IMDB_FIXTURE_GRAPH);
         let mut result = graph
@@ -169,6 +174,7 @@ pub(crate) mod test_utils {
         let count = result
             .data
             .next()
+            .await
             .expect("imdb actor count query returned no rows")
             .expect("imdb actor count row failed to parse")
             .try_get_at::<i64>(0)

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -14,9 +14,13 @@ pub(crate) mod lazy_result_set;
 pub(crate) mod row;
 #[cfg(test)]
 mod row_proptest;
+#[cfg(feature = "tokio")]
+pub(crate) mod row_stream;
 pub(crate) mod slowlog_entry;
 #[cfg(feature = "serde")]
 pub(crate) mod typed_result_set;
+#[cfg(all(feature = "serde", feature = "tokio"))]
+pub(crate) mod typed_row_stream;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, strum::IntoStaticStr)]
 enum StatisticType {
@@ -174,6 +178,19 @@ impl<'a> QueryResult<crate::LazyResultSet<'a>> {
     pub(crate) fn into_typed<T>(self) -> QueryResult<typed_result_set::TypedLazyResultSet<'a, T>> {
         QueryResult {
             data: typed_result_set::TypedLazyResultSet::new(self.data),
+            header: self.header,
+            stats: self.stats,
+        }
+    }
+}
+
+#[cfg(all(feature = "serde", feature = "tokio"))]
+impl QueryResult<crate::RowStream> {
+    /// Convert this owned result set into one whose rows are deserialized into `T` on demand,
+    /// preserving the [`header`](Self::header) and [`stats`](Self::stats).
+    pub(crate) fn into_typed<T>(self) -> QueryResult<crate::TypedRowStream<T>> {
+        QueryResult {
+            data: typed_row_stream::TypedRowStream::new(self.data),
             header: self.header,
             stats: self.stats,
         }

--- a/src/response/row_stream.rs
+++ b/src/response/row_stream.rs
@@ -1,0 +1,225 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! An owned, `Send + 'static` async result set implementing [`futures_core::Stream`], available
+//! with the `tokio` feature.
+
+use crate::parser::{parse_type, ParserTypeMarker};
+use crate::{FalkorDBError, FalkorResult, FalkorValue, GraphSchema, Row};
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+/// The owned result set produced by an [`AsyncGraph`](crate::AsyncGraph) query.
+///
+/// Each row of the `GRAPH.QUERY` reply is parsed **eagerly** when the query runs (resolving compact
+/// ids against the graph schema, refreshing it once on a cache miss) into a `FalkorResult<Row>`, so
+/// a `RowStream` is a self-contained, `Send + 'static` buffer of already-decoded rows. It can be
+/// moved into a `tokio::spawn` task and composed with `futures::StreamExt`/`futures::TryStreamExt`,
+/// and it stays valid even if the graph is mutated or deleted before the stream is consumed.
+///
+/// It implements [`futures_core::Stream`], yielding `FalkorResult<Row>`. The rows are already in
+/// memory, so this is a buffered stream — `poll_next` never returns `Poll::Pending`. Drain it with
+/// `StreamExt`/`TryStreamExt` (`try_next().await`, `try_collect().await`,
+/// `map(..).buffer_unordered(..)`, …).
+///
+/// ```rust,no_run
+/// # async fn run(mut graph: falkordb::AsyncGraph) -> Result<(), falkordb::FalkorDBError> {
+/// use futures::TryStreamExt;
+/// let movies: Vec<falkordb::Row> = graph
+///     .query("MATCH (m:Movie) RETURN m")
+///     .execute()
+///     .await?
+///     .data
+///     .try_collect()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct RowStream {
+    rows: VecDeque<FalkorResult<Row>>,
+}
+
+impl RowStream {
+    /// Parses every raw row of a reply into a [`Row`], surfacing per-row parse failures as `Err`
+    /// items, while resolving compact ids against `graph_schema` (refreshing it on a cache miss).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Parse Row Stream", skip_all, level = "debug")
+    )]
+    pub(crate) fn parse(
+        header: Arc<[String]>,
+        raw_rows: Vec<redis::Value>,
+        graph_schema: &mut GraphSchema,
+    ) -> Self {
+        let rows = raw_rows
+            .into_iter()
+            .map(|raw| {
+                let values = parse_type(ParserTypeMarker::Array, raw, graph_schema)
+                    .and_then(FalkorValue::into_vec)?;
+                if values.len() != header.len() {
+                    return Err(FalkorDBError::RowShapeMismatch {
+                        header_len: header.len(),
+                        value_len: values.len(),
+                    });
+                }
+                Ok(Row::new(Arc::clone(&header), values))
+            })
+            .collect();
+        Self { rows }
+    }
+
+    /// Returns the number of rows remaining in the result set.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Returns whether this result set is empty or depleted.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Iterates the rows as bare `Vec<FalkorValue>`, reproducing the pre-0.7 behaviour in which a
+    /// row that fails to parse is yielded as a single `[FalkorValue::Unparseable]` element instead
+    /// of surfacing the error. Prefer the default fallible iteration.
+    pub fn into_values_lossy(self) -> impl Iterator<Item = Vec<FalkorValue>> {
+        self.rows.into_iter().map(|row| match row {
+            Ok(row) => row.into_values(),
+            Err(err) => vec![FalkorValue::Unparseable(err.to_string())],
+        })
+    }
+}
+
+impl futures_core::Stream for RowStream {
+    type Item = FalkorResult<Row>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // Rows are already parsed and buffered in memory, so a row is always immediately ready;
+        // this never parks the task.
+        Poll::Ready(self.get_mut().rows.pop_front())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.rows.len(), Some(self.rows.len()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+
+    /// A single-column row holding one scalar `i64` (`ParserTypeMarker::I64 == 3`), which parses
+    /// without needing any schema lookup.
+    fn scalar_row(n: i64) -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(3),
+            redis::Value::Int(n),
+        ])])
+    }
+
+    fn stream_of(values: &[i64]) -> RowStream {
+        let header: Arc<[String]> = Arc::from(vec!["n".to_string()]);
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        RowStream::parse(
+            header,
+            values.iter().map(|&n| scalar_row(n)).collect(),
+            &mut schema,
+        )
+    }
+
+    fn assert_send_static<T: Send + 'static>() {}
+
+    #[test]
+    fn row_stream_is_send_and_static() {
+        // The whole point: a `RowStream` can move into a `tokio::spawn` task.
+        assert_send_static::<RowStream>();
+    }
+
+    #[test]
+    fn len_and_is_empty_track_remaining_rows() {
+        let stream = stream_of(&[42, 7]);
+        assert_eq!(stream.len(), 2);
+        assert!(!stream.is_empty());
+        assert!(stream_of(&[]).is_empty());
+    }
+
+    #[test]
+    fn stream_try_collect_parses_each_row() {
+        use futures::TryStreamExt;
+
+        let rows: Vec<Row> =
+            futures::executor::block_on(stream_of(&[42, 7]).try_collect()).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].try_get_at::<i64>(0).unwrap(), 42);
+        assert_eq!(rows[1].try_get_at::<i64>(0).unwrap(), 7);
+    }
+
+    #[test]
+    fn stream_next_via_streamext() {
+        use futures::StreamExt;
+
+        let mut stream = stream_of(&[1, 2]);
+        let row = futures::executor::block_on(stream.next()).unwrap().unwrap();
+        assert_eq!(row.try_get_at::<i64>(0).unwrap(), 1);
+        assert_eq!(stream.len(), 1);
+    }
+
+    #[test]
+    fn into_values_lossy_yields_bare_rows() {
+        let rows: Vec<Vec<FalkorValue>> = stream_of(&[5]).into_values_lossy().collect();
+        assert_eq!(rows, vec![vec![FalkorValue::I64(5)]]);
+    }
+
+    #[test]
+    fn shape_mismatch_surfaces_as_error() {
+        // The header declares one column, but this row carries two values.
+        let two_value_row = redis::Value::Array(vec![
+            redis::Value::Array(vec![redis::Value::Int(3), redis::Value::Int(1)]),
+            redis::Value::Array(vec![redis::Value::Int(3), redis::Value::Int(2)]),
+        ]);
+        let header: Arc<[String]> = Arc::from(vec!["n".to_string()]);
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        let mut stream = RowStream::parse(header, vec![two_value_row], &mut schema);
+
+        let err = stream.rows.pop_front().unwrap().unwrap_err();
+        assert!(matches!(
+            err,
+            FalkorDBError::RowShapeMismatch {
+                header_len: 1,
+                value_len: 2,
+            }
+        ));
+    }
+
+    #[test]
+    fn into_values_lossy_collapses_parse_errors() {
+        // An unknown type marker makes `parse_type` fail; the lossy iterator must yield a single
+        // `Unparseable` element rather than propagate the error.
+        let bad_row = redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(9999),
+            redis::Value::Int(1),
+        ])]);
+        let header: Arc<[String]> = Arc::from(vec!["n".to_string()]);
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        let stream = RowStream::parse(header, vec![bad_row], &mut schema);
+
+        let rows: Vec<Vec<FalkorValue>> = stream.into_values_lossy().collect();
+        assert_eq!(rows.len(), 1);
+        assert!(matches!(rows[0].as_slice(), [FalkorValue::Unparseable(_)]));
+    }
+
+    #[test]
+    fn size_hint_reports_remaining_rows() {
+        use futures_core::Stream;
+
+        let stream = stream_of(&[1, 2, 3]);
+        assert_eq!(Stream::size_hint(&stream), (3, Some(3)));
+    }
+}

--- a/src/response/typed_row_stream.rs
+++ b/src/response/typed_row_stream.rs
@@ -1,0 +1,128 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Typed async streaming over a [`RowStream`], available with the `serde` + `tokio` features.
+
+use crate::{FalkorResult, Row, RowStream};
+use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A typed view over a [`RowStream`] that deserializes each row into `T` on demand.
+///
+/// This is the `data` member of the [`QueryResult`](crate::QueryResult) returned by
+/// [`QueryBuilder::query_as`](crate::QueryBuilder::query_as) on an
+/// [`AsyncGraph`](crate::AsyncGraph). It is `Send + 'static` and implements
+/// [`futures_core::Stream`], yielding one `FalkorResult<T>` per row.
+///
+/// ```rust,no_run
+/// # use serde::Deserialize;
+/// # #[derive(Deserialize)] struct Movie { title: String }
+/// # async fn run(mut graph: falkordb::AsyncGraph) -> Result<(), falkordb::FalkorDBError> {
+/// use futures::TryStreamExt;
+/// let movies: Vec<Movie> = graph
+///     .query("MATCH (m:Movie) RETURN m")
+///     .query_as::<Movie>()
+///     .execute()
+///     .await?
+///     .data
+///     .try_collect()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct TypedRowStream<T> {
+    inner: RowStream,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<T> TypedRowStream<T> {
+    pub(crate) fn new(inner: RowStream) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the number of rows remaining in the result set.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns whether this result set is empty or depleted.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+impl<T> futures_core::Stream for TypedRowStream<T>
+where
+    T: DeserializeOwned,
+{
+    type Item = FalkorResult<T>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let inner = &mut self.get_mut().inner;
+        futures_core::Stream::poll_next(Pin::new(inner), cx)
+            .map(|row| row.map(|row| row.and_then(Row::deserialize::<T>)))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.inner.len(), Some(self.inner.len()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+    use crate::GraphSchema;
+    use std::sync::Arc;
+
+    /// A single-column row holding one scalar `i64` (`ParserTypeMarker::I64 == 3`).
+    fn scalar_row(n: i64) -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![
+            redis::Value::Int(3),
+            redis::Value::Int(n),
+        ])])
+    }
+
+    fn typed_stream(values: &[i64]) -> TypedRowStream<i64> {
+        let header: Arc<[String]> = Arc::from(vec!["n".to_string()]);
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        TypedRowStream::new(RowStream::parse(
+            header,
+            values.iter().map(|&n| scalar_row(n)).collect(),
+            &mut schema,
+        ))
+    }
+
+    #[test]
+    fn len_and_is_empty_track_remaining_rows() {
+        assert_eq!(typed_stream(&[1, 2]).len(), 2);
+        assert!(!typed_stream(&[1]).is_empty());
+        assert!(typed_stream(&[]).is_empty());
+    }
+
+    #[test]
+    fn try_collect_deserializes_each_row() {
+        use futures::TryStreamExt;
+
+        let out: Vec<i64> =
+            futures::executor::block_on(typed_stream(&[10, 20]).try_collect()).unwrap();
+        assert_eq!(out, vec![10, 20]);
+    }
+
+    #[test]
+    fn size_hint_reports_remaining_rows() {
+        use futures_core::Stream;
+
+        assert_eq!(Stream::size_hint(&typed_stream(&[1, 2, 3])), (3, Some(3)));
+    }
+}

--- a/src/value/path.rs
+++ b/src/value/path.rs
@@ -35,12 +35,12 @@ impl Path {
         Ok(Self {
             nodes: redis_value_as_vec(nodes)?
                 .into_iter()
-                .flat_map(|node| Node::parse(node, graph_schema))
-                .collect(),
+                .map(|node| Node::parse(node, graph_schema))
+                .collect::<FalkorResult<Vec<_>>>()?,
             relationships: redis_value_as_vec(relationships)?
                 .into_iter()
-                .flat_map(|edge| Edge::parse(edge, graph_schema))
-                .collect(),
+                .map(|edge| Edge::parse(edge, graph_schema))
+                .collect::<FalkorResult<Vec<_>>>()?,
         })
     }
 }
@@ -104,6 +104,50 @@ mod tests {
         let path1 = Path::default();
         let path2 = Path::default();
         assert_eq!(path1, path2);
+    }
+
+    #[test]
+    fn test_path_parse_propagates_node_error() {
+        // A node value must be a 3-element array; this one has a single element, so `Node::parse`
+        // fails. `Path::parse` must surface that error instead of silently dropping the node and
+        // returning a truncated path.
+        let malformed_node = redis::Value::Array(vec![redis::Value::Int(1)]);
+        let path_value = redis::Value::Array(vec![
+            redis::Value::Array(vec![malformed_node]),
+            redis::Value::Array(vec![]),
+        ]);
+
+        let mut graph_schema = GraphSchema::new(
+            "test_path_parse_propagates_node_error",
+            crate::client::blocking::create_empty_inner_sync_client(),
+        );
+
+        let result = Path::parse(path_value, &mut graph_schema);
+        assert!(
+            matches!(
+                result,
+                Err(FalkorDBError::ParsingArrayToStructElementCount(_))
+            ),
+            "expected the node parse error to propagate, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_path_parse_propagates_relationship_error() {
+        // The relationships side must propagate errors too: an edge value that is not the expected
+        // array shape must fail the whole path parse rather than being dropped.
+        let malformed_edge = redis::Value::Int(7);
+        let path_value = redis::Value::Array(vec![
+            redis::Value::Array(vec![]),
+            redis::Value::Array(vec![malformed_edge]),
+        ]);
+
+        let mut graph_schema = GraphSchema::new(
+            "test_path_parse_propagates_relationship_error",
+            crate::client::blocking::create_empty_inner_sync_client(),
+        );
+
+        assert!(Path::parse(path_value, &mut graph_schema).is_err());
     }
 
     #[test]

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -37,6 +37,7 @@ use falkordb::{
     EmbeddedConfig, EmbeddedServer, EntityType, FalkorClientBuilder, FalkorConnectionInfo,
     IndexType,
 };
+use futures::StreamExt;
 
 /// Common locations the module may live in, mirroring the client's own search list.
 fn common_module_paths() -> Vec<PathBuf> {
@@ -236,6 +237,7 @@ mod async_flavours {
             let count = res
                 .data
                 .next()
+                .await
                 .expect("expected a row")
                 .expect("row should parse")
                 .try_get_at::<i64>(0)
@@ -250,6 +252,7 @@ mod async_flavours {
             let count = ro
                 .data
                 .next()
+                .await
                 .expect("expected a row")
                 .expect("row should parse")
                 .try_get_at::<i64>(0)
@@ -292,6 +295,7 @@ mod async_flavours {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
+                        .await
                         .expect("expected a row")
                         .expect("row should parse")
                         .try_get_at::<i64>(0)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -609,6 +609,7 @@ mod header_aware_rows {
 #[cfg(feature = "tokio")]
 mod async_tests {
     use super::*;
+    use futures::TryStreamExt;
 
     #[tokio::test]
     async fn test_async_client_connection() {
@@ -706,7 +707,8 @@ mod async_tests {
             .await
             .expect("query should succeed")
             .data
-            .collect::<Result<_, _>>()
+            .try_collect()
+            .await
             .expect("row mapping should succeed");
 
         assert_eq!(
@@ -974,5 +976,266 @@ mod serde_typed_mapping {
         assert_eq!(counts, vec![1]);
 
         let _ = graph.delete();
+    }
+}
+
+#[cfg(feature = "tokio")]
+mod async_streaming {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{AsyncGraph, FalkorClientBuilder, FalkorDBError, Row};
+    use futures::{StreamExt, TryStreamExt};
+
+    async fn async_graph_for(name: &str) -> Option<AsyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new_async()
+            .with_connection_info(conn_info)
+            .build()
+            .await
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete().await;
+        Some(graph)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_try_collect_typed_values() {
+        let Some(mut graph) = async_graph_for("test_async_stream_collect").await else {
+            return;
+        };
+        graph
+            .query("UNWIND range(1, 5) AS i CREATE (:N {v: i})")
+            .execute()
+            .await
+            .expect("create");
+
+        let result = graph
+            .query("MATCH (n:N) RETURN n.v AS v ORDER BY v")
+            .execute()
+            .await
+            .expect("query");
+        // The RowStream composes with StreamExt::map + TryStreamExt::try_collect.
+        let values: Vec<i64> = result
+            .data
+            .map(|row| row?.try_get::<i64>("v"))
+            .try_collect()
+            .await
+            .expect("collect");
+        assert_eq!(values, vec![1, 2, 3, 4, 5]);
+        let _ = graph.delete().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn row_stream_moves_into_spawned_task() {
+        let Some(mut graph) = async_graph_for("test_async_stream_spawn").await else {
+            return;
+        };
+        graph
+            .query("UNWIND range(1, 10) AS i CREATE (:N {v: i})")
+            .execute()
+            .await
+            .expect("create");
+
+        let result = graph
+            .query("MATCH (n:N) RETURN n.v AS v")
+            .execute()
+            .await
+            .expect("query");
+        // `RowStream` is Send + 'static: move it into a task while the graph stays usable.
+        let count: i64 = tokio::spawn(async move {
+            result
+                .data
+                .try_fold(
+                    0i64,
+                    |acc, _row| async move { Ok::<_, FalkorDBError>(acc + 1) },
+                )
+                .await
+        })
+        .await
+        .expect("join")
+        .expect("fold");
+        assert_eq!(count, 10);
+        // graph is still usable after moving the result into the task
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fan_out_with_buffer_unordered_over_cloned_handle() {
+        let Some(mut graph) = async_graph_for("test_async_stream_fanout").await else {
+            return;
+        };
+        graph
+            .query("UNWIND range(1, 5) AS i CREATE (:N {v: i})")
+            .execute()
+            .await
+            .expect("create");
+
+        let result = graph
+            .query("MATCH (n:N) RETURN n.v AS v")
+            .execute()
+            .await
+            .expect("query");
+        // For each row run a follow-up query on a *cloned* handle, with bounded concurrency.
+        let mut doubled: Vec<i64> = result
+            .data
+            .map(|row| {
+                let g = graph.clone();
+                async move {
+                    let mut g = g;
+                    let v: i64 = row?.try_get("v")?;
+                    let mut r = g.query(format!("RETURN {v} * 2")).execute().await?;
+                    let doubled: i64 = r.data.try_next().await?.expect("a row").try_get_at(0)?;
+                    Ok::<i64, FalkorDBError>(doubled)
+                }
+            })
+            .buffer_unordered(4)
+            .try_collect()
+            .await
+            .expect("fan-out");
+        doubled.sort_unstable();
+        assert_eq!(doubled, vec![2, 4, 6, 8, 10]);
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn streaming_nodes_refreshes_schema_inline() {
+        let Some(mut graph) = async_graph_for("test_async_stream_nodes").await else {
+            return;
+        };
+        graph
+            .query(
+                "CREATE (:Movie {title: 'Heat', year: 1995}), (:Movie {title: 'Dune', year: 2021})",
+            )
+            .execute()
+            .await
+            .expect("create");
+
+        // Returning whole nodes forces compact-id parsing + a schema refresh during streaming.
+        let result = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .execute()
+            .await
+            .expect("query");
+        let rows: Vec<Row> = result.data.try_collect().await.expect("stream nodes");
+        assert_eq!(rows.len(), 2);
+        for row in &rows {
+            assert!(row.get_at(0).and_then(|v| v.as_node()).is_some());
+        }
+        graph.delete().await.expect("delete");
+    }
+
+    #[cfg(feature = "serde")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn typed_stream_query_as() {
+        #[derive(serde::Deserialize, PartialEq, Debug)]
+        struct Movie {
+            title: String,
+            year: i64,
+        }
+        let Some(mut graph) = async_graph_for("test_async_typed_stream").await else {
+            return;
+        };
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995})")
+            .execute()
+            .await
+            .expect("create");
+
+        let result = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .query_as::<Movie>()
+            .execute()
+            .await
+            .expect("query_as");
+        let movies: Vec<Movie> = result.data.try_collect().await.expect("collect");
+        assert_eq!(
+            movies,
+            vec![Movie {
+                title: "Heat".to_string(),
+                year: 1995
+            }]
+        );
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_streams_from_clones_share_schema() {
+        let Some(mut graph) = async_graph_for("test_async_stream_concurrent").await else {
+            return;
+        };
+        graph
+            .query("UNWIND range(1, 40) AS i CREATE (:Movie {year: i})")
+            .execute()
+            .await
+            .expect("create");
+
+        // Two cloned handles stream node results concurrently, sharing one schema cache (RwLock).
+        let g1 = graph.clone();
+        let g2 = graph.clone();
+        let t1 = tokio::spawn(async move {
+            let mut g = g1;
+            g.query("MATCH (m:Movie) RETURN m")
+                .execute()
+                .await?
+                .data
+                .try_collect::<Vec<Row>>()
+                .await
+        });
+        let t2 = tokio::spawn(async move {
+            let mut g = g2;
+            g.query("MATCH (m:Movie) RETURN m")
+                .execute()
+                .await?
+                .data
+                .try_collect::<Vec<Row>>()
+                .await
+        });
+        let (r1, r2) = tokio::join!(t1, t2);
+        assert_eq!(r1.expect("join1").expect("collect1").len(), 40);
+        assert_eq!(r2.expect("join2").expect("collect2").len(), 40);
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_is_parsed_eagerly_and_survives_graph_deletion() {
+        let Some(mut graph) = async_graph_for("test_async_stream_eager").await else {
+            return;
+        };
+        graph
+            .query("CREATE (:Movie {title: 'Heat', year: 1995})")
+            .execute()
+            .await
+            .expect("create");
+
+        // Take the result but do not consume the stream yet. Rows carry compact label/property ids
+        // that need the schema to decode.
+        let result = graph
+            .query("MATCH (m:Movie) RETURN m")
+            .execute()
+            .await
+            .expect("query");
+
+        // Delete the graph (which clears the shared schema cache) before draining the stream.
+        graph.delete().await.expect("delete");
+
+        // Because rows are parsed eagerly at execute() time, the node still decodes correctly
+        // against the query-time schema rather than failing or misparsing against the now-empty one.
+        let rows: Vec<Row> = result
+            .data
+            .try_collect()
+            .await
+            .expect("collect after delete");
+        assert_eq!(rows.len(), 1);
+        let node: falkordb::Node = rows[0].try_get_at(0).expect("node");
+        assert_eq!(node.labels, vec!["Movie".to_string()]);
+        assert_eq!(
+            node.properties
+                .get("title")
+                .and_then(|v| v.as_string())
+                .map(String::as_str),
+            Some("Heat")
+        );
     }
 }

--- a/tests/multiplexing_parity.rs
+++ b/tests/multiplexing_parity.rs
@@ -17,6 +17,7 @@
 #![cfg(feature = "tokio")]
 
 use falkordb::{ConnectionStrategy, FalkorAsyncClient, FalkorClientBuilder, FalkorConnectionInfo};
+use futures::StreamExt;
 use std::num::NonZeroU8;
 
 fn skip_if_no_server() -> bool {
@@ -122,7 +123,7 @@ async fn test_core_operations_under_all_strategies() {
             .expect("write query should succeed");
 
         // Parameterized read.
-        let mut res = graph
+        let res = graph
             .query("MATCH (p:Person) WHERE p.age >= $min_age RETURN p.age")
             .with_param("min_age", 35)
             .execute()
@@ -130,13 +131,13 @@ async fn test_core_operations_under_all_strategies() {
             .expect("parameterized query should succeed");
         let ages: Vec<i64> = res
             .data
-            .by_ref()
             .map(|row| {
                 row.expect("row should parse")
                     .try_get_at::<i64>(0)
                     .expect("column 0 should be an i64")
             })
-            .collect();
+            .collect()
+            .await;
         assert_eq!(ages, vec![40], "strategy {strategy:?} parameterized read");
 
         // Read-only query.
@@ -148,6 +149,7 @@ async fn test_core_operations_under_all_strategies() {
         let count = ro
             .data
             .next()
+            .await
             .expect("expected a row")
             .expect("row should parse")
             .try_get_at::<i64>(0)
@@ -188,6 +190,7 @@ async fn test_high_concurrency_no_response_mismatch() {
                         .expect("concurrent query should succeed");
                     res.data
                         .next()
+                        .await
                         .expect("expected a row")
                         .expect("row should parse")
                         .try_get_at::<i64>(0)
@@ -236,6 +239,7 @@ async fn test_pooled_multiplexed_behavioral_equivalence() {
             let mut res = graph.query(query).execute().await.expect("query");
             res.data
                 .next()
+                .await
                 .expect("expected a row")
                 .expect("row should parse")
                 .try_get_at::<i64>(0)


### PR DESCRIPTION
## Summary

Makes **async** query results stream-native. On the async client, `QueryResult::data` is now a `RowStream` — an owned, `Send + 'static` `Stream<Item = FalkorResult<Row>>` — instead of an `Iterator`. This is the natural continuation of the 0.7 header-aware `FalkorResult<Row>` work and also retires the documented `AsyncGraph` `Arc<Mutex<_>>` wart.

Breaking change → targets **0.8.0**. The **synchronous** client is unchanged (`LazyResultSet` is still a fallible `Iterator`).

## What you can now do

```rust
use futures::{StreamExt, TryStreamExt};

// collect a typed stream in one line
let years: Vec<i64> = graph.query("MATCH (m:Movie) RETURN m.year AS year")
    .execute().await?.data
    .map(|row| row?.try_get::<i64>("year"))
    .try_collect().await?;

// move a result stream into its own task (Send + 'static)
let mut stream = graph.query("MATCH (n) RETURN n").execute().await?.data;
tokio::spawn(async move { while let Some(row) = stream.next().await { row?; } /* ... */ });

// fan out a follow-up query per row, bounded concurrency, over cloned handles
let out: Vec<_> = graph.query("MATCH (m:Movie) RETURN m.year AS year")
    .execute().await?.data
    .map(|row| { let mut g = graph.clone(); async move { /* ... */ } })
    .buffer_unordered(8).try_collect().await?;
```

With `serde`, async `query_as::<T>()` yields a `TypedRowStream<T>` (a `Stream<Item = FalkorResult<T>>`).

## Design notes

- **`AsyncGraph` schema cache** moved from `Arc<Mutex<GraphSchema>>` to `Arc<parking_lot::RwLock<GraphSchema>>`. Cloning an `AsyncGraph` now **shares one cache** (previously each clone diverged), so you clone the handle to use a graph from several concurrent tasks — no `Arc<Mutex<_>>` wrapping.
- **Rows are parsed eagerly** when the query runs, under a single schema write lock (mirroring the existing async *procedure* path). The whole `GRAPH.QUERY` reply is already buffered in memory, so this only moves CPU work, not I/O — and it makes a `RowStream` fully self-contained: it stays valid even if the graph is mutated/deleted before the stream is drained (covered by an integration test).
- **`RowStream`/`TypedRowStream` implement `Stream` only** (not `Iterator`): implementing both makes `.map`/`.collect` ambiguous once `StreamExt` is imported.
- Query receivers stay `&mut self`; concurrency comes from cheap `graph.clone()` handles that share the schema cache (avoids a large generic-ref refactor of the sync side for `&self`).
- Drive-by fix: `Path::parse` now propagates nested node/edge parse errors instead of silently dropping them.

## Migration

See **[`docs/migrating-to-0.8.md`](docs/migrating-to-0.8.md)**. Quick reference: async `result.data.next()` → `result.data.next().await` (`use futures::StreamExt;`); `result.data.collect::<FalkorResult<Vec<_>>>()` → `result.data.try_collect().await` (`use futures::TryStreamExt;`); wrap-in-`Arc<Mutex<_>>` → clone the graph.

## Tests & docs

- New `RowStream`/`TypedRowStream` unit tests, 7 server-backed `async_streaming` integration tests (incl. fan-out over cloned handles, move-into-task, schema refresh during streaming, concurrent streams from clones, and *survives graph deletion before consumption*), and `Path::parse` error-propagation unit tests.
- README "Async streaming" section + runnable `examples/async_stream.rs` (and rewritten `examples/async_api.rs`); doctests; CHANGELOG; `docs/migrating-to-0.8.md`.
- All gates green locally: fmt, clippy `--all-targets`, full server-backed test suite, doctests, `cargo doc`, `cargo deny`, spellcheck, proptest, examples build. Patch coverage ~100%.

A rubber-duck review of the implementation flagged a deferred-parse-against-mutated-schema correctness risk; that is the reason for the eager-parse approach above (and a dedicated regression test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Async query results now return owned, `Send + 'static` streams requiring `.await` with futures traits instead of async iterators
  * `AsyncGraph` clones now share a schema cache for coordinated concurrent streams

* **New Features**
  * Stream-based result processing using futures combinators
  * `RowStream::into_values_lossy()` escape hatch for backward compatibility
  * Typed row streaming via `query_as<T>()`

* **Documentation**
  * Added 0.8 migration guide with streaming patterns
  * Updated README with async streaming examples
  * New async streaming runnable example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->