### PR TITLE
feat: add opt-in RetryPolicy for transient connection failures

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -150,3 +150,10 @@ ci
 perf
 llms
 llmstxt
+RetryPolicy
+RetryScope
+Backoff
+backon
+millis
+jitter
+getters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in, client-wide `RetryPolicy` that automatically re-issues *eligible* operations on *transient*
+  connection failures with bounded backoff. **Disabled by default**, so existing behavior is
+  byte-for-byte unchanged. Configure it on either builder with
+  `FalkorClientBuilder::with_retry_policy(..)`; the available scope (`RetryScope::ReadOnly`) retries
+  only read-only / idempotent operations, so enabling a policy never re-issues a write. New public
+  types: `RetryPolicy`, `RetryScope`, `Backoff`. Backoff/jitter is powered internally by `backon`.
+
 ## [0.8.6](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.5...v0.8.6) - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
  "fastrand",
+ "tokio",
 ]
 
 [[package]]
@@ -417,6 +418,7 @@ name = "falkordb"
 version = "0.8.6"
 dependencies = [
  "approx",
+ "backon",
  "criterion",
  "futures",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 [lib]
 
 [dependencies]
+backon = { version = "1.6", default-features = false, features = ["std", "std-blocking-sleep"] }
 futures-core = { version = "0.3", default-features = false, optional = true }
 parking_lot = { version = "0.12.5", default-features = false }
 redis = { version = "1.2.2", default-features = false, features = ["sentinel"] }
@@ -55,7 +56,7 @@ default = []
 native-tls = ["redis/tls-native-tls"]
 rustls = ["redis/tls-rustls"]
 
-tokio = ["dep:tokio", "dep:futures-core", "redis/tokio-comp", "redis/connection-manager"]
+tokio = ["dep:tokio", "dep:futures-core", "redis/tokio-comp", "redis/connection-manager", "backon/tokio-sleep"]
 tokio-native-tls = ["tokio", "redis/tokio-native-tls-comp"]
 tokio-rustls = ["tokio", "redis/tokio-rustls-comp"]
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,54 @@ transparently fall back to the primary connection, and `reads_from_replicas()`
 returns `false`. See [`examples/readonly_replica.rs`](examples/readonly_replica.rs)
 for a complete working example.
 
+### Resilience / automatic retries
+
+A client can opt in to a `RetryPolicy` that automatically re-issues *eligible* operations on
+*transient* connection failures, with bounded backoff. It is **disabled by default**, so a client
+built without one behaves exactly as before (every operation is attempted once):
+
+```no_run
+use falkordb::{Backoff, FalkorClientBuilder, RetryPolicy};
+use std::time::Duration;
+
+# fn doc() -> Result<(), Box<dyn std::error::Error>> {
+let client = FalkorClientBuilder::new()
+    .with_retry_policy(
+        RetryPolicy::read_only()                         // retry read-only ops only
+            .max_attempts(4)                             // 1 initial try + up to 3 retries
+            .backoff(Backoff::exponential(Duration::from_millis(50))
+                .max_delay(Duration::from_secs(1))),     // 50ms, 100ms, 200ms, … capped at 1s
+    )
+    .build()?;
+# let _ = client;
+# Ok(())
+# }
+```
+
+The same `with_retry_policy(..)` is available on the async builder
+(`FalkorClientBuilder::new_async()`).
+
+**Write safety.** The only scope available today, `RetryScope::ReadOnly`, retries **read-only /
+idempotent** operations only (`ro_query`, `explain`, `list_indices`, `list_constraints`, read-only
+procedure calls). **Writes are never retried**, so enabling a policy can never duplicate a write.
+Classification is by the API you call, never by inspecting Cypher — `query()` is treated as a write
+even when it only reads, so use `ro_query()` for retryable reads.
+
+Only transient connection errors are retried (a dropped/unavailable connection, or a Sentinel
+resolution failure); deterministic errors (syntax, constraint violations, parse/type errors,
+wait-operation timeouts) are returned immediately. Retries compose with the client's existing
+connection healing: each attempt re-borrows a connection, so a recovered connection is picked up on
+the next try.
+
+**Scope.** Retry currently wraps query and procedure *execution* — `ro_query`, `query`, `explain`,
+`profile`, `call_procedure`/`call_procedure_ro`, and `list_indices`/`list_constraints` (only the
+read-only ones are eligible). Direct client/admin calls (`list_graphs`, configuration getters/setters,
+`slowlog`, server `INFO`) and the internal schema-cache refresh that can run while a result is parsed
+are **not** wrapped yet, so a transient failure there still surfaces even with a policy enabled.
+Broadening the coverage is a planned follow-up.
+
+See [`examples/retry.rs`](examples/retry.rs) for a complete, runnable example.
+
 ### Tracing
 
 This crate fully supports instrumentation using the [`tracing`](https://docs.rs/tracing/latest/tracing/) crate, to use

--- a/examples/retry.rs
+++ b/examples/retry.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Demonstrates the opt-in retry policy that re-issues eligible operations on transient
+//! connection failures.
+//!
+//! A [`RetryPolicy`] is **disabled by default**, so a client built without one attempts every
+//! operation exactly once (the previous behavior). When a policy is configured, read-only /
+//! idempotent operations that fail with a transient connection error are automatically retried
+//! with bounded backoff. **Writes are never retried**, so enabling a policy can never duplicate a
+//! write.
+//!
+//! Set `FALKORDB_CONNECTION` to point at another server (for example `falkor://127.0.0.1:6379`);
+//! it defaults to a local single node.
+
+use falkordb::{Backoff, FalkorClientBuilder, FalkorResult, RetryPolicy};
+use std::time::Duration;
+
+fn main() -> FalkorResult<()> {
+    let connection_info = std::env::var("FALKORDB_CONNECTION")
+        .unwrap_or_else(|_| "falkor://127.0.0.1:6379".to_string());
+
+    // Retry read-only operations on transient connection failures: up to 4 attempts total
+    // (1 initial try + 3 retries), with exponential backoff starting at 50ms and capped at 1s.
+    let policy = RetryPolicy::read_only()
+        .max_attempts(4)
+        .backoff(Backoff::exponential(Duration::from_millis(50)).max_delay(Duration::from_secs(1)));
+
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info.as_str().try_into()?)
+        .with_retry_policy(policy)
+        .build()?;
+
+    let mut graph = client.select_graph("retry_example");
+
+    // Writes are NEVER auto-retried, even with a policy enabled, so a write can never be applied
+    // twice. Classification is by the API you call: `query()` is always treated as a write.
+    graph
+        .query("CREATE (:Greeting {text: 'hello'})")
+        .execute()?;
+
+    // Read-only queries ARE eligible for retry. If the connection drops transiently here, the
+    // client re-borrows a healed connection and re-issues the query (up to `max_attempts`), instead
+    // of surfacing the error on the first blip. Use `ro_query()` (not `query()`) for retryable reads.
+    let mut greetings = graph
+        .ro_query("MATCH (g:Greeting) RETURN g.text")
+        .execute()?;
+
+    for row in greetings.data.by_ref() {
+        println!("read-only result: {row:?}");
+    }
+
+    graph.delete()?;
+
+    Ok(())
+}

--- a/llms.txt
+++ b/llms.txt
@@ -59,6 +59,7 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `AsyncCopyGraphBuilder` — requires `tokio`
 - `AsyncGraph` — requires `tokio`
 - `AsyncIndexOpBuilder` — requires `tokio`
+- `Backoff`
 - `BatchBuilder`
 - `BatchItemResult`
 - `BatchQuery`
@@ -100,6 +101,8 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `QueryBuilder`
 - `QueryResult`
 - `RawParam`
+- `RetryPolicy`
+- `RetryScope`
 - `Row`
 - `RowStream` — requires `tokio`
 - `SchemaType`

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -10,7 +10,7 @@ use crate::{
         blocking::FalkorSyncConnection,
     },
     parser::{parse_config_hashmap, redis_value_as_untyped_string_vec},
-    AsyncGraph, ConfigValue, FalkorConnectionInfo, FalkorDBError, FalkorResult,
+    AsyncGraph, ConfigValue, FalkorConnectionInfo, FalkorDBError, FalkorResult, RetryPolicy,
 };
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -68,9 +68,18 @@ pub struct FalkorAsyncClientInner {
     /// has no readable replicas, in which case read-only queries reuse the primary
     /// backend (preserving the previous behavior).
     readonly: Option<AsyncExecutor>,
+    /// Opt-in retry policy applied to eligible operations; [`disabled`](RetryPolicy::disabled) by
+    /// default, in which case every operation is attempted exactly once.
+    retry_policy: RetryPolicy,
 }
 
 impl FalkorAsyncClientInner {
+    /// The retry policy configured for this client (defaults to
+    /// [`disabled`](RetryPolicy::disabled)).
+    pub(crate) fn retry_policy(&self) -> RetryPolicy {
+        self.retry_policy
+    }
+
     /// Borrow a connection from the given executor. For the pooled strategy this waits
     /// for an available connection; for the multiplexed strategy it hands out a cheap
     /// clone immediately.
@@ -224,6 +233,7 @@ impl FalkorAsyncClient {
         connection_info: FalkorConnectionInfo,
         requested_strategy: ConnectionStrategy,
         max_inflight: Option<NonZeroUsize>,
+        retry_policy: RetryPolicy,
     ) -> FalkorResult<Self> {
         // A multiplexed ConnectionManager built from a Sentinel-resolved client pins to a
         // single node and reconnects to the same address rather than re-resolving the
@@ -264,6 +274,7 @@ impl FalkorAsyncClient {
                 strategy,
                 primary,
                 readonly,
+                retry_policy,
             }),
             _connection_info: connection_info,
         })
@@ -935,6 +946,7 @@ mod tests {
             },
             primary,
             readonly: Some(readonly),
+            retry_policy: RetryPolicy::disabled(),
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -7,7 +7,7 @@ use crate::{
     client::{FalkorClientProvider, ProvidesSyncConnections},
     connection::blocking::{BorrowedSyncConnection, FalkorSyncConnection},
     parser::{parse_config_hashmap, redis_value_as_untyped_string_vec},
-    ConfigValue, FalkorConnectionInfo, FalkorDBError, FalkorResult, SyncGraph,
+    ConfigValue, FalkorConnectionInfo, FalkorDBError, FalkorResult, RetryPolicy, SyncGraph,
 };
 use parking_lot::Mutex;
 use std::{
@@ -36,9 +36,18 @@ pub(crate) struct FalkorSyncClientInner {
     /// deployment has no readable replicas, in which case read-only queries reuse
     /// the primary pool (preserving the previous behavior).
     readonly_pool: Option<SyncConnectionPool>,
+    /// Opt-in retry policy applied to eligible operations; [`disabled`](RetryPolicy::disabled) by
+    /// default, in which case every operation is attempted exactly once.
+    retry_policy: RetryPolicy,
 }
 
 impl FalkorSyncClientInner {
+    /// The retry policy configured for this client (defaults to
+    /// [`disabled`](RetryPolicy::disabled)).
+    pub(crate) fn retry_policy(&self) -> RetryPolicy {
+        self.retry_policy
+    }
+
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -140,6 +149,7 @@ impl FalkorSyncClient {
         mut client: FalkorClientProvider,
         connection_info: FalkorConnectionInfo,
         num_connections: u8,
+        retry_policy: RetryPolicy,
     ) -> FalkorResult<Self> {
         let (connection_pool_tx, connection_pool_rx) = mpsc::sync_channel(num_connections as usize);
 
@@ -163,6 +173,7 @@ impl FalkorSyncClient {
                 connection_pool_tx,
                 connection_pool_rx: Mutex::new(connection_pool_rx),
                 readonly_pool,
+                retry_policy,
             }),
             _connection_info: connection_info,
         })
@@ -441,6 +452,7 @@ pub(crate) fn create_empty_inner_sync_client() -> Arc<FalkorSyncClientInner> {
         connection_pool_tx: tx,
         connection_pool_rx: Mutex::new(rx),
         readonly_pool: None,
+        retry_policy: RetryPolicy::disabled(),
     })
 }
 
@@ -627,6 +639,7 @@ mod tests {
             connection_pool_tx: tx,
             connection_pool_rx: Mutex::new(rx),
             readonly_pool: Some(pool),
+            retry_policy: RetryPolicy::disabled(),
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     client::{ConnectionStrategy, FalkorClientProvider},
-    FalkorConnectionInfo, FalkorDBError, FalkorResult, FalkorSyncClient,
+    FalkorConnectionInfo, FalkorDBError, FalkorResult, FalkorSyncClient, RetryPolicy,
 };
 use std::num::{NonZeroU8, NonZeroUsize};
 use std::time::Duration;
@@ -20,6 +20,7 @@ pub struct FalkorClientBuilder<const R: char> {
     #[cfg_attr(not(feature = "tokio"), allow(dead_code))]
     max_inflight: Option<NonZeroUsize>,
     tcp_settings: Option<redis::io::tcp::TcpSettings>,
+    retry_policy: RetryPolicy,
 }
 
 impl<const R: char> FalkorClientBuilder<R> {
@@ -60,6 +61,35 @@ impl<const R: char> FalkorClientBuilder<R> {
     ) -> Self {
         Self {
             strategy: self.strategy.with_connection_count(num_connections),
+            ..self
+        }
+    }
+
+    /// Configure an opt-in [`RetryPolicy`] that automatically re-issues *eligible* operations on
+    /// *transient* connection failures, with bounded backoff.
+    ///
+    /// **Disabled by default**: without this call the client attempts every operation exactly once,
+    /// exactly as before. The available scope ([`RetryScope::ReadOnly`](crate::RetryScope)) retries
+    /// only read-only / idempotent operations, so enabling a policy never re-issues a write.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use falkordb::{FalkorClientBuilder, RetryPolicy};
+    ///
+    /// # fn doc() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = FalkorClientBuilder::new()
+    ///     .with_retry_policy(RetryPolicy::read_only().max_attempts(4))
+    ///     .build()?;
+    /// # let _ = client;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_retry_policy(
+        self,
+        retry_policy: RetryPolicy,
+    ) -> Self {
+        Self {
+            retry_policy,
             ..self
         }
     }
@@ -198,6 +228,7 @@ impl FalkorClientBuilder<'S'> {
             },
             max_inflight: None,
             tcp_settings: None,
+            retry_policy: RetryPolicy::disabled(),
         }
     }
 
@@ -226,6 +257,7 @@ impl FalkorClientBuilder<'S'> {
             client,
             actual_connection_info,
             self.strategy.connection_count().get(),
+            self.retry_policy,
         )
     }
 }
@@ -244,6 +276,7 @@ impl FalkorClientBuilder<'A'> {
             },
             max_inflight: None,
             tcp_settings: None,
+            retry_policy: RetryPolicy::disabled(),
         }
     }
 
@@ -339,6 +372,7 @@ impl FalkorClientBuilder<'A'> {
             actual_connection_info,
             self.strategy,
             self.max_inflight,
+            self.retry_policy,
         )
         .await
     }

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -220,6 +220,7 @@ impl AsyncGraph {
     )]
     pub async fn list_indices(&mut self) -> FalkorResult<QueryResult<Vec<FalkorIndex>>> {
         ProcedureQueryBuilder::<QueryResult<Vec<FalkorIndex>>, Self>::new(self, "DB.INDEXES")
+            .read_only()
             .execute()
             .await
     }
@@ -285,6 +286,7 @@ impl AsyncGraph {
     )]
     pub async fn list_constraints(&mut self) -> FalkorResult<QueryResult<Vec<Constraint>>> {
         ProcedureQueryBuilder::<QueryResult<Vec<Constraint>>, Self>::new(self, "DB.CONSTRAINTS")
+            .read_only()
             .execute()
             .await
     }

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -208,6 +208,7 @@ impl SyncGraph {
     )]
     pub fn list_indices(&mut self) -> FalkorResult<QueryResult<Vec<FalkorIndex>>> {
         ProcedureQueryBuilder::<QueryResult<Vec<FalkorIndex>>, Self>::new(self, "DB.INDEXES")
+            .read_only()
             .execute()
     }
 
@@ -276,6 +277,7 @@ impl SyncGraph {
     )]
     pub fn list_constraints(&mut self) -> FalkorResult<QueryResult<Vec<Constraint>>> {
         ProcedureQueryBuilder::<QueryResult<Vec<Constraint>>, Self>::new(self, "DB.CONSTRAINTS")
+            .read_only()
             .execute()
     }
 

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -6,6 +6,7 @@
 use crate::{
     graph::HasGraphSchema,
     parser::{parse_header, redis_value_as_vec, SchemaParsable},
+    retry::{op_kind_for_command, run_with_retry_blocking, OpKind},
     Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult, GraphSchema,
     IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, SyncGraph,
 };
@@ -16,7 +17,7 @@ use std::{
 };
 
 #[cfg(feature = "tokio")]
-use crate::{AsyncGraph, RowStream};
+use crate::{retry::run_with_retry_async, AsyncGraph, RowStream};
 
 #[cfg(feature = "serde")]
 use crate::TypedLazyResultSet;
@@ -270,19 +271,21 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         }
 
         let client = self.graph.get_client();
-        let conn = if self.command == "GRAPH.RO_QUERY" {
-            client.borrow_readonly_connection(client.clone())
-        } else {
-            client.borrow_connection(client.clone())
-        };
+        let graph_name = self.graph.graph_name();
+        let command = self.command;
+        let readonly_conn = command == "GRAPH.RO_QUERY";
+        let params_ref = params.as_slice();
+        let policy = client.retry_policy();
 
-        conn.and_then(|mut conn| {
-            conn.execute_command(
-                Some(self.graph.graph_name()),
-                self.command,
-                None,
-                Some(params.as_slice()),
-            )
+        run_with_retry_blocking(&policy, op_kind_for_command(command), || {
+            let conn = if readonly_conn {
+                client.borrow_readonly_connection(client.clone())
+            } else {
+                client.borrow_connection(client.clone())
+            };
+            conn.and_then(|mut conn| {
+                conn.execute_command(Some(graph_name), command, None, Some(params_ref))
+            })
         })
     }
 }
@@ -309,20 +312,23 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         }
 
         let client = self.graph.get_client();
-        let conn = if self.command == "GRAPH.RO_QUERY" {
-            client.borrow_readonly_connection(client.clone()).await
-        } else {
-            client.borrow_connection(client.clone()).await
-        };
+        let graph_name = self.graph.graph_name();
+        let command = self.command;
+        let readonly_conn = command == "GRAPH.RO_QUERY";
+        let params_ref = params.as_slice();
+        let policy = client.retry_policy();
 
-        conn?
-            .execute_command(
-                Some(self.graph.graph_name()),
-                self.command,
-                None,
-                Some(params.as_slice()),
-            )
-            .await
+        run_with_retry_async(&policy, op_kind_for_command(command), || async move {
+            let conn = if readonly_conn {
+                client.borrow_readonly_connection(client.clone()).await
+            } else {
+                client.borrow_connection(client.clone()).await
+            };
+            conn?
+                .execute_command(Some(graph_name), command, None, Some(params_ref))
+                .await
+        })
+        .await
     }
 
     /// Eagerly parses the reply into an owned [`RowStream`] under the schema write lock, so the
@@ -513,6 +519,7 @@ pub struct ProcedureQueryBuilder<'a, Output, G> {
     _unused: PhantomData<Output>,
     graph: &'a mut G,
     readonly: bool,
+    op_kind: OpKind,
     procedure_name: &'a str,
     args: Option<&'a [&'a str]>,
     yields: Option<&'a [&'a str]>,
@@ -528,6 +535,7 @@ impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
 
             graph,
             readonly: false,
+            op_kind: OpKind::Write,
             procedure_name,
             args: None,
             yields: None,
@@ -542,10 +550,19 @@ impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
             _unused: PhantomData,
             graph,
             readonly: true,
+            op_kind: OpKind::ReadOnly,
             procedure_name,
             args: None,
             yields: None,
         }
+    }
+
+    /// Mark this procedure call as read-only / idempotent for retry purposes, independent of the
+    /// wire command. Used by internal listing procedures (`DB.INDEXES`, `DB.CONSTRAINTS`) which are
+    /// dispatched over `GRAPH.QUERY` yet only read, so they remain safe to re-issue.
+    pub(crate) fn read_only(mut self) -> Self {
+        self.op_kind = OpKind::ReadOnly;
+        self
     }
 
     /// Pass arguments to the procedure call
@@ -630,19 +647,21 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
-        let conn = if self.readonly {
-            client.borrow_readonly_connection(client.clone())
-        } else {
-            client.borrow_connection(client.clone())
-        };
+        let graph_name = self.graph.graph_name();
+        let readonly_conn = self.readonly;
+        let op_kind = self.op_kind;
+        let exec_params = [query.as_str(), "--compact"];
+        let policy = client.retry_policy();
 
-        conn.and_then(|mut conn| {
-            conn.execute_command(
-                Some(self.graph.graph_name()),
-                command,
-                None,
-                Some(&[query.as_str(), "--compact"]),
-            )
+        run_with_retry_blocking(&policy, op_kind, || {
+            let conn = if readonly_conn {
+                client.borrow_readonly_connection(client.clone())
+            } else {
+                client.borrow_connection(client.clone())
+            };
+            conn.and_then(|mut conn| {
+                conn.execute_command(Some(graph_name), command, None, Some(&exec_params))
+            })
         })
     }
 }
@@ -669,20 +688,23 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
-        let conn = if self.readonly {
-            client.borrow_readonly_connection(client.clone()).await
-        } else {
-            client.borrow_connection(client.clone()).await
-        };
+        let graph_name = self.graph.graph_name();
+        let readonly_conn = self.readonly;
+        let op_kind = self.op_kind;
+        let exec_params = [query.as_str(), "--compact"];
+        let policy = client.retry_policy();
 
-        conn?
-            .execute_command(
-                Some(self.graph.graph_name()),
-                command,
-                None,
-                Some(&[query.as_str(), "--compact"]),
-            )
-            .await
+        run_with_retry_async(&policy, op_kind, || async move {
+            let conn = if readonly_conn {
+                client.borrow_readonly_connection(client.clone()).await
+            } else {
+                client.borrow_connection(client.clone()).await
+            };
+            conn?
+                .execute_command(Some(graph_name), command, None, Some(&exec_params))
+                .await
+        })
+        .await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod graph;
 mod graph_schema;
 mod parser;
 mod response;
+mod retry;
 mod value;
 
 /// A [`Result`] which only returns [`FalkorDBError`] as its E type
@@ -45,6 +46,7 @@ pub use response::{
     slowlog_entry::SlowlogEntry,
     QueryResult,
 };
+pub use retry::{Backoff, RetryPolicy, RetryScope};
 pub use value::{
     config::ConfigValue,
     graph_entities::{Edge, EntityType, Node},

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,777 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Opt-in, client-wide retry of transient connection failures.
+//!
+//! A [`RetryPolicy`] is **disabled by default**, so a client built without one behaves exactly as
+//! before: every operation is attempted once. When a policy is configured on the
+//! [`FalkorClientBuilder`](crate::FalkorClientBuilder), eligible operations that fail with a
+//! transient connection error are automatically re-issued with a bounded backoff.
+//!
+//! # Safety
+//!
+//! The only scope available today is [`RetryScope::ReadOnly`], which retries **read-only /
+//! idempotent** operations (`ro_query`, `explain`, `list_*`, …). **Write operations are never
+//! retried**, so enabling a policy can never duplicate a write. Classification is by the API you
+//! call, never by inspecting Cypher: `query()` is treated as a write even when it only reads, so
+//! use `ro_query()` for retryable reads.
+//!
+//! # Scope
+//!
+//! Retry wraps query and procedure *execution* (the `QueryBuilder` / `ProcedureQueryBuilder`
+//! seams). Direct client/admin calls (`list_graphs`, config getters/setters, `slowlog`, server
+//! `INFO`) and the internal schema-cache refresh that may run while a result is parsed are not yet
+//! wrapped; broadening coverage is a planned follow-up.
+
+use crate::{FalkorDBError, FalkorResult};
+use std::time::Duration;
+
+/// Which operations an enabled [`RetryPolicy`] is allowed to re-issue.
+///
+/// `#[non_exhaustive]` so future scopes (e.g. retrying writes that provably never reached the
+/// server) can be added without a breaking change.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RetryScope {
+    /// Retry nothing. Identical to configuring no policy at all (the default).
+    Disabled,
+    /// Retry read-only / idempotent operations only. Writes are never retried.
+    ReadOnly,
+}
+
+/// The backoff schedule applied between retry attempts.
+///
+/// The delay for retry `n` (0-based) is `min(base * factor.powi(n), max_delay)`, optionally with
+/// full jitter (a uniform random value in `[0, delay)`) to avoid synchronized retries across many
+/// clients. Build one with [`Backoff::exponential`] or [`Backoff::fixed`].
+///
+/// ```
+/// use falkordb::Backoff;
+/// use std::time::Duration;
+///
+/// // Exponential: 100ms, 300ms, 900ms, … (factor 3), never above 5s, jitter off.
+/// let exponential = Backoff::exponential(Duration::from_millis(100))
+///     .factor(3.0)
+///     .max_delay(Duration::from_secs(5))
+///     .jitter(false);
+///
+/// // Fixed: the same delay before every retry.
+/// let fixed = Backoff::fixed(Duration::from_millis(250));
+/// # let _ = (exponential, fixed);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Backoff {
+    base: Duration,
+    factor: f64,
+    max_delay: Duration,
+    jitter: bool,
+}
+
+impl Backoff {
+    /// A constant delay between every attempt (no growth, no jitter).
+    #[must_use]
+    pub fn fixed(delay: Duration) -> Self {
+        Self {
+            base: delay,
+            factor: 1.0,
+            max_delay: delay,
+            jitter: false,
+        }
+    }
+
+    /// Exponential backoff starting at `base`, doubling each attempt (factor `2.0`), capped at
+    /// `1s`, with full jitter enabled. Tune with [`factor`](Self::factor),
+    /// [`max_delay`](Self::max_delay) and [`jitter`](Self::jitter).
+    #[must_use]
+    pub fn exponential(base: Duration) -> Self {
+        Self {
+            base,
+            factor: 2.0,
+            max_delay: Duration::from_secs(1),
+            jitter: true,
+        }
+    }
+
+    /// Set the growth factor applied to the delay after each attempt. Values below `1.0` are
+    /// clamped to `1.0` (a non-growing schedule); `1.0` yields a constant delay.
+    #[must_use]
+    pub fn factor(
+        mut self,
+        factor: f64,
+    ) -> Self {
+        self.factor = factor.max(1.0);
+        self
+    }
+
+    /// Set the upper bound on any single delay.
+    #[must_use]
+    pub fn max_delay(
+        mut self,
+        max_delay: Duration,
+    ) -> Self {
+        self.max_delay = max_delay;
+        self
+    }
+
+    /// Enable or disable full jitter (a uniform random value in `[0, delay)`).
+    #[must_use]
+    pub fn jitter(
+        mut self,
+        jitter: bool,
+    ) -> Self {
+        self.jitter = jitter;
+        self
+    }
+}
+
+impl Default for Backoff {
+    /// Exponential backoff from `50ms`, doubling, capped at `1s`, jitter on.
+    fn default() -> Self {
+        Self::exponential(Duration::from_millis(50))
+    }
+}
+
+/// An opt-in, client-wide policy describing how many times, how fast, and which operations to
+/// re-issue on transient connection failures.
+///
+/// Disabled by default: [`RetryPolicy::default`] equals [`RetryPolicy::disabled`], so a client
+/// built without an explicit policy retries nothing and behaves exactly as before.
+///
+/// ```
+/// use falkordb::{RetryPolicy, Backoff};
+/// use std::time::Duration;
+///
+/// // Retry read-only operations up to 4 times total, exponential 100ms backoff capped at 2s.
+/// let policy = RetryPolicy::read_only()
+///     .max_attempts(4)
+///     .backoff(Backoff::exponential(Duration::from_millis(100)).max_delay(Duration::from_secs(2)));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RetryPolicy {
+    scope: RetryScope,
+    max_attempts: u32,
+    backoff: Backoff,
+}
+
+impl RetryPolicy {
+    /// A policy that retries nothing — identical to configuring no policy at all.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            scope: RetryScope::Disabled,
+            max_attempts: 1,
+            backoff: Backoff::default(),
+        }
+    }
+
+    /// Retry read-only / idempotent operations on transient connection failures: `3` attempts
+    /// total with the [default exponential backoff](Backoff::default). Writes are never retried.
+    #[must_use]
+    pub fn read_only() -> Self {
+        Self {
+            scope: RetryScope::ReadOnly,
+            max_attempts: 3,
+            backoff: Backoff::default(),
+        }
+    }
+
+    /// Set the **total** number of attempts (the first try plus retries). Values below `1` are
+    /// clamped to `1`; `max_attempts(1)` is equivalent to disabling retries.
+    #[must_use]
+    pub fn max_attempts(
+        mut self,
+        attempts: u32,
+    ) -> Self {
+        self.max_attempts = attempts.max(1);
+        self
+    }
+
+    /// Replace the [`Backoff`] schedule used between attempts.
+    #[must_use]
+    pub fn backoff(
+        mut self,
+        backoff: Backoff,
+    ) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// The scope this policy applies to.
+    #[must_use]
+    pub fn scope(&self) -> RetryScope {
+        self.scope
+    }
+}
+
+impl Default for RetryPolicy {
+    /// The default policy is [`RetryPolicy::disabled`].
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+/// Whether an operation may be retried under [`RetryScope::ReadOnly`]. Threaded explicitly from
+/// each call site (never inferred from the Cypher text) so the read/write boundary is the API the
+/// caller chose.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OpKind {
+    /// A read-only / idempotent operation, safe to re-issue.
+    ReadOnly,
+    /// A write or otherwise non-idempotent operation; never auto-retried in v1.
+    Write,
+}
+
+impl RetryPolicy {
+    /// Fast-path check: when `true`, the execution seams skip the retry machinery entirely and run
+    /// the operation exactly once, guaranteeing byte-identical behavior to having no policy.
+    pub(crate) fn is_disabled(&self) -> bool {
+        self.scope == RetryScope::Disabled || self.max_attempts <= 1
+    }
+
+    /// Whether `err` is a transient connection failure that a fresh attempt could recover from.
+    ///
+    /// Deliberately conservative: only the dead-/missing-connection family is retryable. The mixed
+    /// [`RedisError`](FalkorDBError::RedisError) bucket (logic/syntax/auth/query-timeout/IO) and the
+    /// [`Timeout`](FalkorDBError::Timeout) wait-operation error are **not** retried.
+    fn is_retryable_error(err: &FalkorDBError) -> bool {
+        matches!(
+            err,
+            FalkorDBError::ConnectionDown
+                | FalkorDBError::NoConnection
+                | FalkorDBError::EmptyConnection
+                | FalkorDBError::SentinelConnection(_)
+        )
+    }
+
+    /// Whether an operation of `kind` that failed with `err` is eligible for another attempt under
+    /// this policy. Used as backon's `.when(..)` predicate; the attempt budget is enforced
+    /// separately by the backoff schedule.
+    pub(crate) fn should_retry(
+        &self,
+        kind: OpKind,
+        err: &FalkorDBError,
+    ) -> bool {
+        match self.scope {
+            RetryScope::Disabled => false,
+            RetryScope::ReadOnly => kind == OpKind::ReadOnly && Self::is_retryable_error(err),
+        }
+    }
+
+    /// Build the backoff that drives this policy's sleep schedule and attempt budget. We supply our
+    /// own [`FalkorBackoffBuilder`] (rather than `backon::ExponentialBuilder`) so jitter is true
+    /// *full* jitter bounded by `max_delay` — `backon`'s built-in jitter is additive and can exceed
+    /// the cap. `backon` still drives the retry loop and sleeping.
+    pub(crate) fn backon_builder(&self) -> FalkorBackoffBuilder {
+        FalkorBackoffBuilder {
+            base: self.backoff.base,
+            factor: self.backoff.factor,
+            max_delay: self.backoff.max_delay,
+            max_attempts: self.max_attempts,
+            jitter: self.backoff.jitter,
+        }
+    }
+}
+
+/// A [`backon::BackoffBuilder`] producing our exponential schedule: each delay is
+/// `min(base * factor^n, max_delay)`, optionally replaced by full jitter (a uniform value in
+/// `[0, delay)`). Yields `max_attempts - 1` delays, then `None` to stop.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FalkorBackoffBuilder {
+    base: Duration,
+    factor: f64,
+    max_delay: Duration,
+    max_attempts: u32,
+    jitter: bool,
+}
+
+impl backon::BackoffBuilder for FalkorBackoffBuilder {
+    type Backoff = FalkorBackoff;
+
+    fn build(self) -> Self::Backoff {
+        FalkorBackoff {
+            next_base: self.base.as_secs_f64(),
+            factor: self.factor,
+            max_delay: self.max_delay.as_secs_f64(),
+            remaining: self.max_attempts.saturating_sub(1),
+            jitter: self.jitter,
+            rng: if self.jitter { jitter_seed() } else { 0 },
+        }
+    }
+}
+
+/// The [`backon::Backoff`] iterator built from a [`FalkorBackoffBuilder`].
+#[derive(Debug)]
+pub(crate) struct FalkorBackoff {
+    next_base: f64,
+    factor: f64,
+    max_delay: f64,
+    remaining: u32,
+    jitter: bool,
+    rng: u64,
+}
+
+impl Iterator for FalkorBackoff {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+
+        let capped = self.next_base.min(self.max_delay);
+        // Advance the (pre-jitter) base for the next attempt, holding it at the cap.
+        self.next_base = (self.next_base * self.factor).min(self.max_delay);
+
+        let delay = if self.jitter {
+            // Full jitter: a uniform value in [0, capped), so it never exceeds max_delay.
+            capped * next_unit_f64(&mut self.rng)
+        } else {
+            capped
+        };
+        Some(Duration::from_secs_f64(delay))
+    }
+}
+
+/// Seed the jitter PRNG from a process-wide counter mixed with the wall clock, so concurrent
+/// retries don't share a sequence. Jitter does not need cryptographic randomness.
+fn jitter_seed() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    // Ensure non-zero so the first splitmix64 step is well-distributed.
+    (nanos ^ counter.wrapping_mul(0x9E37_79B9_7F4A_7C15)) | 1
+}
+
+/// One `splitmix64` step mapped to `[0, 1)`.
+fn next_unit_f64(state: &mut u64) -> f64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^= z >> 31;
+    // Take the top 53 bits for a uniform double in [0, 1).
+    (z >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// The explicit read/write classification of a `QueryBuilder` wire command, used to decide retry
+/// eligibility. An allowlist of idempotent commands defaulting to [`OpKind::Write`], so an
+/// unrecognized (or future) command is never retried until it is deliberately classified here.
+/// `GRAPH.EXPLAIN` is read-only even though it is not `GRAPH.RO_QUERY`; `GRAPH.PROFILE` runs the
+/// query and is therefore a write.
+pub(crate) fn op_kind_for_command(command: &str) -> OpKind {
+    match command {
+        "GRAPH.RO_QUERY" | "GRAPH.EXPLAIN" => OpKind::ReadOnly,
+        _ => OpKind::Write,
+    }
+}
+
+/// Run a blocking operation under `policy`, retrying transient failures eligible for `kind`.
+///
+/// When the policy [is disabled](RetryPolicy::is_disabled) the operation runs exactly once with no
+/// retry machinery, guaranteeing byte-identical behavior to having no policy.
+pub(crate) fn run_with_retry_blocking<T>(
+    policy: &RetryPolicy,
+    kind: OpKind,
+    mut attempt: impl FnMut() -> FalkorResult<T>,
+) -> FalkorResult<T> {
+    if policy.is_disabled() {
+        return attempt();
+    }
+    use backon::BlockingRetryable as _;
+    attempt
+        .retry(policy.backon_builder())
+        .when(|err: &FalkorDBError| policy.should_retry(kind, err))
+        .call()
+}
+
+/// Async counterpart of [`run_with_retry_blocking`]. The `attempt` closure is re-invoked per try, so
+/// each attempt re-borrows a fresh connection (the healed one) before re-sending the command.
+#[cfg(feature = "tokio")]
+pub(crate) async fn run_with_retry_async<T, Fut>(
+    policy: &RetryPolicy,
+    kind: OpKind,
+    mut attempt: impl FnMut() -> Fut,
+) -> FalkorResult<T>
+where
+    Fut: std::future::Future<Output = FalkorResult<T>>,
+{
+    if policy.is_disabled() {
+        return attempt().await;
+    }
+    use backon::Retryable as _;
+    attempt
+        .retry(policy.backon_builder())
+        .when(|err: &FalkorDBError| policy.should_retry(kind, err))
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_is_disabled() {
+        assert_eq!(RetryPolicy::default(), RetryPolicy::disabled());
+        assert_eq!(RetryPolicy::default().scope(), RetryScope::Disabled);
+        assert!(RetryPolicy::default().is_disabled());
+    }
+
+    #[test]
+    fn read_only_preset_is_enabled() {
+        let policy = RetryPolicy::read_only();
+        assert_eq!(policy.scope(), RetryScope::ReadOnly);
+        assert!(!policy.is_disabled());
+    }
+
+    #[test]
+    fn max_attempts_one_disables_retry() {
+        let policy = RetryPolicy::read_only().max_attempts(1);
+        assert!(policy.is_disabled());
+    }
+
+    #[test]
+    fn max_attempts_is_clamped_to_at_least_one() {
+        assert!(RetryPolicy::read_only().max_attempts(0).is_disabled());
+    }
+
+    #[test]
+    fn disabled_scope_never_retries_any_error() {
+        let policy = RetryPolicy::disabled();
+        for err in retryable_errors() {
+            assert!(!policy.should_retry(OpKind::ReadOnly, &err));
+            assert!(!policy.should_retry(OpKind::Write, &err));
+        }
+    }
+
+    #[test]
+    fn read_only_retries_read_ops_on_transient_errors() {
+        let policy = RetryPolicy::read_only();
+        for err in retryable_errors() {
+            assert!(
+                policy.should_retry(OpKind::ReadOnly, &err),
+                "expected retry for read op on {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn read_only_never_retries_writes() {
+        let policy = RetryPolicy::read_only();
+        for err in retryable_errors() {
+            assert!(
+                !policy.should_retry(OpKind::Write, &err),
+                "writes must never be retried, even on {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_transient_errors_are_not_retried() {
+        let policy = RetryPolicy::read_only();
+        for err in non_retryable_errors() {
+            assert!(
+                !policy.should_retry(OpKind::ReadOnly, &err),
+                "non-transient error must not be retried: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn connection_down_healed_into_no_connection_is_still_retryable_for_reads() {
+        // The recovery path can convert a post-send ConnectionDown into NoConnection; both remain
+        // retryable for reads, and (critically) neither is ever retried for writes in v1.
+        let policy = RetryPolicy::read_only();
+        assert!(policy.should_retry(OpKind::ReadOnly, &FalkorDBError::NoConnection));
+        assert!(!policy.should_retry(OpKind::Write, &FalkorDBError::NoConnection));
+    }
+
+    #[test]
+    fn command_classification_table() {
+        // Read-only commands are an explicit allowlist; everything else (incl. PROFILE, which runs
+        // the query) is a write, and unknown commands fall back to the conservative Write default.
+        assert_eq!(op_kind_for_command("GRAPH.RO_QUERY"), OpKind::ReadOnly);
+        assert_eq!(op_kind_for_command("GRAPH.EXPLAIN"), OpKind::ReadOnly);
+        assert_eq!(op_kind_for_command("GRAPH.QUERY"), OpKind::Write);
+        assert_eq!(op_kind_for_command("GRAPH.PROFILE"), OpKind::Write);
+        assert_eq!(op_kind_for_command("SOMETHING.NEW"), OpKind::Write);
+    }
+
+    #[test]
+    fn backoff_yields_max_attempts_minus_one_delays() {
+        use backon::BackoffBuilder as _;
+        let delays: Vec<Duration> = RetryPolicy::read_only()
+            .max_attempts(5)
+            .backon_builder()
+            .build()
+            .collect();
+        assert_eq!(
+            delays.len(),
+            4,
+            "N total attempts means N-1 inter-attempt delays"
+        );
+    }
+
+    #[test]
+    fn backoff_exponential_without_jitter_grows_and_caps() {
+        use backon::BackoffBuilder as _;
+        let delays: Vec<Duration> = RetryPolicy::read_only()
+            .max_attempts(6)
+            .backoff(
+                Backoff::exponential(Duration::from_millis(50))
+                    .max_delay(Duration::from_millis(180))
+                    .jitter(false),
+            )
+            .backon_builder()
+            .build()
+            .collect();
+        // 50, 100, 200→180 (capped), 180, 180 — monotonic non-decreasing, never above the cap.
+        let cap = Duration::from_millis(180);
+        for pair in delays.windows(2) {
+            assert!(
+                pair[0] <= pair[1],
+                "delays must be non-decreasing: {delays:?}"
+            );
+        }
+        assert!(
+            delays.iter().all(|d| *d <= cap),
+            "no delay may exceed max_delay: {delays:?}"
+        );
+        assert!(
+            delays[2] == cap && delays[delays.len() - 1] == cap,
+            "tail must sit at the cap"
+        );
+    }
+
+    #[test]
+    fn backoff_full_jitter_never_exceeds_cap() {
+        use backon::BackoffBuilder as _;
+        // Many short attempts: every jittered delay must stay within [0, max_delay].
+        let cap = Duration::from_millis(40);
+        let delays: Vec<Duration> = RetryPolicy::read_only()
+            .max_attempts(64)
+            .backoff(
+                Backoff::exponential(Duration::from_millis(10))
+                    .max_delay(cap)
+                    .jitter(true),
+            )
+            .backon_builder()
+            .build()
+            .collect();
+        assert_eq!(delays.len(), 63);
+        assert!(
+            delays.iter().all(|d| *d <= cap),
+            "full jitter must never exceed max_delay: {delays:?}"
+        );
+    }
+
+    #[test]
+    fn backoff_fixed_is_constant() {
+        use backon::BackoffBuilder as _;
+        let delays: Vec<Duration> = RetryPolicy::read_only()
+            .max_attempts(4)
+            .backoff(Backoff::fixed(Duration::from_millis(25)))
+            .backon_builder()
+            .build()
+            .collect();
+        assert_eq!(delays, vec![Duration::from_millis(25); 3]);
+    }
+
+    fn retryable_errors() -> Vec<FalkorDBError> {
+        vec![
+            FalkorDBError::ConnectionDown,
+            FalkorDBError::NoConnection,
+            FalkorDBError::EmptyConnection,
+            FalkorDBError::SentinelConnection("sentinel down".into()),
+        ]
+    }
+
+    fn non_retryable_errors() -> Vec<FalkorDBError> {
+        vec![
+            FalkorDBError::RedisError("ERR syntax error".into()),
+            FalkorDBError::ParsingError("bad reply".into()),
+            FalkorDBError::InvalidDataReceived,
+            FalkorDBError::SentinelMastersCount,
+            FalkorDBError::Timeout {
+                operation: crate::WaitOperation::IndexCreation,
+                timeout: Duration::from_secs(5),
+            },
+        ]
+    }
+}
+
+/// Hermetic fault-injection over the blocking runner: a `Cell` counter records attempts while the
+/// closure returns a scripted sequence of errors/successes, so the retry semantics are proven
+/// without a server.
+#[cfg(test)]
+mod blocking_runner_tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// A read-only policy with zero backoff so tests don't actually sleep between attempts.
+    fn fast_read_only(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy::read_only()
+            .max_attempts(max_attempts)
+            .backoff(Backoff::fixed(Duration::ZERO))
+    }
+
+    #[test]
+    fn disabled_attempts_exactly_once_even_on_transient_error() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_blocking(&RetryPolicy::disabled(), OpKind::ReadOnly, || {
+                calls.set(calls.get() + 1);
+                Err(FalkorDBError::ConnectionDown)
+            });
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(calls.get(), 1, "disabled policy must attempt exactly once");
+    }
+
+    #[test]
+    fn read_only_retries_until_success() {
+        let calls = Cell::new(0);
+        let result = run_with_retry_blocking(&fast_read_only(3), OpKind::ReadOnly, || {
+            calls.set(calls.get() + 1);
+            if calls.get() < 3 {
+                Err(FalkorDBError::ConnectionDown)
+            } else {
+                Ok(42)
+            }
+        });
+        assert_eq!(result.expect("should eventually succeed"), 42);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[test]
+    fn write_is_never_retried() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_blocking(&fast_read_only(5), OpKind::Write, || {
+                calls.set(calls.get() + 1);
+                Err(FalkorDBError::ConnectionDown)
+            });
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(
+            calls.get(),
+            1,
+            "writes must never be retried under ReadOnly scope"
+        );
+    }
+
+    #[test]
+    fn exhausts_max_attempts_then_returns_last_error() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_blocking(&fast_read_only(4), OpKind::ReadOnly, || {
+                calls.set(calls.get() + 1);
+                Err(FalkorDBError::ConnectionDown)
+            });
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(calls.get(), 4, "should attempt exactly max_attempts times");
+    }
+
+    #[test]
+    fn non_transient_error_is_not_retried() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_blocking(&fast_read_only(5), OpKind::ReadOnly, || {
+                calls.set(calls.get() + 1);
+                Err(FalkorDBError::RedisError("ERR syntax".into()))
+            });
+        assert!(matches!(result, Err(FalkorDBError::RedisError(_))));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn connection_down_healed_into_no_connection_is_still_retried_for_reads() {
+        // Mirrors the recovery path: ConnectionDown, then a healed NoConnection, then success.
+        let calls = Cell::new(0);
+        let result = run_with_retry_blocking(&fast_read_only(3), OpKind::ReadOnly, || {
+            calls.set(calls.get() + 1);
+            match calls.get() {
+                1 => Err(FalkorDBError::ConnectionDown),
+                2 => Err(FalkorDBError::NoConnection),
+                _ => Ok("ok"),
+            }
+        });
+        assert_eq!(result.expect("should succeed after healing"), "ok");
+        assert_eq!(calls.get(), 3);
+    }
+}
+
+/// Async parity of [`blocking_runner_tests`].
+#[cfg(all(test, feature = "tokio"))]
+mod async_runner_tests {
+    use super::*;
+    use std::cell::Cell;
+
+    fn fast_read_only(max_attempts: u32) -> RetryPolicy {
+        RetryPolicy::read_only()
+            .max_attempts(max_attempts)
+            .backoff(Backoff::fixed(Duration::ZERO))
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn disabled_attempts_exactly_once() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_async(&RetryPolicy::disabled(), OpKind::ReadOnly, || {
+                calls.set(calls.get() + 1);
+                async { Err(FalkorDBError::ConnectionDown) }
+            })
+            .await;
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn read_only_retries_until_success() {
+        let calls = Cell::new(0);
+        let result = run_with_retry_async(&fast_read_only(3), OpKind::ReadOnly, || {
+            calls.set(calls.get() + 1);
+            let attempt = calls.get();
+            async move {
+                if attempt < 3 {
+                    Err(FalkorDBError::ConnectionDown)
+                } else {
+                    Ok(7)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.expect("should eventually succeed"), 7);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_is_never_retried() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_async(&fast_read_only(5), OpKind::Write, || {
+                calls.set(calls.get() + 1);
+                async { Err(FalkorDBError::ConnectionDown) }
+            })
+            .await;
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(calls.get(), 1, "writes must never be retried");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exhausts_max_attempts_then_returns_last_error() {
+        let calls = Cell::new(0);
+        let result: FalkorResult<()> =
+            run_with_retry_async(&fast_read_only(4), OpKind::ReadOnly, || {
+                calls.set(calls.get() + 1);
+                async { Err(FalkorDBError::ConnectionDown) }
+            })
+            .await;
+        assert!(matches!(result, Err(FalkorDBError::ConnectionDown)));
+        assert_eq!(calls.get(), 4);
+    }
+}


### PR DESCRIPTION
## What

Adds an opt-in, client-wide `RetryPolicy` that automatically re-issues **eligible** operations on **transient** connection failures with bounded backoff. **Disabled by default**, so existing behavior is byte-for-byte unchanged.

```rust
let client = FalkorClientBuilder::new()
    .with_retry_policy(RetryPolicy::read_only().max_attempts(4))
    .build()?;
```

`with_retry_policy(..)` is available on both the sync and async builders.

## Safety (the core invariant)

- **Disabled by default ⇒ no semantic change.** With no policy, every operation is attempted exactly once (the `is_disabled()` fast path skips the retry machinery entirely). All existing tests pass unchanged.
- **Writes are never retried.** The only scope is `RetryScope::ReadOnly`. Classification is by an explicit `OpKind` per call site (never by inspecting Cypher): `GRAPH.RO_QUERY`/`GRAPH.EXPLAIN` ⇒ read-only; `GRAPH.QUERY`/`GRAPH.PROFILE` ⇒ write (PROFILE runs the query). `query()` is a write even when it only reads — use `ro_query()` for retryable reads.
- The read-only `DB.INDEXES`/`DB.CONSTRAINTS` listings dispatch over `GRAPH.QUERY` yet are idempotent, so they carry an explicit `.read_only()` marker and stay retry-eligible.
- Only transient connection errors are retried (`ConnectionDown`/`NoConnection`/`EmptyConnection`/`SentinelConnection`); deterministic errors (syntax/constraint/parse/type) and wait-operation timeouts are returned immediately.

## Design

- New public types: `RetryPolicy`, `RetryScope`, `Backoff`. `RetryPolicy::default() == disabled`.
- Backoff/jitter is driven internally by `backon`; its `tokio-sleep` feature is gated behind the crate's `tokio` feature so **sync-only builds don't pull in tokio**.
- Jitter is **true full jitter** (uniform in `[0, delay]`) with a **hard `max_delay` cap**, via a small custom `backon::Backoff` (backon's built-in jitter is additive and can exceed the cap).
- The retry loop lives inside the async/sync query + procedure execution seams; each attempt re-borrows a fresh connection so the existing connection healing is picked up on the next try. The async closure captures only `Copy` references (`async move`), so no `&mut self` is held across `.await`.

## Scope / follow-ups (documented in README + rustdoc)

- Retry currently wraps **query and procedure execution**. Direct client/admin calls (`list_graphs`, config, `slowlog`, server `INFO`) and the internal schema-cache refresh are **not** wrapped yet — a planned follow-up.
- `fresh_connection`-on-retry (more robust recovery for fully-drained multi-connection pools) is deferred as an efficacy refinement; it is **not** a safety issue (the async default is the auto-healing multiplexed strategy).
- MSRV is unchanged: `redis@1.2.3` already requires rustc 1.88, above `backon`'s 1.85 floor, so this adds no MSRV constraint.

## Tests

- 24 hermetic `retry::` tests: classification truth table, command table, backoff schedule (exact growth + **cap never exceeded with jitter**), and fault-injection over both runners (disabled ⇒ exactly one attempt, read retried→succeeds, **write never retried**, max-attempts exhaustion, `ConnectionDown`→`NoConnection` healing still retried for reads), with sync + async parity.
- Full suite green: 531 tests pass; `just done` (fmt, strict clippy-all, build, doc, deny, llms drift), spellcheck, and `llms.txt` regenerated.

Reviewed via an internal rubber-duck pass (no blocking issues; the jitter-cap and coverage-doc findings are addressed here).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in automatic retry policy for transient connection failures with bounded exponential backoff and jitter.
  * Retries are disabled by default; enable via `FalkorClientBuilder::with_retry_policy()`.
  * Only retries read-only/idempotent operations; write operations are never retried.
  * New public types: `RetryPolicy`, `RetryScope`, and `Backoff` for configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->