### PR TITLE
feat: add FalkorDBError::mitigation_hint() for actionable error guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `FalkorDBError::mitigation_hint()` returns a short, actionable remediation hint for common,
+  recognizable errors (or `None`). It is additive — `Display`/`Debug` and the raw message are
+  unchanged — and hints are fixed `&'static str`s, so they never echo text from the underlying
+  error.
+
 ## [0.8.5](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.4...v0.8.5) - 2026-06-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -684,6 +684,22 @@ The embedded server:
 - Automatically cleans up when the client is dropped
 - Can be configured with custom paths, database directory, and socket location
 
+### Actionable error hints
+
+`FalkorDBError::mitigation_hint()` turns common, recognizable failures into a short, actionable
+remediation tip — handy for logs and AI tooling. It is purely additive: the raw error and its
+`Display`/`Debug` output are unchanged, hints are fixed `&'static str`s (so they never echo text from
+the underlying message), and unrecognized errors return `None`.
+
+```rust,no_run
+use falkordb::FalkorDBError;
+
+let err = FalkorDBError::ConnectionDown;
+if let Some(hint) = err.mitigation_hint() {
+    println!("hint: {hint}");
+}
+```
+
 ## Development
 
 This repository ships a [`just`](https://github.com/casey/just) file that automates the

--- a/docs/llms.template.md
+++ b/docs/llms.template.md
@@ -33,6 +33,8 @@
 - Run many queries in one round-trip with a batch:
   `let mut b = graph.batch(); b.query("…"); b.ro_query("…"); let results = b.execute()?;` —
   one result per query, in submission order, each independently fallible.
+- On an error, `err.mitigation_hint()` may return a short, actionable remediation tip (or `None`);
+  the raw `FalkorDBError` is always preserved.
 
 ## Pitfalls (avoid)
 

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,8 @@
 - Run many queries in one round-trip with a batch:
   `let mut b = graph.batch(); b.query("…"); b.ro_query("…"); let results = b.execute()?;` —
   one result per query, in submission order, each independently fallible.
+- On an error, `err.mitigation_hint()` may return a short, actionable remediation tip (or `None`);
+  the raw `FalkorDBError` is always preserved.
 
 ## Pitfalls (avoid)
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -260,6 +260,7 @@ fn server_message_hint(message: &str) -> Option<&'static str> {
     let message = message.to_ascii_lowercase();
     if message.contains("invalid graph operation on empty key")
         || message.contains("key doesn't contains a graph")
+        || message.contains("key doesn't contain a graph")
     {
         Some(
             "the graph key is missing or isn't a graph — create the graph with a write query (e.g. \
@@ -393,6 +394,7 @@ mod tests {
         let cases = [
             ("Invalid graph operation on empty key", "create the graph"),
             ("key doesn't contains a graph", "create the graph"),
+            ("key doesn't contain a graph", "create the graph"),
             (
                 "errMsg: syntax error line: 1, column: 5, offset: 4",
                 "Cypher syntax",

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -196,6 +196,93 @@ pub enum FalkorDBError {
     },
 }
 
+impl FalkorDBError {
+    /// A short, actionable remediation hint for common, recognizable errors, or [`None`] when there
+    /// is no specific guidance for this error.
+    ///
+    /// This is purely additive convenience for humans and AI tooling: the error's
+    /// [`Display`](std::fmt::Display) / [`Debug`] output is unchanged and the raw message is always
+    /// preserved. Hints are fixed `&'static str`s — no text from the underlying error is echoed into
+    /// them, so a hint can never leak data from the original message — and unrecognized errors
+    /// return `None`. Recognition of server messages is best-effort and version-tolerant: it matches
+    /// a few well-known FalkorDB phrases and returns `None` for anything else.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use falkordb::FalkorDBError;
+    ///
+    /// // A recognized client-side error gives a hint.
+    /// assert!(FalkorDBError::ConnectionDown.mitigation_hint().is_some());
+    ///
+    /// // An unrecognized message gives `None` — the raw error is still available via `Display`.
+    /// let err = FalkorDBError::RedisError("READONLY You can't write against a replica".into());
+    /// assert_eq!(err.mitigation_hint(), None);
+    /// ```
+    #[must_use]
+    pub fn mitigation_hint(&self) -> Option<&'static str> {
+        match self {
+            Self::SingleThreadedRuntime => Some(
+                "run async operations on a multi-thread Tokio runtime, e.g. \
+                 `#[tokio::main(flavor = \"multi_thread\")]`, not the current-thread runtime",
+            ),
+            Self::NoRuntime => Some(
+                "no Tokio runtime is running — call async APIs from inside a runtime, or use the \
+                 synchronous client instead",
+            ),
+            Self::ConnectionDown => Some(
+                "the connection dropped — retry the operation; the client swaps in a fresh \
+                 connection for the next attempt",
+            ),
+            Self::MissingSchemaId(_) => Some(
+                "the local schema cache is stale; it normally self-heals on refresh, so retry the \
+                 query",
+            ),
+            Self::UnavailableProvider => Some(
+                "the connection URL needs a feature that isn't enabled — turn on the matching cargo \
+                 feature (for example `tokio` for async, or `rustls` / `native-tls` for TLS)",
+            ),
+            Self::RedisError(message) | Self::EmbeddedServerError(message) => {
+                server_message_hint(message)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Best-effort recognition of well-known FalkorDB *server* error messages.
+///
+/// [`FalkorDBError::RedisError`] / [`FalkorDBError::EmbeddedServerError`] are mixed buckets — they
+/// also carry connection and client errors — so this matches conservatively on lowercased,
+/// multi-token phrases and returns [`None`] for anything it does not specifically recognize.
+fn server_message_hint(message: &str) -> Option<&'static str> {
+    let message = message.to_ascii_lowercase();
+    if message.contains("invalid graph operation on empty key")
+        || message.contains("key doesn't contains a graph")
+    {
+        Some("the graph doesn't exist yet — create it by running a write query (e.g. `CREATE`) first")
+    } else if message.contains("errmsg:") {
+        Some(
+            "Cypher syntax error — check the query near the reported position, and pass values with \
+             `with_param` instead of formatting them into the query string",
+        )
+    } else if message.contains("query timed out") {
+        Some(
+            "the query exceeded its timeout — raise it with `QueryBuilder::with_timeout(ms)` (or the \
+             batch query's `with_timeout(ms)`)",
+        )
+    } else if message.contains("wrong number of arguments")
+        || message.contains("unknown command 'graph")
+    {
+        Some(
+            "the server didn't accept this graph command — make sure it is FalkorDB (not plain \
+             Redis) and recent enough",
+        )
+    } else {
+        None
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::de::Error for FalkorDBError {
     fn custom<T: std::fmt::Display>(msg: T) -> Self {
@@ -267,5 +354,84 @@ mod tests {
     fn test_no_connection_error() {
         let error = FalkorDBError::NoConnection;
         assert!(error.to_string().contains("Could not connect"));
+    }
+
+    #[test]
+    fn mitigation_hint_for_recognized_variants() {
+        assert!(FalkorDBError::SingleThreadedRuntime
+            .mitigation_hint()
+            .unwrap()
+            .contains("multi-thread"));
+        assert!(FalkorDBError::NoRuntime
+            .mitigation_hint()
+            .unwrap()
+            .contains("runtime"));
+        assert!(FalkorDBError::ConnectionDown
+            .mitigation_hint()
+            .unwrap()
+            .contains("retry"));
+        assert!(FalkorDBError::MissingSchemaId(SchemaType::Labels)
+            .mitigation_hint()
+            .unwrap()
+            .contains("retry"));
+        assert!(FalkorDBError::UnavailableProvider
+            .mitigation_hint()
+            .unwrap()
+            .contains("feature"));
+    }
+
+    #[test]
+    fn mitigation_hint_recognizes_server_messages() {
+        // Frozen sample strings (not live server output) so the test never depends on a server build.
+        let cases = [
+            ("Invalid graph operation on empty key", "create it"),
+            ("key doesn't contains a graph", "create it"),
+            (
+                "errMsg: syntax error at line 1, column 5 (offset 4)",
+                "Cypher syntax",
+            ),
+            ("Query timed out", "timeout"),
+            (
+                "ERR wrong number of arguments for 'GRAPH.QUERY' command",
+                "FalkorDB",
+            ),
+            ("ERR unknown command 'GRAPH.QUERY'", "FalkorDB"),
+        ];
+        for (message, needle) in cases {
+            let hint = FalkorDBError::RedisError(message.to_string())
+                .mitigation_hint()
+                .unwrap_or_else(|| panic!("expected a hint for {message:?}"));
+            assert!(
+                hint.contains(needle),
+                "{message:?} -> {hint:?} is missing {needle:?}"
+            );
+        }
+        // EmbeddedServerError shares the same recognizer.
+        assert!(FalkorDBError::EmbeddedServerError("Query timed out".into())
+            .mitigation_hint()
+            .is_some());
+    }
+
+    #[test]
+    fn mitigation_hint_is_none_for_unrecognized_errors() {
+        // An unrelated message in the mixed `RedisError` bucket must not false-positive.
+        assert_eq!(
+            FalkorDBError::RedisError("READONLY You can't write against a replica.".into())
+                .mitigation_hint(),
+            None
+        );
+        // A variant with no specific guidance.
+        assert_eq!(FalkorDBError::InvalidDataReceived.mitigation_hint(), None);
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn mitigation_hint_never_panics(message in ".*") {
+            // For any message, the recognizer must not panic (and returns a 'static hint or None).
+            let _ = FalkorDBError::RedisError(message.clone()).mitigation_hint();
+            let _ = FalkorDBError::EmbeddedServerError(message).mitigation_hint();
+        }
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -239,8 +239,9 @@ impl FalkorDBError {
                  query",
             ),
             Self::UnavailableProvider => Some(
-                "the connection URL needs a feature that isn't enabled — turn on the matching cargo \
-                 feature (for example `tokio` for async, or `rustls` / `native-tls` for TLS)",
+                "the requested provider or read-replica route isn't available — enable the matching \
+                 cargo feature (for example `tokio` for async, or `rustls` / `native-tls` for TLS), \
+                 and for read-only queries make sure a read replica is configured",
             ),
             Self::RedisError(message) | Self::EmbeddedServerError(message) => {
                 server_message_hint(message)
@@ -260,18 +261,24 @@ fn server_message_hint(message: &str) -> Option<&'static str> {
     if message.contains("invalid graph operation on empty key")
         || message.contains("key doesn't contains a graph")
     {
-        Some("the graph doesn't exist yet — create it by running a write query (e.g. `CREATE`) first")
-    } else if message.contains("errmsg:") {
         Some(
-            "Cypher syntax error — check the query near the reported position, and pass values with \
-             `with_param` instead of formatting them into the query string",
+            "the graph key is missing or isn't a graph — create the graph with a write query (e.g. \
+             `CREATE`) first, or pick a name that doesn't collide with an existing non-graph key",
+        )
+    } else if message.contains("errmsg:")
+        && message.contains("line:")
+        && message.contains("column:")
+    {
+        Some(
+            "Cypher syntax error — check the query near the reported line/column, and pass values \
+             with `with_param` instead of formatting them into the query string",
         )
     } else if message.contains("query timed out") {
         Some(
             "the query exceeded its timeout — raise it with `QueryBuilder::with_timeout(ms)` (or the \
              batch query's `with_timeout(ms)`)",
         )
-    } else if message.contains("wrong number of arguments")
+    } else if message.contains("wrong number of arguments for 'graph")
         || message.contains("unknown command 'graph")
     {
         Some(
@@ -384,10 +391,10 @@ mod tests {
     fn mitigation_hint_recognizes_server_messages() {
         // Frozen sample strings (not live server output) so the test never depends on a server build.
         let cases = [
-            ("Invalid graph operation on empty key", "create it"),
-            ("key doesn't contains a graph", "create it"),
+            ("Invalid graph operation on empty key", "create the graph"),
+            ("key doesn't contains a graph", "create the graph"),
             (
-                "errMsg: syntax error at line 1, column 5 (offset 4)",
+                "errMsg: syntax error line: 1, column: 5, offset: 4",
                 "Cypher syntax",
             ),
             ("Query timed out", "timeout"),
@@ -398,12 +405,10 @@ mod tests {
             ("ERR unknown command 'GRAPH.QUERY'", "FalkorDB"),
         ];
         for (message, needle) in cases {
-            let hint = FalkorDBError::RedisError(message.to_string())
-                .mitigation_hint()
-                .unwrap_or_else(|| panic!("expected a hint for {message:?}"));
+            let hint = FalkorDBError::RedisError(message.to_string()).mitigation_hint();
             assert!(
-                hint.contains(needle),
-                "{message:?} -> {hint:?} is missing {needle:?}"
+                hint.is_some_and(|h| h.contains(needle)),
+                "{message:?} -> {hint:?} should contain {needle:?}"
             );
         }
         // EmbeddedServerError shares the same recognizer.
@@ -422,6 +427,17 @@ mod tests {
         );
         // A variant with no specific guidance.
         assert_eq!(FalkorDBError::InvalidDataReceived.mitigation_hint(), None);
+        // A non-graph Redis arity error must not get the graph-command hint.
+        assert_eq!(
+            FalkorDBError::RedisError("ERR wrong number of arguments for 'AUTH' command".into())
+                .mitigation_hint(),
+            None
+        );
+        // An `errMsg:` token without a line/column position is not treated as a Cypher parse error.
+        assert_eq!(
+            FalkorDBError::RedisError("errMsg: something else entirely".into()).mitigation_hint(),
+            None
+        );
     }
 
     use proptest::prelude::*;


### PR DESCRIPTION
## What

**Idea 8 Part B.** Adds an additive `FalkorDBError::mitigation_hint(&self) -> Option<&'static str>` that maps common, recognizable errors to a short, actionable remediation tip — useful for logs and AI tooling (it complements Part A's `llms.txt`: that says *what the API is*, this says *what to do when a call errors*).

## Behaviour
- **Direct hints** for `SingleThreadedRuntime`, `NoRuntime`, `ConnectionDown`, `MissingSchemaId`, `UnavailableProvider`.
- **Best-effort server-message recognition** for the `RedisError` / `EmbeddedServerError` *mixed buckets* (they also carry connection/client errors), matched conservatively on **lowercased, multi-token** phrases: graph-not-created, Cypher parse error (`errMsg:`), query timeout, unsupported command. Anything else → `None`.

## Guardrails (from the rubber-ducked design)
- Purely additive — `Display`/`Debug` and the raw message are unchanged.
- Hints are fixed `&'static str` — **no text from the underlying error is echoed**, so a hint can't leak data.
- Conservative matching to avoid false positives on the mixed `RedisError` bucket.

## Tests & docs
- Table-driven tests with **frozen sample strings** (never live server output, so no dependency on a server build), **negative cases** (unrelated message → `None`), and a **proptest** that it never panics. Plus a doctest.
- Docs kept in sync per the convention: a `mitigation_hint` idiom in `docs/llms.template.md` (`llms.txt` regenerated, `check-llms` green), a README **Actionable error hints** section, and a CHANGELOG entry.

## Validation (via `just`)
`just done` (fmt-check, clippy, clippy-all, build, doc, deny, check-llms) ✓, `just spellcheck` ✓, the new unit tests + proptest + doctest ✓. Coverage verification in progress.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional remediation hint API for recognized error conditions, returning short actionable guidance when available.

* **Documentation**
  * Updated the README, changelog, and core documentation to explain how to retrieve and display these hints, including a runnable example snippet.

* **Tests**
  * Extended coverage to validate hint behavior across supported error variants and ensure safe, non-panicking recognition for unrecognized message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->