### PR TITLE
fix(test): de-flake copy-graph tests by retrying transient ConnectionDown

### DIFF
--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -590,7 +590,8 @@ mod tests {
     use crate::{
         test_utils::{
             create_async_test_client, default_on_connection_down, imdb_async_test_client,
-            retry_until_async_fn_with_timeout, TestAsyncGraphHandle, COPY_RETRY_TIMEOUT,
+            read_copied_actors, retry_until_async_fn_with_timeout, TestAsyncGraphHandle,
+            COPY_RETRY_TIMEOUT,
         },
         FalkorClientBuilder,
     };
@@ -1013,20 +1014,12 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                let attempt: crate::FalkorResult<Vec<_>> = async {
-                    let mut graph = client.copy_graph("imdb", "imdb_ro_copy_async").await?;
-                    Ok(graph
-                        .query("MATCH (a:actor) RETURN a")
-                        .execute()
-                        .await?
-                        .data
-                        .collect::<Vec<_>>()
-                        .await)
-                }
-                .await;
-                // A transient `ConnectionDown` retries with a fresh connection; any other error is a
-                // genuine failure and fails fast.
-                default_on_connection_down("Could not copy graph", attempt)
+                // A transient `ConnectionDown` retries with a fresh connection; any other error
+                // fails fast.
+                default_on_connection_down(
+                    "Could not copy graph",
+                    read_copied_actors(client.copy_graph("imdb", "imdb_ro_copy_async")).await,
+                )
             },
             |rows| rows == &expected,
         )
@@ -1063,21 +1056,15 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                let attempt: crate::FalkorResult<Vec<_>> = async {
-                    let mut graph = client
-                        .copy_graph_op("imdb", "imdb_op_copy_async_wait")
-                        .wait()
-                        .await?;
-                    Ok(graph
-                        .query("MATCH (a:actor) RETURN a")
-                        .execute()
-                        .await?
-                        .data
-                        .collect::<Vec<_>>()
-                        .await)
-                }
-                .await;
-                default_on_connection_down("Could not copy graph", attempt)
+                default_on_connection_down(
+                    "Could not copy graph",
+                    read_copied_actors(
+                        client
+                            .copy_graph_op("imdb", "imdb_op_copy_async_wait")
+                            .wait(),
+                    )
+                    .await,
+                )
             },
             |rows| rows == &expected,
         )

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -1013,18 +1013,16 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                let mut graph = client
-                    .copy_graph("imdb", "imdb_ro_copy_async")
-                    .await
-                    .expect("Could not copy graph");
-                graph
-                    .query("MATCH (a:actor) RETURN a")
-                    .execute()
-                    .await
-                    .expect("Could not get actors from copied graph")
-                    .data
-                    .collect::<Vec<_>>()
-                    .await
+                // A transient error (e.g. a `ConnectionDown` whose connection the client has just
+                // swapped out) is retryable: return an empty result so the predicate treats it as a
+                // miss and the helper retries with a fresh connection, instead of panicking the test.
+                let Ok(mut graph) = client.copy_graph("imdb", "imdb_ro_copy_async").await else {
+                    return Vec::new();
+                };
+                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute().await else {
+                    return Vec::new();
+                };
+                result.data.collect::<Vec<_>>().await
             },
             |rows| rows == &expected,
         )
@@ -1061,19 +1059,19 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                let mut graph = client
+                // A transient error is retryable: return an empty result so the predicate treats it
+                // as a miss and the helper retries with a fresh connection, instead of panicking.
+                let Ok(mut graph) = client
                     .copy_graph_op("imdb", "imdb_op_copy_async_wait")
                     .wait()
                     .await
-                    .expect("Could not copy graph");
-                graph
-                    .query("MATCH (a:actor) RETURN a")
-                    .execute()
-                    .await
-                    .expect("Could not get actors from copied graph")
-                    .data
-                    .collect::<Vec<_>>()
-                    .await
+                else {
+                    return Vec::new();
+                };
+                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute().await else {
+                    return Vec::new();
+                };
+                result.data.collect::<Vec<_>>().await
             },
             |rows| rows == &expected,
         )

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -589,8 +589,8 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{
-            create_async_test_client, imdb_async_test_client, retry_until_async_fn_with_timeout,
-            TestAsyncGraphHandle, COPY_RETRY_TIMEOUT,
+            create_async_test_client, default_on_connection_down, imdb_async_test_client,
+            retry_until_async_fn_with_timeout, TestAsyncGraphHandle, COPY_RETRY_TIMEOUT,
         },
         FalkorClientBuilder,
     };
@@ -1013,16 +1013,20 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                // A transient error (e.g. a `ConnectionDown` whose connection the client has just
-                // swapped out) is retryable: return an empty result so the predicate treats it as a
-                // miss and the helper retries with a fresh connection, instead of panicking the test.
-                let Ok(mut graph) = client.copy_graph("imdb", "imdb_ro_copy_async").await else {
-                    return Vec::new();
-                };
-                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute().await else {
-                    return Vec::new();
-                };
-                result.data.collect::<Vec<_>>().await
+                let attempt: crate::FalkorResult<Vec<_>> = async {
+                    let mut graph = client.copy_graph("imdb", "imdb_ro_copy_async").await?;
+                    Ok(graph
+                        .query("MATCH (a:actor) RETURN a")
+                        .execute()
+                        .await?
+                        .data
+                        .collect::<Vec<_>>()
+                        .await)
+                }
+                .await;
+                // A transient `ConnectionDown` retries with a fresh connection; any other error is a
+                // genuine failure and fails fast.
+                default_on_connection_down("Could not copy graph", attempt)
             },
             |rows| rows == &expected,
         )
@@ -1059,19 +1063,21 @@ mod tests {
                     .delete()
                     .await
                     .ok();
-                // A transient error is retryable: return an empty result so the predicate treats it
-                // as a miss and the helper retries with a fresh connection, instead of panicking.
-                let Ok(mut graph) = client
-                    .copy_graph_op("imdb", "imdb_op_copy_async_wait")
-                    .wait()
-                    .await
-                else {
-                    return Vec::new();
-                };
-                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute().await else {
-                    return Vec::new();
-                };
-                result.data.collect::<Vec<_>>().await
+                let attempt: crate::FalkorResult<Vec<_>> = async {
+                    let mut graph = client
+                        .copy_graph_op("imdb", "imdb_op_copy_async_wait")
+                        .wait()
+                        .await?;
+                    Ok(graph
+                        .query("MATCH (a:actor) RETURN a")
+                        .execute()
+                        .await?
+                        .data
+                        .collect::<Vec<_>>()
+                        .await)
+                }
+                .await;
+                default_on_connection_down("Could not copy graph", attempt)
             },
             |rows| rows == &expected,
         )

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -450,8 +450,8 @@ mod tests {
     use crate::FalkorValue::Node;
     use crate::{
         test_utils::{
-            create_test_client, imdb_test_client, retry_until_with_timeout, TestSyncGraphHandle,
-            COPY_RETRY_TIMEOUT,
+            create_test_client, default_on_connection_down, imdb_test_client,
+            retry_until_with_timeout, TestSyncGraphHandle, COPY_RETRY_TIMEOUT,
         },
         FalkorClientBuilder, FalkorValue, LazyResultSet, QueryResult,
     };
@@ -720,15 +720,17 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_ro_copy").delete().ok();
-                // A transient error is retryable: return an empty result so the predicate treats it
-                // as a miss and the helper retries with a fresh connection, instead of panicking.
-                let Ok(mut graph) = client.copy_graph("imdb", "imdb_ro_copy") else {
-                    return Vec::new();
-                };
-                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute() else {
-                    return Vec::new();
-                };
-                result.data.collect::<Vec<_>>()
+                let attempt = (|| -> crate::FalkorResult<Vec<_>> {
+                    let mut graph = client.copy_graph("imdb", "imdb_ro_copy")?;
+                    Ok(graph
+                        .query("MATCH (a:actor) RETURN a")
+                        .execute()?
+                        .data
+                        .collect::<Vec<_>>())
+                })();
+                // A transient `ConnectionDown` retries with a fresh connection; any other error is a
+                // genuine failure and fails fast.
+                default_on_connection_down("Could not copy graph", attempt)
             },
             |rows| rows == &expected,
         );
@@ -758,15 +760,15 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_op_copy_wait").delete().ok();
-                // A transient error is retryable: return an empty result so the predicate treats it
-                // as a miss and the helper retries with a fresh connection, instead of panicking.
-                let Ok(mut graph) = client.copy_graph_op("imdb", "imdb_op_copy_wait").wait() else {
-                    return Vec::new();
-                };
-                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute() else {
-                    return Vec::new();
-                };
-                result.data.collect::<Vec<_>>()
+                let attempt = (|| -> crate::FalkorResult<Vec<_>> {
+                    let mut graph = client.copy_graph_op("imdb", "imdb_op_copy_wait").wait()?;
+                    Ok(graph
+                        .query("MATCH (a:actor) RETURN a")
+                        .execute()?
+                        .data
+                        .collect::<Vec<_>>())
+                })();
+                default_on_connection_down("Could not copy graph", attempt)
             },
             |rows| rows == &expected,
         );

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -720,17 +720,19 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_ro_copy").delete().ok();
-                let attempt = (|| -> crate::FalkorResult<Vec<_>> {
-                    let mut graph = client.copy_graph("imdb", "imdb_ro_copy")?;
-                    Ok(graph
-                        .query("MATCH (a:actor) RETURN a")
-                        .execute()?
-                        .data
-                        .collect::<Vec<_>>())
-                })();
-                // A transient `ConnectionDown` retries with a fresh connection; any other error is a
-                // genuine failure and fails fast.
-                default_on_connection_down("Could not copy graph", attempt)
+                // A transient `ConnectionDown` retries with a fresh connection; any other error
+                // fails fast (combinator chain so the error plumbing has no untaken branches).
+                default_on_connection_down(
+                    "Could not copy graph",
+                    client
+                        .copy_graph("imdb", "imdb_ro_copy")
+                        .and_then(|mut graph| {
+                            graph
+                                .query("MATCH (a:actor) RETURN a")
+                                .execute()
+                                .map(|result| result.data.collect::<Vec<_>>())
+                        }),
+                )
             },
             |rows| rows == &expected,
         );
@@ -760,15 +762,18 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_op_copy_wait").delete().ok();
-                let attempt = (|| -> crate::FalkorResult<Vec<_>> {
-                    let mut graph = client.copy_graph_op("imdb", "imdb_op_copy_wait").wait()?;
-                    Ok(graph
-                        .query("MATCH (a:actor) RETURN a")
-                        .execute()?
-                        .data
-                        .collect::<Vec<_>>())
-                })();
-                default_on_connection_down("Could not copy graph", attempt)
+                default_on_connection_down(
+                    "Could not copy graph",
+                    client
+                        .copy_graph_op("imdb", "imdb_op_copy_wait")
+                        .wait()
+                        .and_then(|mut graph| {
+                            graph
+                                .query("MATCH (a:actor) RETURN a")
+                                .execute()
+                                .map(|result| result.data.collect::<Vec<_>>())
+                        }),
+                )
             },
             |rows| rows == &expected,
         );

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -720,15 +720,15 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_ro_copy").delete().ok();
-                let mut graph = client
-                    .copy_graph("imdb", "imdb_ro_copy")
-                    .expect("Could not copy graph");
-                graph
-                    .query("MATCH (a:actor) RETURN a")
-                    .execute()
-                    .expect("Could not get actors from copied graph")
-                    .data
-                    .collect::<Vec<_>>()
+                // A transient error is retryable: return an empty result so the predicate treats it
+                // as a miss and the helper retries with a fresh connection, instead of panicking.
+                let Ok(mut graph) = client.copy_graph("imdb", "imdb_ro_copy") else {
+                    return Vec::new();
+                };
+                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute() else {
+                    return Vec::new();
+                };
+                result.data.collect::<Vec<_>>()
             },
             |rows| rows == &expected,
         );
@@ -758,16 +758,15 @@ mod tests {
             COPY_RETRY_TIMEOUT,
             || {
                 client.select_graph("imdb_op_copy_wait").delete().ok();
-                let mut graph = client
-                    .copy_graph_op("imdb", "imdb_op_copy_wait")
-                    .wait()
-                    .expect("Could not copy graph");
-                graph
-                    .query("MATCH (a:actor) RETURN a")
-                    .execute()
-                    .expect("Could not get actors from copied graph")
-                    .data
-                    .collect::<Vec<_>>()
+                // A transient error is retryable: return an empty result so the predicate treats it
+                // as a miss and the helper retries with a fresh connection, instead of panicking.
+                let Ok(mut graph) = client.copy_graph_op("imdb", "imdb_op_copy_wait").wait() else {
+                    return Vec::new();
+                };
+                let Ok(result) = graph.query("MATCH (a:actor) RETURN a").execute() else {
+                    return Vec::new();
+                };
+                result.data.collect::<Vec<_>>()
             },
             |rows| rows == &expected,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,6 +296,22 @@ pub(crate) mod test_utils {
             tokio::time::sleep(RETRY_INTERVAL).await;
         }
     }
+
+    /// Classifies a copy-retry attempt: pass an `Ok` value through, return the default (e.g. an
+    /// empty `Vec`, so the caller's predicate treats it as a miss and re-issues) on a transient
+    /// [`FalkorDBError::ConnectionDown`] — the client has already swapped in a fresh connection — and
+    /// panic immediately on any other error so a genuine regression fails fast with context instead
+    /// of being masked until the retry timeout.
+    pub(crate) fn default_on_connection_down<T: Default>(
+        context: &str,
+        result: FalkorResult<T>,
+    ) -> T {
+        match result {
+            Ok(value) => value,
+            Err(FalkorDBError::ConnectionDown) => T::default(),
+            Err(err) => panic!("{context}: {err}"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -331,5 +347,28 @@ mod retry_tests {
         .await;
         assert_eq!(value, 3);
         assert_eq!(calls.load(Ordering::Relaxed), 3);
+    }
+
+    #[test]
+    fn default_on_connection_down_passes_ok_through() {
+        use super::test_utils::default_on_connection_down;
+        let value = default_on_connection_down("ctx", Ok::<_, crate::FalkorDBError>(vec![1, 2, 3]));
+        assert_eq!(value, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn default_on_connection_down_returns_default_on_connection_down() {
+        use super::test_utils::default_on_connection_down;
+        let value: Vec<i32> =
+            default_on_connection_down("ctx", Err(crate::FalkorDBError::ConnectionDown));
+        assert!(value.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "could not copy")]
+    fn default_on_connection_down_panics_on_other_error() {
+        use super::test_utils::default_on_connection_down;
+        let _: Vec<i32> =
+            default_on_connection_down("could not copy", Err(crate::FalkorDBError::ParsingArray));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,24 @@ pub(crate) mod test_utils {
             Err(err) => panic!("{context}: {err}"),
         }
     }
+
+    /// Awaits a `copy_graph(...)`/`copy_graph_op(...).wait()` future and reads the copied graph's
+    /// actors. Shared by the async copy tests so the (necessarily `?`-based) async error plumbing
+    /// lives in one place.
+    #[cfg(feature = "tokio")]
+    pub(crate) async fn read_copied_actors(
+        copy: impl std::future::Future<Output = FalkorResult<AsyncGraph>>
+    ) -> FalkorResult<Vec<FalkorResult<Row>>> {
+        use futures::StreamExt as _;
+        let mut graph = copy.await?;
+        Ok(graph
+            .query("MATCH (a:actor) RETURN a")
+            .execute()
+            .await?
+            .data
+            .collect::<Vec<_>>()
+            .await)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes the flaky **copy-graph** tests that intermittently failed the `coverage` CI job (e.g. on the v0.8.1 release PR #238):

```
test_copy_graph ... FAILED
panicked at src/client/asynchronous.rs:1019: Could not copy graph: ConnectionDown
```

## Root cause

`test_copy_graph` and `test_copy_graph_op_wait` (sync **and** async) already wrap the copy in `retry_until[_async_fn]_with_timeout`, whose predicate retries the "copy completed empty" case. But the retry **closure** used `.expect()` on `copy_graph(...)` and the follow-up query. A transient `ConnectionDown` — which the client surfaces for one attempt while it swaps in a fresh connection for the next — therefore **panicked** the test instead of being retried. `nextest`'s fail-fast then cancelled the whole coverage run.

## Fix

Make those retry closures return an **empty result on any error** (`let Ok(..) = .. else { return Vec::new(); }`), so the predicate treats it as a miss and the helper re-issues the copy with the now-fresh connection. No production code changes.

The `*_op_execute` variants already returned a `Result` (their predicate retries on `Err`) and were unaffected.

## Validation

- The 6 copy tests pass; ran the copy-test set in a loop **6×** with no failures.
- Full suite green locally (537 lib + 49 integration + 5 multiplexing + 17 doctests), fmt + clippy `--all-targets` clean.

Flaky tests block everyone regardless of whether they're a regression, so this is a priority fix independent of feature work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling in graph copy operation tests to gracefully handle transient failures during retry scenarios, preventing false test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->