### PR TITLE
feat: batch & pipelined execution (graph.batch())

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Added
+
+- batch / pipelined execution: `graph.batch()` queues several queries and dispatches them over a
+  single Redis pipeline in **one round-trip**, returning one result per query in submission order
+  (`BatchResult = FalkorResult<Vec<BatchItemResult>>`, where `BatchItemResult =
+  FalkorResult<QueryResult<Vec<Row>>>`). Queue with `query`/`ro_query` (or `push` an owned
+  `BatchQuery`), set per-query params/timeout, then `execute()` (sync) / `execute().await` (async).
+  A failing query (bad Cypher or a parameter that cannot be encoded) is isolated to its own slot;
+  the rest still run. A pipeline is not a transaction. Available on both `SyncGraph` and `AsyncGraph`.
+
 ### Fixed
 
 - `slowlog()` (sync and async) now surfaces a parse error for a malformed entry instead of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ serde = ["dep:serde"]
 name = "basic_usage"
 
 [[example]]
+name = "batch"
+
+[[example]]
 name = "async_api"
 required-features = ["tokio"]
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,52 @@ graph.query("RETURN point($p)").with_param("p", coords).execute()?;
 If you really need a raw Cypher expression, `with_raw_param("key", "…")` is the explicit escape
 hatch — no escaping is applied to the value (the parameter name is still validated).
 
+### Batch & pipelined execution
+
+Normally each query is one network round-trip. `graph.batch()` queues several queries and sends them
+over a single Redis pipeline in **one round-trip**, returning one result per query **in submission
+order**. Queue queries with `query` (a `GRAPH.QUERY`) / `ro_query` (a `GRAPH.RO_QUERY`) and set
+per-query parameters on the returned handle:
+
+```rust,ignore
+let mut batch = graph.batch();
+for movie in &movies {
+    batch.query("CREATE (:Movie {title: $t})").with_param("t", movie);
+}
+batch.ro_query("MATCH (m:Movie) RETURN count(m) AS n");
+
+let results = batch.execute()?; // Vec<BatchItemResult>, one per query, in order
+for (i, item) in results.into_iter().enumerate() {
+    match item {
+        Ok(result) => { /* result.data: Vec<Row>, result.header, result.stats */ }
+        Err(err) => eprintln!("query {i} failed: {err}"),
+    }
+}
+```
+
+On the async client it is identical but for the `await`:
+
+```rust,ignore
+let mut batch = graph.batch();
+// … queue queries …
+let results = batch.execute().await?;
+```
+
+Key points:
+
+- **Per-item errors.** A failing query (bad Cypher, or a parameter that can't be encoded) becomes
+  that slot's `Err`; the other queries are unaffected. The **outer** `Result` only fails if the whole
+  batch could not be completed — and if that happens *after* the pipeline was sent, the server may
+  have run some or all queries (the state is unknown), which matters for writes.
+- **Not a transaction.** A pipeline is not `MULTI`/`EXEC`: every queued query is executed, so a
+  failure in one does **not** roll back or stop the others.
+- **Results are eager.** Each query's rows are parsed up front into a `Vec<Row>` (the same `Row` as
+  elsewhere), since many result sets coexist in one batch.
+- **Owned queries.** To build queries ahead of time, construct `BatchQuery::write(..)` /
+  `BatchQuery::read(..)`, attach params/timeout, and `batch.push(query)`.
+
+A runnable version lives in [`examples/batch.rs`](examples/batch.rs).
+
 ### Waiting for background operations
 
 Some FalkorDB operations finish **after** the command that starts them returns: when you create or

--- a/examples/batch.rs
+++ b/examples/batch.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Batch / pipelined execution: send many queries in one round-trip.
+//!
+//! Run with: `cargo run --example batch`
+//!
+//! Requires a running FalkorDB instance (defaults to `127.0.0.1:6379`).
+
+use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorResult};
+
+fn main() -> FalkorResult<()> {
+    let connection_info: FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()?;
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info)
+        .build()?;
+    let mut graph = client.select_graph("batch_example");
+    let _ = graph.delete();
+
+    // ── Queue many writes + a read, dispatched in ONE round-trip ────────────
+    let mut batch = graph.batch();
+    for year in 1990..=1995 {
+        batch
+            .query("CREATE (:Movie {title: $t, year: $y})")
+            .with_param("t", format!("Movie {year}"))
+            .with_param("y", year);
+    }
+    // A read in the same batch sees the writes above (the schema is refreshed if needed).
+    batch.ro_query("MATCH (m:Movie) RETURN count(m) AS n");
+
+    let results = batch.execute()?;
+    println!("{} queries ran in one round-trip", results.len());
+
+    // The last item is the count read.
+    let count: i64 = results[results.len() - 1]
+        .as_ref()
+        .expect("count query succeeded")
+        .data[0]
+        .try_get("n")?;
+    println!("movies created: {count}");
+
+    // ── Per-item error attribution: one bad query doesn't sink the others ───
+    let mut batch = graph.batch();
+    batch.query("CREATE (:Movie {title: 'Heat', year: 1995})");
+    batch.query("THIS IS NOT VALID CYPHER"); // this one fails …
+    batch.ro_query("MATCH (m:Movie) RETURN count(m) AS n"); // … this one still runs
+
+    for (i, item) in batch.execute()?.into_iter().enumerate() {
+        match item {
+            Ok(_) => println!("query {i}: ok"),
+            Err(e) => println!("query {i}: failed ({e})"),
+        }
+    }
+
+    graph.delete()?;
+    Ok(())
+}

--- a/src/connection/asynchronous.rs
+++ b/src/connection/asynchronous.rs
@@ -62,6 +62,30 @@ impl FalkorAsyncConnection {
         }
     }
 
+    /// Dispatch a whole [`redis::Pipeline`] in one round-trip, returning one [`redis::Value`] per
+    /// command (a failed command is a `Value::ServerError` in its slot, not a transport error).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Connection Inner Execute Pipeline", skip_all, level = "debug")
+    )]
+    pub(crate) async fn execute_pipeline(
+        &mut self,
+        pipeline: &redis::Pipeline,
+    ) -> FalkorResult<Vec<redis::Value>> {
+        use redis::aio::ConnectionLike as _;
+        let count = pipeline.len();
+        match self {
+            FalkorAsyncConnection::Redis(redis_conn) => redis_conn
+                .req_packed_commands(pipeline, 0, count)
+                .await
+                .map_err(map_redis_err),
+            FalkorAsyncConnection::Managed(redis_conn) => redis_conn
+                .req_packed_commands(pipeline, 0, count)
+                .await
+                .map_err(map_redis_err),
+        }
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "Connection Get Redis Info", skip_all, level = "info")
@@ -154,13 +178,41 @@ impl BorrowedAsyncConnection {
         subcommand: Option<&str>,
         params: Option<&[&str]>,
     ) -> FalkorResult<redis::Value> {
-        match self
+        let result = self
             .as_inner()?
             .execute_command(graph_name, command, subcommand, params)
-            .await
-        {
+            .await;
+        self.recover_on_connection_down(result).await
+        // `self` is dropped here, returning the connection (see the `Drop` impl below).
+    }
+
+    /// Dispatch a whole pipeline in one round-trip, with the same dead-connection recovery as
+    /// [`execute_command`](Self::execute_command).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "Borrowed Connection Execute Pipeline",
+            skip_all,
+            level = "trace"
+        )
+    )]
+    pub(crate) async fn execute_pipeline(
+        mut self,
+        pipeline: &redis::Pipeline,
+    ) -> FalkorResult<Vec<redis::Value>> {
+        let result = self.as_inner()?.execute_pipeline(pipeline).await;
+        self.recover_on_connection_down(result).await
+    }
+
+    /// On a dead-connection error, swap in a fresh connection so a live one is returned to the pool
+    /// on drop, then re-surface `ConnectionDown` (or `NoConnection` if none is available); other
+    /// results pass through unchanged.
+    async fn recover_on_connection_down<T>(
+        &mut self,
+        result: FalkorResult<T>,
+    ) -> FalkorResult<T> {
+        match result {
             Err(FalkorDBError::ConnectionDown) => {
-                // Swap in a healthy connection so a live one is returned to the pool on drop.
                 if let Ok(new_conn) = self.client.fresh_connection(self.readonly).await {
                     self.conn = Some(new_conn);
                     return Err(FalkorDBError::ConnectionDown);
@@ -169,7 +221,6 @@ impl BorrowedAsyncConnection {
             }
             res => res,
         }
-        // `self` is dropped here, returning the connection (see the `Drop` impl below).
     }
 }
 

--- a/src/connection/blocking.rs
+++ b/src/connection/blocking.rs
@@ -51,6 +51,28 @@ impl FalkorSyncConnection {
         }
     }
 
+    /// Dispatch a whole [`redis::Pipeline`] in one round-trip, returning one [`redis::Value`] per
+    /// command (a failed command is a `Value::ServerError` in its slot, not a transport error).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Connection Inner Execute Pipeline", skip_all, level = "debug")
+    )]
+    pub(crate) fn execute_pipeline(
+        &mut self,
+        pipeline: &redis::Pipeline,
+    ) -> FalkorResult<Vec<redis::Value>> {
+        match self {
+            FalkorSyncConnection::Redis(redis_conn) => {
+                use redis::ConnectionLike as _;
+                redis_conn
+                    .req_packed_commands(&pipeline.get_packed_pipeline(), 0, pipeline.len())
+                    .map_err(map_redis_err)
+            }
+            #[cfg(test)]
+            FalkorSyncConnection::None => Ok(Vec::new()),
+        }
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "Connection Get Redis Info", skip_all, level = "info")
@@ -117,10 +139,38 @@ impl BorrowedSyncConnection {
         subcommand: Option<&str>,
         params: Option<&[&str]>,
     ) -> Result<redis::Value, FalkorDBError> {
-        match self
+        let result = self
             .as_inner()?
-            .execute_command(graph_name, command, subcommand, params)
-        {
+            .execute_command(graph_name, command, subcommand, params);
+        self.recover_on_connection_down(result)
+    }
+
+    /// Dispatch a whole pipeline in one round-trip, with the same dead-connection recovery as
+    /// [`execute_command`](Self::execute_command).
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "Borrowed Connection Execute Pipeline",
+            skip_all,
+            level = "trace"
+        )
+    )]
+    pub(crate) fn execute_pipeline(
+        &mut self,
+        pipeline: &redis::Pipeline,
+    ) -> FalkorResult<Vec<redis::Value>> {
+        let result = self.as_inner()?.execute_pipeline(pipeline);
+        self.recover_on_connection_down(result)
+    }
+
+    /// On a dead-connection error, swap in a fresh connection so a live one is returned to the pool
+    /// on drop, then re-surface `ConnectionDown` (or `NoConnection` if none is available); other
+    /// results pass through unchanged.
+    fn recover_on_connection_down<T>(
+        &mut self,
+        result: FalkorResult<T>,
+    ) -> FalkorResult<T> {
+        match result {
             Err(FalkorDBError::ConnectionDown) => {
                 let new_conn = if self.readonly {
                     self.client.get_replica_connection()
@@ -143,5 +193,50 @@ impl Drop for BorrowedSyncConnection {
         if let Some(conn) = self.conn.take() {
             self.return_tx.send(conn).ok();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+
+    fn empty_borrowed() -> BorrowedSyncConnection {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        BorrowedSyncConnection::new(
+            FalkorSyncConnection::None,
+            tx,
+            create_empty_inner_sync_client(),
+            false,
+        )
+    }
+
+    #[test]
+    fn execute_pipeline_on_none_connection_is_empty() {
+        let mut conn = FalkorSyncConnection::None;
+        let out = conn
+            .execute_pipeline(&redis::pipe())
+            .expect("none -> empty");
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn recover_on_connection_down_passes_other_results_through() {
+        let mut conn = empty_borrowed();
+        let out: FalkorResult<i32> = conn.recover_on_connection_down(Ok(7));
+        assert_eq!(out.expect("ok passes through"), 7);
+        let err: FalkorResult<i32> =
+            conn.recover_on_connection_down(Err(FalkorDBError::EmptyConnection));
+        assert!(matches!(err, Err(FalkorDBError::EmptyConnection)));
+    }
+
+    #[test]
+    fn recover_on_connection_down_handles_dead_connection() {
+        let mut conn = empty_borrowed();
+        // The empty client cannot supply a healthy replacement, so the dead-connection error is
+        // re-surfaced (as ConnectionDown if a stub was swapped in, else NoConnection).
+        let out: FalkorResult<redis::Value> =
+            conn.recover_on_connection_down(Err(FalkorDBError::ConnectionDown));
+        assert!(out.is_err());
     }
 }

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -174,8 +174,8 @@ impl AsyncGraph {
     ///
     /// # Returns
     /// A [`BatchBuilder`](crate::BatchBuilder) borrowing this graph until executed.
-    pub fn batch(&mut self) -> crate::graph::batch::BatchBuilder<'_, Self> {
-        crate::graph::batch::BatchBuilder::new(self)
+    pub fn batch(&mut self) -> crate::BatchBuilder<'_, Self> {
+        crate::BatchBuilder::new(self)
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -168,6 +168,16 @@ impl AsyncGraph {
         QueryBuilder::new(self, "GRAPH.RO_QUERY", query_string)
     }
 
+    /// Starts a [`BatchBuilder`](crate::BatchBuilder) for this graph: queue several queries with
+    /// `query`/`ro_query` (or `push`) and `execute().await` them over a single pipelined round-trip,
+    /// getting one result per query in submission order.
+    ///
+    /// # Returns
+    /// A [`BatchBuilder`](crate::BatchBuilder) borrowing this graph until executed.
+    pub fn batch(&mut self) -> crate::graph::batch::BatchBuilder<'_, Self> {
+        crate::graph::batch::BatchBuilder::new(self)
+    }
+
     /// Creates a [`ProcedureQueryBuilder`] for this graph
     /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     /// Read-only queries are more limited with the operations they are allowed to perform.

--- a/src/graph/batch.rs
+++ b/src/graph/batch.rs
@@ -1,0 +1,507 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Batch / pipelined execution: queue many queries and dispatch them over a single Redis pipeline
+//! in one round-trip, with per-query results in submission order.
+
+use crate::graph::query_builder::{
+    build_vec_rows, construct_query, dispatch_query_response, unwrap_query_response,
+};
+use crate::graph::HasGraphSchema;
+use crate::{
+    FalkorDBError, FalkorParams, FalkorResult, GraphSchema, IntoFalkorParam, IntoFalkorParams,
+    QueryResult, Row, SyncGraph,
+};
+
+/// The result of one query in a batch: `Ok` with its [`QueryResult`] (rows eagerly parsed into a
+/// `Vec<Row>`), or `Err` with that query's server / encoding / parse error. A failure here does
+/// **not** affect the other queries in the batch.
+pub type BatchItemResult = FalkorResult<QueryResult<Vec<Row>>>;
+
+/// The result of [`BatchBuilder::execute`]: one [`BatchItemResult`] per query, in submission order.
+///
+/// The **outer** `FalkorResult` only fails if the batch could not be completed. If it fails *after*
+/// the pipeline was sent (a transport error while reading replies), the server may have executed
+/// some or all queries — the result state is unknown. A batch with nothing to send (empty, or every
+/// query failed to encode) returns `Ok` without a round-trip.
+pub type BatchResult = FalkorResult<Vec<BatchItemResult>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BatchCommand {
+    Query,
+    RoQuery,
+}
+
+impl BatchCommand {
+    fn as_str(self) -> &'static str {
+        match self {
+            BatchCommand::Query => "GRAPH.QUERY",
+            BatchCommand::RoQuery => "GRAPH.RO_QUERY",
+        }
+    }
+
+    fn is_readonly(self) -> bool {
+        matches!(self, BatchCommand::RoQuery)
+    }
+}
+
+/// A single, graph-less query to run as part of a [`BatchBuilder`]. Owns its query text, parameters
+/// and timeout, so queries can be built up front (e.g. in a loop) and `push`ed into a batch.
+///
+/// Build one with [`BatchQuery::write`] (a `GRAPH.QUERY`) or [`BatchQuery::read`] (a read-only
+/// `GRAPH.RO_QUERY`), then attach parameters/timeout. Parameter encoding errors are reported per
+/// query when the batch executes (the failing query becomes an `Err`, the rest still run).
+pub struct BatchQuery {
+    command: BatchCommand,
+    query_string: String,
+    params: FalkorParams,
+    timeout: Option<i64>,
+}
+
+impl BatchQuery {
+    fn new(
+        command: BatchCommand,
+        query_string: impl Into<String>,
+    ) -> Self {
+        Self {
+            command,
+            query_string: query_string.into(),
+            params: FalkorParams::new(),
+            timeout: None,
+        }
+    }
+
+    /// A read-write query, dispatched as `GRAPH.QUERY`.
+    pub fn write(query_string: impl Into<String>) -> Self {
+        Self::new(BatchCommand::Query, query_string)
+    }
+
+    /// A read-only query, dispatched as `GRAPH.RO_QUERY`.
+    pub fn read(query_string: impl Into<String>) -> Self {
+        Self::new(BatchCommand::RoQuery, query_string)
+    }
+
+    /// Add a single typed parameter, referenced as `$key` in the query (escaped for you). Any
+    /// encoding error surfaces when the batch executes, as this query's `Err`.
+    pub fn with_param<V: IntoFalkorParam>(
+        &mut self,
+        key: &str,
+        value: V,
+    ) -> &mut Self {
+        self.params.add_param(key, value);
+        self
+    }
+
+    /// Add several typed parameters at once. See [`IntoFalkorParams`].
+    pub fn with_params<P: IntoFalkorParams>(
+        &mut self,
+        params: P,
+    ) -> &mut Self {
+        self.params.merge(params.into_falkor_params());
+        self
+    }
+
+    /// Escape hatch: insert a raw, already-valid Cypher expression as the parameter value (the name
+    /// is still validated). Prefer [`with_param`](Self::with_param).
+    pub fn with_raw_param(
+        &mut self,
+        key: &str,
+        raw_cypher: impl Into<String>,
+    ) -> &mut Self {
+        self.params.add_raw(key, raw_cypher.into());
+        self
+    }
+
+    /// Set a server-side timeout (milliseconds) for this query. This is per query, not a
+    /// client-side deadline for the whole batch.
+    pub fn with_timeout(
+        &mut self,
+        timeout: i64,
+    ) -> &mut Self {
+        self.timeout = Some(timeout);
+        self
+    }
+}
+
+/// Accumulates queries to run as a single pipelined batch. Create one with `graph.batch()`.
+///
+/// `query`/`ro_query` push a query and return a `&mut BatchQuery` for chaining parameters; the
+/// borrow ends at the statement, so a `for` loop works. To keep several queries around before
+/// adding them, build owned [`BatchQuery`] values and [`push`](Self::push) them.
+///
+/// ```no_run
+/// # fn main() -> Result<(), falkordb::FalkorDBError> {
+/// use falkordb::FalkorClientBuilder;
+/// # let info: falkordb::FalkorConnectionInfo = "falkor://127.0.0.1:6379".try_into()?;
+/// let client = FalkorClientBuilder::new().with_connection_info(info).build()?;
+/// let mut graph = client.select_graph("social");
+///
+/// let mut batch = graph.batch();
+/// for name in ["alice", "bob"] {
+///     batch.query("CREATE (:Person {name: $n})").with_param("n", name);
+/// }
+/// batch.ro_query("MATCH (p:Person) RETURN count(p) AS n");
+///
+/// let results = batch.execute()?; // one round-trip; one result per query, in order
+/// assert_eq!(results.len(), 3);
+/// # Ok(())
+/// # }
+/// ```
+pub struct BatchBuilder<'a, G> {
+    graph: &'a mut G,
+    queries: Vec<BatchQuery>,
+}
+
+impl<'a, G> BatchBuilder<'a, G> {
+    pub(crate) fn new(graph: &'a mut G) -> Self {
+        Self {
+            graph,
+            queries: Vec::new(),
+        }
+    }
+
+    /// Queue a read-write query (`GRAPH.QUERY`) and return a handle to set its params/timeout.
+    pub fn query(
+        &mut self,
+        query_string: impl Into<String>,
+    ) -> &mut BatchQuery {
+        self.queries.push(BatchQuery::write(query_string));
+        self.queries.last_mut().expect("a query was just pushed")
+    }
+
+    /// Queue a read-only query (`GRAPH.RO_QUERY`) and return a handle to set its params/timeout.
+    pub fn ro_query(
+        &mut self,
+        query_string: impl Into<String>,
+    ) -> &mut BatchQuery {
+        self.queries.push(BatchQuery::read(query_string));
+        self.queries.last_mut().expect("a query was just pushed")
+    }
+
+    /// Append an already-built [`BatchQuery`].
+    pub fn push(
+        &mut self,
+        query: BatchQuery,
+    ) -> &mut Self {
+        self.queries.push(query);
+        self
+    }
+
+    /// The number of queries queued so far.
+    pub fn len(&self) -> usize {
+        self.queries.len()
+    }
+
+    /// Whether no queries have been queued.
+    pub fn is_empty(&self) -> bool {
+        self.queries.is_empty()
+    }
+}
+
+/// Builds the pipeline, pre-filling a result slot for every query that fails to encode (those are
+/// never sent), and recording the original index of each *submitted* command so replies can be
+/// woven back into submission order.
+fn prepare(
+    graph_name: &str,
+    queries: &[BatchQuery],
+) -> (redis::Pipeline, Vec<usize>, Vec<Option<BatchItemResult>>) {
+    let mut pipe = redis::pipe();
+    let mut submitted = Vec::with_capacity(queries.len());
+    let mut slots: Vec<Option<BatchItemResult>> = (0..queries.len()).map(|_| None).collect();
+
+    for (index, query) in queries.iter().enumerate() {
+        match construct_query(&query.query_string, &query.params) {
+            Ok(query_string) => {
+                pipe.cmd(query.command.as_str())
+                    .arg(graph_name)
+                    .arg(query_string)
+                    .arg("--compact");
+                if let Some(timeout) = query.timeout {
+                    pipe.arg(format!("timeout {timeout}"));
+                }
+                submitted.push(index);
+            }
+            Err(err) => slots[index] = Some(Err(err)),
+        }
+    }
+
+    (pipe, submitted, slots)
+}
+
+/// Returns whether any queued query is a write (so the batch needs a read-write connection).
+fn has_write(queries: &[BatchQuery]) -> bool {
+    queries.iter().any(|query| !query.command.is_readonly())
+}
+
+/// Parses each reply (in submission order) into its original slot under the graph schema, then
+/// returns the fully-populated, in-order results. Errors if the server returned a different number
+/// of replies than commands submitted (a protocol surprise), so the contract can never panic.
+fn weave_replies(
+    mut slots: Vec<Option<BatchItemResult>>,
+    submitted: &[usize],
+    replies: Vec<redis::Value>,
+    graph_schema: &mut GraphSchema,
+) -> BatchResult {
+    if replies.len() != submitted.len() {
+        return Err(FalkorDBError::RedisParsingError(format!(
+            "batch expected {} replies but the server returned {}",
+            submitted.len(),
+            replies.len()
+        )));
+    }
+    for (reply, &index) in replies.into_iter().zip(submitted) {
+        slots[index] = Some(
+            unwrap_query_response(reply)
+                .and_then(|res| dispatch_query_response(res, &mut *graph_schema, build_vec_rows)),
+        );
+    }
+    Ok(slots
+        .into_iter()
+        .map(|slot| slot.expect("every slot is filled: encode errors up front, replies by index"))
+        .collect())
+}
+
+impl BatchBuilder<'_, SyncGraph> {
+    /// Dispatch all queued queries over one pipelined round-trip and return their results in
+    /// submission order. An empty batch (or one whose every query failed to encode) returns without
+    /// a round-trip.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Execute Batch", skip_all, level = "info")
+    )]
+    pub fn execute(self) -> BatchResult {
+        let (pipe, submitted, slots) = prepare(self.graph.graph_name(), &self.queries);
+        if submitted.is_empty() {
+            return Ok(slots
+                .into_iter()
+                .map(|slot| slot.expect("all filled"))
+                .collect());
+        }
+
+        let client = self.graph.get_client().clone();
+        let conn = if has_write(&self.queries) {
+            client.borrow_connection(client.clone())
+        } else {
+            client.borrow_readonly_connection(client.clone())
+        };
+        let replies = conn?.execute_pipeline(&pipe)?;
+
+        let graph_schema = self.graph.get_graph_schema_mut();
+        weave_replies(slots, &submitted, replies, graph_schema)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl BatchBuilder<'_, crate::AsyncGraph> {
+    /// Dispatch all queued queries over one pipelined round-trip and return their results in
+    /// submission order. An empty batch (or one whose every query failed to encode) returns without
+    /// a round-trip.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Execute Batch", skip_all, level = "info")
+    )]
+    pub async fn execute(self) -> BatchResult {
+        let (pipe, submitted, slots) = prepare(self.graph.graph_name(), &self.queries);
+        if submitted.is_empty() {
+            return Ok(slots
+                .into_iter()
+                .map(|slot| slot.expect("all filled"))
+                .collect());
+        }
+
+        let client = self.graph.get_client().clone();
+        let conn = if has_write(&self.queries) {
+            client.borrow_connection(client.clone()).await
+        } else {
+            client.borrow_readonly_connection(client.clone()).await
+        };
+        let replies = conn?.execute_pipeline(&pipe).await?;
+
+        let schema = self.graph.schema_handle();
+        let mut guard = schema.write();
+        weave_replies(slots, &submitted, replies, &mut guard)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+
+    /// A minimal valid `GRAPH.QUERY` reply: a one-element response (stats only), which parses into
+    /// an empty result without needing any schema lookup.
+    fn stats_only_reply() -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![])])
+    }
+
+    #[test]
+    fn batch_command_strings_and_readonly() {
+        assert_eq!(BatchCommand::Query.as_str(), "GRAPH.QUERY");
+        assert_eq!(BatchCommand::RoQuery.as_str(), "GRAPH.RO_QUERY");
+        assert!(!BatchCommand::Query.is_readonly());
+        assert!(BatchCommand::RoQuery.is_readonly());
+    }
+
+    #[test]
+    fn builder_mechanics_are_graph_agnostic() {
+        let mut graph = (); // the queue-building methods work for any graph type
+        let mut batch = BatchBuilder::new(&mut graph);
+        assert!(batch.is_empty());
+        batch.query("RETURN 1").with_param("k", 1).with_timeout(500);
+        batch.ro_query("RETURN 2");
+        batch.push(BatchQuery::write("RETURN 3"));
+        assert_eq!(batch.len(), 3);
+        assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn has_write_detects_any_write_query() {
+        assert!(has_write(&[BatchQuery::write("x")]));
+        assert!(has_write(&[BatchQuery::read("x"), BatchQuery::write("y")]));
+        assert!(!has_write(&[BatchQuery::read("x"), BatchQuery::read("y")]));
+        assert!(!has_write(&[]));
+    }
+
+    #[test]
+    fn prepare_skips_encode_errors_and_records_submitted_indices() {
+        let mut bad = BatchQuery::write("RETURN 2");
+        bad.with_param("invalid name!", 1); // invalid Cypher identifier -> encode error
+        let queries = vec![
+            BatchQuery::write("RETURN 1"),
+            bad,
+            BatchQuery::read("RETURN 3"),
+        ];
+
+        let (pipe, submitted, slots) = prepare("g", &queries);
+
+        assert_eq!(submitted, vec![0, 2], "the middle query must be skipped");
+        assert_eq!(
+            pipe.len(),
+            2,
+            "only the two encodable queries are pipelined"
+        );
+        assert!(slots[0].is_none());
+        assert!(
+            matches!(slots[1], Some(Err(_))),
+            "skipped slot is pre-filled with its error"
+        );
+        assert!(slots[2].is_none());
+    }
+
+    #[test]
+    fn prepare_all_encode_errors_pipelines_nothing() {
+        let mut q = BatchQuery::write("RETURN 1");
+        q.with_param("invalid name!", 1);
+        let (pipe, submitted, slots) = prepare("g", &[q]);
+        assert!(submitted.is_empty());
+        assert_eq!(pipe.len(), 0);
+        assert!(matches!(slots[0], Some(Err(_))));
+    }
+
+    #[test]
+    fn weave_replies_aligns_replies_around_a_skipped_slot() {
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        // Original order: [submitted, skipped(Err), submitted].
+        let slots: Vec<Option<BatchItemResult>> = vec![
+            None,
+            Some(Err(FalkorDBError::RedisError("encode".to_string()))),
+            None,
+        ];
+        let submitted = vec![0usize, 2usize];
+        let replies = vec![stats_only_reply(), stats_only_reply()];
+
+        let out = weave_replies(slots, &submitted, replies, &mut schema).expect("woven");
+
+        assert_eq!(out.len(), 3);
+        assert!(out[0].is_ok(), "first submitted query parsed");
+        assert!(
+            matches!(&out[1], Err(FalkorDBError::RedisError(m)) if m == "encode"),
+            "the pre-filled encode error is preserved in its original slot"
+        );
+        assert!(
+            out[2].is_ok(),
+            "second submitted query parsed into slot 2, not slot 1"
+        );
+    }
+
+    #[test]
+    fn weave_replies_errors_on_reply_count_mismatch() {
+        let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+        // Two commands submitted but only one reply -> a protocol surprise, surfaced as Err
+        // (never a panic).
+        let too_few = weave_replies(
+            vec![None, None],
+            &[0, 1],
+            vec![stats_only_reply()],
+            &mut schema,
+        );
+        assert!(matches!(too_few, Err(FalkorDBError::RedisParsingError(_))));
+        // More replies than commands also errors.
+        let too_many = weave_replies(
+            vec![None],
+            &[0],
+            vec![stats_only_reply(), stats_only_reply()],
+            &mut schema,
+        );
+        assert!(matches!(too_many, Err(FalkorDBError::RedisParsingError(_))));
+    }
+}
+
+#[cfg(test)]
+mod proptest {
+    use super::*;
+    use crate::client::blocking::create_empty_inner_sync_client;
+    use ::proptest::prelude::*;
+
+    fn stats_only_reply() -> redis::Value {
+        redis::Value::Array(vec![redis::Value::Array(vec![])])
+    }
+
+    /// `true` = an encodable (good) query, `false` = a query whose param fails to encode (skipped).
+    fn batch_of(good_flags: &[bool]) -> Vec<BatchQuery> {
+        good_flags
+            .iter()
+            .map(|&good| {
+                let mut q = BatchQuery::write("RETURN 1");
+                if !good {
+                    q.with_param("invalid name!", 1); // never encodes
+                }
+                q
+            })
+            .collect()
+    }
+
+    proptest! {
+        /// For any mix of encodable and non-encodable queries, `prepare` + `weave_replies` keep the
+        /// results 1:1 with submission order: every good query maps to its reply, every skipped
+        /// query keeps its pre-filled error, and lengths never drift (the off-by-one guard).
+        #[test]
+        fn skip_and_weave_preserves_submission_order(good_flags in prop::collection::vec(any::<bool>(), 0..16)) {
+            let queries = batch_of(&good_flags);
+            let (pipe, submitted, slots) = prepare("g", &queries);
+
+            let expected_submitted: Vec<usize> = good_flags
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &good)| good.then_some(i))
+                .collect();
+            prop_assert_eq!(&submitted, &expected_submitted);
+            prop_assert_eq!(pipe.len(), submitted.len());
+            for (i, &good) in good_flags.iter().enumerate() {
+                prop_assert_eq!(slots[i].is_some(), !good);
+            }
+
+            // Simulate a successful dispatch: one reply per submitted command.
+            let replies = vec![stats_only_reply(); submitted.len()];
+            let mut schema = GraphSchema::new("test", create_empty_inner_sync_client());
+            let out = weave_replies(slots, &submitted, replies, &mut schema).expect("woven");
+
+            prop_assert_eq!(out.len(), good_flags.len());
+            for (i, &good) in good_flags.iter().enumerate() {
+                prop_assert_eq!(out[i].is_ok(), good);
+            }
+        }
+    }
+}

--- a/src/graph/batch.rs
+++ b/src/graph/batch.rs
@@ -219,7 +219,7 @@ fn prepare(
                     .arg(query_string)
                     .arg("--compact");
                 if let Some(timeout) = query.timeout {
-                    pipe.arg(format!("timeout {timeout}"));
+                    pipe.arg("timeout").arg(timeout);
                 }
                 submitted.push(index);
             }

--- a/src/graph/batch.rs
+++ b/src/graph/batch.rs
@@ -357,6 +357,20 @@ mod tests {
     }
 
     #[test]
+    fn batch_query_with_params_and_raw_param_encode() {
+        // Exercise with_params (bulk typed params) and with_raw_param (raw Cypher value);
+        // a successful `prepare` confirms all three params were merged and encoded.
+        let mut q = BatchQuery::write("CREATE (n {a: $a, b: $b, c: $c})");
+        q.with_params([("a", 1), ("b", 2)])
+            .with_raw_param("c", "timestamp()");
+        let queries = vec![q];
+        let (pipe, submitted, slots) = prepare("g", &queries);
+        assert_eq!(submitted, vec![0], "query with bulk + raw params encodes");
+        assert_eq!(pipe.len(), 1);
+        assert!(slots[0].is_none());
+    }
+
+    #[test]
     fn has_write_detects_any_write_query() {
         assert!(has_write(&[BatchQuery::write("x")]));
         assert!(has_write(&[BatchQuery::read("x"), BatchQuery::write("y")]));

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -162,8 +162,8 @@ impl SyncGraph {
     ///
     /// # Returns
     /// A [`BatchBuilder`](crate::BatchBuilder) borrowing this graph until executed.
-    pub fn batch(&mut self) -> crate::graph::batch::BatchBuilder<'_, Self> {
-        crate::graph::batch::BatchBuilder::new(self)
+    pub fn batch(&mut self) -> crate::BatchBuilder<'_, Self> {
+        crate::BatchBuilder::new(self)
     }
 
     /// Creates a [`ProcedureQueryBuilder`] for this graph

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -156,6 +156,16 @@ impl SyncGraph {
         QueryBuilder::new(self, "GRAPH.RO_QUERY", query_string)
     }
 
+    /// Starts a [`BatchBuilder`](crate::BatchBuilder) for this graph: queue several queries with
+    /// `query`/`ro_query` (or `push`) and `execute()` them over a single pipelined round-trip,
+    /// getting one result per query in submission order.
+    ///
+    /// # Returns
+    /// A [`BatchBuilder`](crate::BatchBuilder) borrowing this graph until executed.
+    pub fn batch(&mut self) -> crate::graph::batch::BatchBuilder<'_, Self> {
+        crate::graph::batch::BatchBuilder::new(self)
+    }
+
     /// Creates a [`ProcedureQueryBuilder`] for this graph
     /// This [`ProcedureQueryBuilder`] has to be dropped or ran using [`ProcedureQueryBuilder::execute`], before reusing the graph, as it takes a mutable reference to the graph for as long as it exists
     /// Read-only queries are more limited with the operations they are allowed to perform.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -9,6 +9,8 @@ use std::{collections::HashMap, fmt::Display};
 pub(crate) mod blocking;
 pub(crate) mod query_builder;
 
+pub(crate) mod batch;
+
 pub(crate) mod ops;
 
 #[cfg(feature = "tokio")]

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -262,9 +262,12 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
     fn common_execute_steps(&mut self) -> FalkorResult<redis::Value> {
         let query = construct_query(&self.query_string, &self.params)?;
 
-        let timeout = self.timeout.map(|timeout| format!("timeout {timeout}"));
+        let timeout = self.timeout.map(|timeout| timeout.to_string());
         let mut params = vec![query.as_str(), "--compact"];
-        params.extend(timeout.as_deref());
+        if let Some(timeout) = timeout.as_deref() {
+            params.push("timeout");
+            params.push(timeout);
+        }
 
         let client = self.graph.get_client();
         let conn = if self.command == "GRAPH.RO_QUERY" {
@@ -298,9 +301,12 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
     async fn common_execute_steps(&mut self) -> FalkorResult<redis::Value> {
         let query = construct_query(&self.query_string, &self.params)?;
 
-        let timeout = self.timeout.map(|timeout| format!("timeout {timeout}"));
+        let timeout = self.timeout.map(|timeout| timeout.to_string());
         let mut params = vec![query.as_str(), "--compact"];
-        params.extend(timeout.as_deref());
+        if let Some(timeout) = timeout.as_deref() {
+            params.push("timeout");
+            params.push(timeout);
+        }
 
         let client = self.graph.get_client();
         let conn = if self.command == "GRAPH.RO_QUERY" {

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -48,9 +48,24 @@ fn build_row_stream_result(
     QueryResult::from_response(header, data, stats)
 }
 
+/// Builds a [`QueryResult`] over an eagerly-parsed `Vec<Row>`, used by the batch API where N result
+/// sets coexist (so a borrowing [`LazyResultSet`] is not an option). A row that fails to parse
+/// collapses the whole result to that `Err`.
+pub(crate) fn build_vec_rows(
+    header: Arc<[String]>,
+    rows: Vec<redis::Value>,
+    stats: redis::Value,
+    graph_schema: &mut GraphSchema,
+) -> FalkorResult<QueryResult<Vec<crate::Row>>> {
+    let data = crate::response::row::parse_rows(Arc::clone(&header), rows, graph_schema)
+        .into_iter()
+        .collect::<FalkorResult<Vec<_>>>()?;
+    QueryResult::from_response(header, data, stats)
+}
+
 /// Unwraps a top-level query reply: a `ServerError` becomes a [`FalkorDBError::RedisError`],
 /// otherwise the reply is read as the response array.
-fn unwrap_query_response(value: redis::Value) -> FalkorResult<Vec<redis::Value>> {
+pub(crate) fn unwrap_query_response(value: redis::Value) -> FalkorResult<Vec<redis::Value>> {
     if let redis::Value::ServerError(e) = value {
         return Err(FalkorDBError::RedisError(
             e.details().unwrap_or("Unknown error").to_string(),
@@ -63,7 +78,7 @@ fn unwrap_query_response(value: redis::Value) -> FalkorResult<Vec<redis::Value>>
 /// is a header with no rows, three is header + rows + stats. Any other length is malformed. The
 /// `build` closure constructs the concrete result set (sync [`LazyResultSet`] or async
 /// [`RowStream`](crate::RowStream)) from the parsed header, rows, stats, and `schema` handle.
-fn dispatch_query_response<S, D>(
+pub(crate) fn dispatch_query_response<S, D>(
     res: Vec<redis::Value>,
     schema: S,
     build: impl FnOnce(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use client::{blocking::FalkorSyncClient, builder::FalkorClientBuilder, Conne
 pub use connection_info::FalkorConnectionInfo;
 pub use error::FalkorDBError;
 pub use graph::{
+    batch::{BatchBuilder, BatchItemResult, BatchQuery, BatchResult},
     blocking::SyncGraph,
     ops::{ConstraintOpBuilder, CopyGraphBuilder, IndexOpBuilder, WaitOperation, WaitOptions},
     query_builder::{ProcedureQueryBuilder, QueryBuilder},

--- a/src/response/row.rs
+++ b/src/response/row.rs
@@ -8,7 +8,6 @@
 use crate::{FalkorDBError, FalkorResult, FalkorValue, FromFalkorValue};
 use std::collections::HashMap;
 use std::sync::Arc;
-
 /// A single result row: the query's column names (the *header*) paired with this row's values.
 ///
 /// `Row` is what the default [`LazyResultSet`](crate::LazyResultSet) backing `QueryResult::data`
@@ -211,6 +210,35 @@ impl FromIterator<(String, FalkorValue)> for Row {
             values,
         }
     }
+}
+
+/// Parses every raw row of a query reply into a [`Row`], resolving compact ids against
+/// `graph_schema` (refreshing it once on a cache miss). Per-row parse failures are surfaced as `Err`
+/// items rather than aborting the whole set, so callers choose whether to keep going
+/// ([`RowStream`](crate::RowStream)) or collapse to the first error (the batch API).
+///
+/// Shared by [`RowStream::parse`](crate::RowStream) (async, lazy-yielding) and the batch builder
+/// (eager `Vec<Row>`), so the row-decoding logic lives in exactly one place.
+pub(crate) fn parse_rows(
+    header: Arc<[String]>,
+    raw_rows: Vec<redis::Value>,
+    graph_schema: &mut crate::GraphSchema,
+) -> Vec<FalkorResult<Row>> {
+    use crate::parser::{parse_type, ParserTypeMarker};
+    raw_rows
+        .into_iter()
+        .map(|raw| {
+            let values = parse_type(ParserTypeMarker::Array, raw, graph_schema)
+                .and_then(FalkorValue::into_vec)?;
+            if values.len() != header.len() {
+                return Err(FalkorDBError::RowShapeMismatch {
+                    header_len: header.len(),
+                    value_len: values.len(),
+                });
+            }
+            Ok(Row::new(Arc::clone(&header), values))
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/response/row_stream.rs
+++ b/src/response/row_stream.rs
@@ -6,8 +6,7 @@
 //! An owned, `Send + 'static` async result set implementing [`futures_core::Stream`], available
 //! with the `tokio` feature.
 
-use crate::parser::{parse_type, ParserTypeMarker};
-use crate::{FalkorDBError, FalkorResult, FalkorValue, GraphSchema, Row};
+use crate::{FalkorResult, FalkorValue, GraphSchema, Row};
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -55,21 +54,9 @@ impl RowStream {
         raw_rows: Vec<redis::Value>,
         graph_schema: &mut GraphSchema,
     ) -> Self {
-        let rows = raw_rows
-            .into_iter()
-            .map(|raw| {
-                let values = parse_type(ParserTypeMarker::Array, raw, graph_schema)
-                    .and_then(FalkorValue::into_vec)?;
-                if values.len() != header.len() {
-                    return Err(FalkorDBError::RowShapeMismatch {
-                        header_len: header.len(),
-                        value_len: values.len(),
-                    });
-                }
-                Ok(Row::new(Arc::clone(&header), values))
-            })
-            .collect();
-        Self { rows }
+        Self {
+            rows: crate::response::row::parse_rows(header, raw_rows, graph_schema).into(),
+        }
     }
 
     /// Returns the number of rows remaining in the result set.
@@ -114,6 +101,7 @@ impl futures_core::Stream for RowStream {
 mod tests {
     use super::*;
     use crate::client::blocking::create_empty_inner_sync_client;
+    use crate::FalkorDBError;
 
     /// A single-column row holding one scalar `i64` (`ParserTypeMarker::I64 == 3`), which parses
     /// without needing any schema lookup.

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1239,3 +1239,230 @@ mod async_streaming {
         );
     }
 }
+
+mod batch_pipelining {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{BatchQuery, FalkorClientBuilder, FalkorDBError};
+
+    fn graph_for(name: &str) -> Option<falkordb::SyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete();
+        Some(graph)
+    }
+
+    #[test]
+    fn bulk_create_then_count_in_one_round_trip() {
+        let Some(mut graph) = graph_for("test_batch_bulk") else {
+            return;
+        };
+        let mut batch = graph.batch();
+        for i in 1..=5 {
+            batch.query("CREATE (:N {v: $v})").with_param("v", i);
+        }
+        batch.ro_query("MATCH (n:N) RETURN count(n) AS n");
+        let results = batch.execute().expect("batch dispatched");
+
+        assert_eq!(results.len(), 6);
+        for r in &results[..5] {
+            assert!(r.is_ok(), "create failed: {r:?}");
+        }
+        let count: i64 = results[5].as_ref().expect("count ok").data[0]
+            .try_get("n")
+            .expect("n");
+        assert_eq!(count, 5);
+        graph.delete().expect("delete");
+    }
+
+    #[test]
+    fn invalid_query_is_isolated_and_siblings_commit() {
+        let Some(mut graph) = graph_for("test_batch_isolated") else {
+            return;
+        };
+        let mut batch = graph.batch();
+        batch.query("CREATE (:N {v: 1})");
+        batch.query("THIS IS NOT CYPHER"); // invalid -> per-item Err
+        batch.query("CREATE (:N {v: 2})");
+        let results = batch.execute().expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        assert!(
+            matches!(results[1], Err(FalkorDBError::RedisError(_))),
+            "bad cypher must surface as that item's Err, got {:?}",
+            results[1]
+        );
+        assert!(results[2].is_ok());
+
+        // Both valid siblings committed despite the middle failure.
+        let mut count = graph
+            .ro_query("MATCH (n:N) RETURN count(n) AS n")
+            .execute()
+            .expect("count");
+        let n: i64 = count.data.next().unwrap().unwrap().try_get("n").unwrap();
+        assert_eq!(n, 2);
+        graph.delete().expect("delete");
+    }
+
+    #[test]
+    fn param_encode_error_is_isolated() {
+        let Some(mut graph) = graph_for("test_batch_param_err") else {
+            return;
+        };
+        let mut batch = graph.batch();
+        batch.query("CREATE (:N {v: 1})");
+        batch
+            .query("CREATE (:N {v: $v})")
+            .with_param("invalid name!", 1); // never encodes -> never sent
+        batch.query("CREATE (:N {v: 2})");
+        let results = batch.execute().expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        assert!(results[1].is_err(), "param encode error -> per-item Err");
+        assert!(results[2].is_ok());
+        graph.delete().expect("delete");
+    }
+
+    #[test]
+    fn empty_batch_returns_empty() {
+        let Some(mut graph) = graph_for("test_batch_empty") else {
+            return;
+        };
+        let results = graph.batch().execute().expect("empty batch ok");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn write_then_read_new_label_in_same_batch() {
+        let Some(mut graph) = graph_for("test_batch_newlabel") else {
+            return;
+        };
+        let mut batch = graph.batch();
+        batch.query("CREATE (:Movie {title: 'Heat'})");
+        batch.ro_query("MATCH (m:Movie) RETURN m.title AS title");
+        let results = batch.execute().expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        let rows = &results[1].as_ref().expect("read ok").data;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].try_get::<String>("title").unwrap(), "Heat");
+        graph.delete().expect("delete");
+    }
+
+    #[test]
+    fn push_owned_batch_queries() {
+        let Some(mut graph) = graph_for("test_batch_push") else {
+            return;
+        };
+        let mut read = BatchQuery::read("MATCH (n:N) RETURN count(n) AS n");
+        read.with_timeout(5000);
+
+        let mut batch = graph.batch();
+        batch.push(BatchQuery::write("CREATE (:N {v: 1})"));
+        batch.push(read);
+        let results = batch.execute().expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        let n: i64 = results[1].as_ref().unwrap().data[0].try_get("n").unwrap();
+        assert_eq!(n, 1);
+        graph.delete().expect("delete");
+    }
+}
+
+#[cfg(feature = "tokio")]
+mod async_batch_pipelining {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{AsyncGraph, ConnectionStrategy, FalkorClientBuilder, FalkorDBError};
+    use std::num::NonZeroU8;
+
+    async fn async_graph_for(name: &str) -> Option<AsyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new_async()
+            .with_connection_info(conn_info)
+            .build()
+            .await
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete().await;
+        Some(graph)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_bulk_create_then_count() {
+        let Some(mut graph) = async_graph_for("test_async_batch_bulk").await else {
+            return;
+        };
+        let mut batch = graph.batch();
+        for i in 1..=5 {
+            batch.query("CREATE (:N {v: $v})").with_param("v", i);
+        }
+        batch.ro_query("MATCH (n:N) RETURN count(n) AS n");
+        let results = batch.execute().await.expect("batch dispatched");
+
+        assert_eq!(results.len(), 6);
+        for r in &results[..5] {
+            assert!(r.is_ok());
+        }
+        let count: i64 = results[5].as_ref().expect("count ok").data[0]
+            .try_get("n")
+            .expect("n");
+        assert_eq!(count, 5);
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_invalid_query_is_isolated() {
+        let Some(mut graph) = async_graph_for("test_async_batch_isolated").await else {
+            return;
+        };
+        let mut batch = graph.batch();
+        batch.query("CREATE (:N {v: 1})");
+        batch.query("NOT CYPHER AT ALL");
+        batch.query("CREATE (:N {v: 2})");
+        let results = batch.execute().await.expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        assert!(matches!(results[1], Err(FalkorDBError::RedisError(_))));
+        assert!(results[2].is_ok());
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_batch_over_pooled_connection() {
+        // The pooled async strategy uses the non-multiplexed connection variant, so this exercises
+        // the pipeline dispatch path for that variant.
+        if skip_if_no_server() {
+            return;
+        }
+        let conn_info = get_test_connection_info().expect("conn info");
+        let client = FalkorClientBuilder::new_async()
+            .with_connection_info(conn_info)
+            .with_connection_strategy(ConnectionStrategy::Pooled {
+                size: NonZeroU8::new(2).expect("valid pool size"),
+            })
+            .build()
+            .await
+            .expect("pooled client");
+        let mut graph = client.select_graph("test_async_batch_pooled");
+        let _ = graph.delete().await;
+
+        let mut batch = graph.batch();
+        batch.query("CREATE (:N {v: 1})");
+        batch.ro_query("MATCH (n:N) RETURN count(n) AS n");
+        let results = batch.execute().await.expect("batch dispatched");
+
+        assert!(results[0].is_ok());
+        let n: i64 = results[1].as_ref().unwrap().data[0].try_get("n").unwrap();
+        assert_eq!(n, 1);
+        graph.delete().await.expect("delete");
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1508,6 +1508,10 @@ mod async_batch_pipelining {
             .try_get("n")
             .expect("n");
         assert_eq!(n, 2);
+        let m: i64 = results[1].as_ref().expect("max ok").data[0]
+            .try_get("m")
+            .expect("m");
+        assert_eq!(m, 2);
         graph.delete().await.expect("delete");
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1339,6 +1339,49 @@ mod batch_pipelining {
     }
 
     #[test]
+    fn readonly_only_batch_uses_readonly_path() {
+        let Some(mut graph) = graph_for("test_batch_ro_only") else {
+            return;
+        };
+        // Seed with a separate write, then run a batch of only read-only queries so
+        // execute() takes the read-only connection path (no writes in the batch).
+        graph
+            .query("CREATE (:N {v: 1}), (:N {v: 2})")
+            .execute()
+            .expect("seed");
+        let mut batch = graph.batch();
+        batch.ro_query("MATCH (n:N) RETURN count(n) AS n");
+        batch.ro_query("MATCH (n:N) RETURN max(n.v) AS m");
+        let results = batch.execute().expect("ro batch dispatched");
+
+        assert_eq!(results.len(), 2);
+        let n: i64 = results[0].as_ref().expect("count ok").data[0]
+            .try_get("n")
+            .expect("n");
+        assert_eq!(n, 2);
+        let m: i64 = results[1].as_ref().expect("max ok").data[0]
+            .try_get("m")
+            .expect("m");
+        assert_eq!(m, 2);
+        graph.delete().expect("delete");
+    }
+
+    #[test]
+    fn query_with_timeout_executes() {
+        let Some(mut graph) = graph_for("test_query_timeout") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN 1 AS one")
+            .with_timeout(5000)
+            .execute()
+            .expect("query with timeout");
+        let v: i64 = result.data.next().unwrap().unwrap().try_get("one").unwrap();
+        assert_eq!(v, 1);
+        graph.delete().expect("delete");
+    }
+
+    #[test]
     fn write_then_read_new_label_in_same_batch() {
         let Some(mut graph) = graph_for("test_batch_newlabel") else {
             return;
@@ -1433,6 +1476,56 @@ mod async_batch_pipelining {
         assert!(results[0].is_ok());
         assert!(matches!(results[1], Err(FalkorDBError::RedisError(_))));
         assert!(results[2].is_ok());
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_empty_batch_returns_empty() {
+        let Some(mut graph) = async_graph_for("test_async_batch_empty").await else {
+            return;
+        };
+        let results = graph.batch().execute().await.expect("empty async batch ok");
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_readonly_only_batch_uses_readonly_path() {
+        let Some(mut graph) = async_graph_for("test_async_batch_ro_only").await else {
+            return;
+        };
+        graph
+            .query("CREATE (:N {v: 1}), (:N {v: 2})")
+            .execute()
+            .await
+            .expect("seed");
+        let mut batch = graph.batch();
+        batch.ro_query("MATCH (n:N) RETURN count(n) AS n");
+        batch.ro_query("MATCH (n:N) RETURN max(n.v) AS m");
+        let results = batch.execute().await.expect("ro async batch");
+
+        assert_eq!(results.len(), 2);
+        let n: i64 = results[0].as_ref().expect("count ok").data[0]
+            .try_get("n")
+            .expect("n");
+        assert_eq!(n, 2);
+        graph.delete().await.expect("delete");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn async_query_with_timeout_executes() {
+        use futures::TryStreamExt;
+        let Some(mut graph) = async_graph_for("test_async_query_timeout").await else {
+            return;
+        };
+        let result = graph
+            .query("RETURN 1 AS one")
+            .with_timeout(5000)
+            .execute()
+            .await
+            .expect("async query with timeout");
+        let rows: Vec<falkordb::Row> = result.data.try_collect().await.expect("collect");
+        let v: i64 = rows[0].try_get("one").unwrap();
+        assert_eq!(v, 1);
         graph.delete().await.expect("delete");
     }
 


### PR DESCRIPTION
## Summary

Adds **batch / pipelined execution**: `graph.batch()` queues many queries and dispatches them over a single Redis pipeline in **one round-trip**, returning one result per query **in submission order**. This is next-steps Idea 4 — the highest value-for-effort item, and it builds directly on the 0.8.0 streaming/schema work.

Additive / non-breaking → targets **0.9.0**. Available on both `SyncGraph` and `AsyncGraph`.

## Usage

```rust
let mut batch = graph.batch();
for movie in &movies {
    batch.query("CREATE (:Movie {title: $t})").with_param("t", movie);
}
batch.ro_query("MATCH (m:Movie) RETURN count(m) AS n");

let results = batch.execute()?; // async: batch.execute().await?
for (i, item) in results.into_iter().enumerate() {
    match item {
        Ok(result) => { /* result.data: Vec<Row>, result.header, result.stats */ }
        Err(err)   => eprintln!("query {i} failed: {err}"),
    }
}
```

`BatchResult = FalkorResult<Vec<BatchItemResult>>` and `BatchItemResult = FalkorResult<QueryResult<Vec<Row>>>`.

## Design

- **Per-item error attribution.** The low-level `req_packed_commands` returns a per-command `Value::ServerError` in its slot (verified empirically against a live server for both sync and async — unlike `Pipeline::query`, which fails the whole batch). Each slot is mapped through the existing `unwrap_query_response`, so a failing query (bad Cypher, or a parameter that can't be encoded) is isolated to its own `Err`; siblings still run. **Not a transaction** — every queued query is executed.
- **Reuses the 0.8.0 machinery.** Replies are eagerly parsed into `Vec<Row>` under one schema write lock (the same pattern as the async procedure path and `RowStream`); a write-then-read-new-label batch refreshes the schema inline. The row loop is factored into a shared `response::row::parse_rows` reused by `RowStream` (so there's no tokio-gating duplication).
- **Skip-and-weave.** A query whose params fail to encode is pre-filled as an `Err` slot and never sent; `prepare` records the original index of each *submitted* command and `weave_replies` zips replies back so results stay 1:1 with submission order. A reply-count mismatch is surfaced as an `Err` (never a panic).
- **Connection handling.** One connection is borrowed for the batch (write if any query is `GRAPH.QUERY`, else a read-only/replica connection). The dead-connection recovery is now a shared generic `recover_on_connection_down<T>` used by both `execute_command` and the new `execute_pipeline`.
- **Owned queries.** `BatchQuery::write(..)`/`read(..)` + `batch.push(..)` for building queries ahead of time.

The outer `Result` only fails if the batch can't be completed; if that happens *after* the pipeline is sent, the server may have run some/all queries (state unknown) — documented, and it matters for writes.

## Tests & docs

- Server-less unit tests (skip-and-weave alignment, reply-count-mismatch error, `has_write`, command construction, connection-down recovery, `None`-connection pipeline), a **property test** for skip-and-weave order preservation, and **sync + async** server-backed integration tests (bulk create + count in one round-trip, mixed RO/write, an invalid query isolated with siblings committed, param-encode-error isolated, empty batch, write-then-read-new-label, pooled-connection dispatch).
- Runnable [`examples/batch.rs`](examples/batch.rs), a README "Batch & pipelined execution" section, a `BatchBuilder` doctest, and a CHANGELOG entry.
- All gates green locally: fmt, clippy `--all-targets`, full server-backed suite, doctests, `cargo doc`, `cargo deny`, spellcheck, `just proptest`, and **~99% patch coverage**.

Both the design and the implementation went through a rubber-duck review; the design review tightened the outer-error semantics, schema invariant, skip-and-weave algorithm, and the shared connection helper, and the implementation review hardened `weave_replies` against reply-count drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch/pipelined graph query execution via `graph.batch()` on both sync and async instances
  * Queue multiple read/write and read-only queries (including owned queries) with per-item parameters and optional timeouts
  * Execute in a single pipeline round-trip; results are returned in submission order with per-item error isolation (batch is not a transaction)

* **Documentation**
  * Added a “Batch & pipelined execution” README section and a runnable batch example

* **Tests**
  * Added sync and async integration coverage for ordering, empty batches, timeouts, and error scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->