### PR TITLE
fix: surface slowlog parse errors instead of silently dropping entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `slowlog()` (sync and async) now surfaces a parse error for a malformed entry instead of
+  silently dropping it (the previous `flat_map` swallowed per-entry errors). Behavior for valid
+  replies is unchanged.
+
+
 ## [0.8.0](https://github.com/FalkorDB/falkordb-rs/compare/v0.7.0...v0.8.0) - 2026-06-17
 
 ### Added

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -6,7 +6,6 @@
 use crate::{
     client::asynchronous::FalkorAsyncClientInner,
     graph::{generate_create_index_query, generate_drop_index_query},
-    parser::redis_value_as_vec,
     Constraint, ConstraintType, EntityType, ExecutionPlan, FalkorIndex, FalkorResult, GraphSchema,
     IndexType, ProcedureQueryBuilder, QueryBuilder, QueryResult, RowStream, SlowlogEntry,
 };
@@ -95,10 +94,7 @@ impl AsyncGraph {
     pub async fn slowlog(&self) -> FalkorResult<Vec<SlowlogEntry>> {
         self.execute_command("GRAPH.SLOWLOG", None, None)
             .await
-            .and_then(|res| {
-                redis_value_as_vec(res)
-                    .map(|as_vec| as_vec.into_iter().flat_map(SlowlogEntry::parse).collect())
-            })
+            .and_then(crate::response::slowlog_entry::parse_slowlog)
     }
 
     /// Resets the slowlog, all query time data will be cleared.

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -6,7 +6,6 @@
 use crate::{
     client::blocking::FalkorSyncClientInner,
     graph::{generate_create_index_query, generate_drop_index_query, HasGraphSchema},
-    parser::redis_value_as_vec,
     Constraint, ConstraintType, EntityType, ExecutionPlan, FalkorIndex, FalkorResult, GraphSchema,
     IndexType, LazyResultSet, ProcedureQueryBuilder, QueryBuilder, QueryResult, SlowlogEntry,
 };
@@ -84,10 +83,7 @@ impl SyncGraph {
     )]
     pub fn slowlog(&self) -> FalkorResult<Vec<SlowlogEntry>> {
         self.execute_command("GRAPH.SLOWLOG", None, None)
-            .and_then(|res| {
-                redis_value_as_vec(res)
-                    .map(|as_vec| as_vec.into_iter().flat_map(SlowlogEntry::parse).collect())
-            })
+            .and_then(crate::response::slowlog_entry::parse_slowlog)
     }
 
     /// Resets the slowlog, all query time data will be cleared.

--- a/src/response/slowlog_entry.rs
+++ b/src/response/slowlog_entry.rs
@@ -48,6 +48,16 @@ impl SlowlogEntry {
     }
 }
 
+/// Parses a `GRAPH.SLOWLOG` reply (a list of entries) into [`SlowlogEntry`]s, propagating a parse
+/// error for any malformed entry instead of silently dropping it. Shared by the sync and async
+/// `slowlog` methods.
+pub(crate) fn parse_slowlog(value: redis::Value) -> FalkorResult<Vec<SlowlogEntry>> {
+    redis_value_as_vec(value)?
+        .into_iter()
+        .map(SlowlogEntry::parse)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,5 +127,50 @@ mod tests {
         assert_eq!(entry.command, "TEST");
         assert_eq!(entry.arguments, "test args");
         assert_eq!(entry.time_taken, 0.5);
+    }
+
+    fn valid_entry() -> redis::Value {
+        redis::Value::Array(vec![
+            redis::Value::BulkString(b"1700000000".to_vec()),
+            redis::Value::BulkString(b"GRAPH.QUERY".to_vec()),
+            redis::Value::BulkString(b"MATCH (n) RETURN n".to_vec()),
+            redis::Value::BulkString(b"12.5".to_vec()),
+        ])
+    }
+
+    #[test]
+    fn parse_slowlog_parses_valid_entries() {
+        let parsed = parse_slowlog(redis::Value::Array(vec![valid_entry()])).expect("valid");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].timestamp, 1_700_000_000);
+        assert_eq!(parsed[0].command, "GRAPH.QUERY");
+        assert_eq!(parsed[0].arguments, "MATCH (n) RETURN n");
+        assert_eq!(parsed[0].time_taken, 12.5);
+    }
+
+    #[test]
+    fn parse_slowlog_empty_reply_is_empty() {
+        assert!(parse_slowlog(redis::Value::Array(vec![]))
+            .expect("empty")
+            .is_empty());
+    }
+
+    #[test]
+    fn parse_slowlog_propagates_malformed_entry_error() {
+        // A second entry with the wrong element count must fail the whole call rather than being
+        // silently dropped.
+        let value = redis::Value::Array(vec![
+            valid_entry(),
+            redis::Value::Array(vec![redis::Value::Int(1)]),
+        ]);
+        assert!(matches!(
+            parse_slowlog(value),
+            Err(FalkorDBError::ParsingArrayToStructElementCount(_))
+        ));
+    }
+
+    #[test]
+    fn parse_slowlog_rejects_non_array_reply() {
+        assert!(parse_slowlog(redis::Value::Int(5)).is_err());
     }
 }


### PR DESCRIPTION
## Summary

`SyncGraph::slowlog` and `AsyncGraph::slowlog` parsed entries with `flat_map(SlowlogEntry::parse)`. Because a `Result`'s iterator yields **nothing** on `Err`, a malformed slowlog entry was **silently dropped** instead of being reported — the same error-swallowing anti-pattern that was fixed for procedure results and `Path::parse` in 0.8.0 (and flagged by Copilot on #234).

This is a small, focused `fix:` (no API change).

## Change

- Factor the parse loop into a shared, testable `parse_slowlog(res) -> FalkorResult<Vec<SlowlogEntry>>` (in `response::slowlog_entry`) that propagates errors via `map(SlowlogEntry::parse).collect()`.
- Both `slowlog()` methods (sync + async) call it; drops the now-unused `redis_value_as_vec` import in each graph module.
- Behavior for valid replies is unchanged.

## Tests

Added unit tests for `parse_slowlog`: valid entries, empty reply, a **malformed entry now returns `Err`** (instead of being dropped), and a non-array reply. All gates pass locally (fmt, clippy `--all-targets`, full suite, doctests, `cargo doc`, `cargo deny`, spellcheck).

## Note

Other `flat_map(parse)` sites (index field-type enums, `GRAPH.CONFIG` parsing, `redis_value_as_untyped_string_vec`) are **intentional forward-compat leniency** — dropping an unknown/extra value keeps listing working against newer servers — so they are deliberately left as-is. `parse_redis_info` likewise intentionally skips non-`key:value` lines. Only the slowlog path, where a malformed entry is a genuine error, is changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed slowlog() (sync and async) to properly report parse errors for malformed entries instead of silently skipping them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->