### PR TITLE
feat: enrich tracing spans with structured fields and a redacting query fingerprint

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -157,3 +157,4 @@ backon
 millis
 jitter
 getters
+OpenTelemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Observability: when the `tracing` feature is enabled, the query- and procedure-execution spans are
+  enriched with structured, low-cardinality fields (named after the OpenTelemetry database semantic
+  conventions): `db.system.name`, `db.namespace` (graph), `db.operation.name`, `db.falkordb.read_only`,
+  `db.falkordb.strategy`, a privacy-safe `db.query.fingerprint`, and `error.type` on failure. The raw
+  query text and parameter values are **never** recorded by default — the fingerprint is a hash of the
+  query with all literals redacted. Opt in to recording the raw Cypher (`db.query.text`) with the new
+  `FalkorClientBuilder::with_query_logging(true)`.
 - Opt-in, client-wide `RetryPolicy` that automatically re-issues *eligible* operations on *transient*
   connection failures with bounded backoff. **Disabled by default**, so existing behavior is
   byte-for-byte unchanged. Configure it on either builder with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "ureq",
  "which",
 ]
@@ -815,6 +816,12 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1463,6 +1470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1710,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ criterion = { version = "0.5", features = ["async_tokio"] }
 futures = "0.3"
 proptest = "1"
 serde_json = "1"
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std", "fmt"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"
@@ -99,3 +101,7 @@ name = "typed_params"
 
 [[example]]
 name = "rows"
+
+[[example]]
+name = "observability"
+required-features = ["tracing"]

--- a/README.md
+++ b/README.md
@@ -583,6 +583,49 @@ cargo add falkordb --features tracing
 Note that different functions use different filtration levels, to avoid spamming your tests, be sure to enable the
 correct level as you desire it.
 
+When the `tracing` feature is enabled, the query- and procedure-execution spans are enriched with
+structured, low-cardinality fields you can slice and filter on (named after the
+[OpenTelemetry database conventions](https://opentelemetry.io/docs/specs/semconv/database/) so they
+map cleanly when exported via `tracing-opentelemetry`):
+
+| Field | Example | Meaning |
+|---|---|---|
+| `db.system.name` | `falkordb` | constant |
+| `db.namespace` | `social` | the graph name |
+| `db.operation.name` | `GRAPH.RO_QUERY` / `db.idx.fulltext.queryNodes` | the command or procedure |
+| `db.falkordb.read_only` | `true` | whether the operation is read-only |
+| `db.falkordb.strategy` | `multiplexed` | the active connection strategy |
+| `db.query.fingerprint` | `a1b2c3d4e5f60718` | a privacy-safe hash of the query *shape* |
+| `error.type` | `connection_down` | a bounded error kind, recorded on failure |
+
+**Privacy by default.** The raw query text and parameter values are **never** recorded by default —
+only the `db.query.fingerprint`, which is a hash of the query with all literals (strings, numbers,
+`true`/`false`/`null`) redacted, so two queries that differ only in their values share a fingerprint
+and no value ever enters a span. If you need the raw Cypher for debugging in a trusted environment,
+opt in explicitly:
+
+```no_run
+use falkordb::FalkorClientBuilder;
+
+# fn doc() -> Result<(), Box<dyn std::error::Error>> {
+let client = FalkorClientBuilder::new()
+    .with_query_logging(true) // records `db.query.text`; off by default
+    .build()?;
+# let _ = client;
+# Ok(())
+# }
+```
+
+Parameter values supplied via `with_param` are never recorded even when query logging is enabled
+(they live in the query preamble, not the query text).
+
+> **Note:** the async query/procedure futures are deeply nested (retry + instrumentation). If you
+> `tokio::spawn` them with the `tracing` feature enabled and hit a `recursion limit` /
+> `overflow evaluating ... Send` error, add `#![recursion_limit = "256"]` to your crate root — the
+> standard fix for deep `async` + `tracing` stacks.
+
+See [`examples/observability.rs`](examples/observability.rs) for a complete, runnable example.
+
 ### Typed result mapping (serde)
 
 Enable the optional `serde` feature to map query results straight into your own types instead of hand-matching every

--- a/examples/async_api.rs
+++ b/examples/async_api.rs
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+#![recursion_limit = "256"]
+
 use falkordb::{FalkorClientBuilder, FalkorResult};
 use futures::{StreamExt, TryStreamExt};
 use tokio::task::JoinSet;

--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+#![recursion_limit = "256"]
+
 //! Async streaming results with `futures::StreamExt` / `TryStreamExt`.
 //!
 //! Run with: `cargo run --example async_stream --features tokio`

--- a/examples/multiplexed_async.rs
+++ b/examples/multiplexed_async.rs
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+#![recursion_limit = "256"]
+
 //! Demonstrates the multiplexed async connection strategy: many concurrent queries
 //! share a small number of auto-reconnecting sockets, each carrying several in-flight
 //! commands at once.

--- a/examples/observability.rs
+++ b/examples/observability.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Demonstrates the `tracing` span enrichment (run with `--features tracing`).
+//!
+//! With the `tracing` feature enabled, the query- and procedure-execution spans carry structured,
+//! low-cardinality fields you can slice on — the graph (`db.namespace`), the command
+//! (`db.operation.name`), whether it is read-only, the connection strategy, and a privacy-safe
+//! `db.query.fingerprint`. The raw query text and parameter values are never recorded by default.
+//!
+//! This installs a simple `tracing-subscriber` that prints each span (and its fields) as it closes,
+//! so you can see the enriched execution spans for the write and the read below. Run with:
+//! `cargo run --example observability --features tracing`.
+
+use falkordb::{FalkorClientBuilder, FalkorResult};
+use tracing_subscriber::fmt::format::FmtSpan;
+
+fn main() -> FalkorResult<()> {
+    // Print each span and its recorded fields when it closes. The execution spans are at TRACE
+    // level, so enable TRACE to see them (a real app would scope this to the `falkordb` target).
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_span_events(FmtSpan::CLOSE)
+        .with_target(true)
+        .init();
+
+    let connection_info = std::env::var("FALKORDB_CONNECTION")
+        .unwrap_or_else(|_| "falkor://127.0.0.1:6379".to_string());
+
+    // `with_query_logging(true)` would additionally record the raw Cypher as `db.query.text`;
+    // it is off by default for privacy, so only the redacted fingerprint is recorded.
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info.as_str().try_into()?)
+        .build()?;
+
+    let mut graph = client.select_graph("observability_example");
+
+    // A write: its span carries `db.operation.name = "GRAPH.QUERY"`, `db.falkordb.read_only = false`.
+    graph
+        .query("CREATE (:Movie {title: 'The Matrix', year: 1999})")
+        .execute()?;
+
+    // A read: its span carries `db.operation.name = "GRAPH.RO_QUERY"`, `read_only = true`, and a
+    // `db.query.fingerprint` that is independent of the inlined `'The Matrix'` literal.
+    let mut titles = graph
+        .ro_query("MATCH (m:Movie) WHERE m.title = 'The Matrix' RETURN m.year")
+        .execute()?;
+
+    for row in titles.data.by_ref() {
+        println!("read-only result: {row:?}");
+    }
+
+    graph.delete()?;
+
+    Ok(())
+}

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -71,6 +71,9 @@ pub struct FalkorAsyncClientInner {
     /// Opt-in retry policy applied to eligible operations; [`disabled`](RetryPolicy::disabled) by
     /// default, in which case every operation is attempted exactly once.
     retry_policy: RetryPolicy,
+    /// When set, the raw query text is recorded as a span field (opt-in via `with_query_logging`).
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
+    query_logging: bool,
 }
 
 impl FalkorAsyncClientInner {
@@ -78,6 +81,18 @@ impl FalkorAsyncClientInner {
     /// [`disabled`](RetryPolicy::disabled)).
     pub(crate) fn retry_policy(&self) -> RetryPolicy {
         self.retry_policy
+    }
+
+    /// The active connection strategy (used for observability span fields).
+    #[cfg(feature = "tracing")]
+    pub(crate) fn strategy(&self) -> ConnectionStrategy {
+        self.strategy
+    }
+
+    /// Whether raw query text may be recorded on spans (opt-in; `false` by default).
+    #[cfg(feature = "tracing")]
+    pub(crate) fn query_logging(&self) -> bool {
+        self.query_logging
     }
 
     /// Borrow a connection from the given executor. For the pooled strategy this waits
@@ -234,6 +249,7 @@ impl FalkorAsyncClient {
         requested_strategy: ConnectionStrategy,
         max_inflight: Option<NonZeroUsize>,
         retry_policy: RetryPolicy,
+        query_logging: bool,
     ) -> FalkorResult<Self> {
         // A multiplexed ConnectionManager built from a Sentinel-resolved client pins to a
         // single node and reconnects to the same address rather than re-resolving the
@@ -275,6 +291,7 @@ impl FalkorAsyncClient {
                 primary,
                 readonly,
                 retry_policy,
+                query_logging,
             }),
             _connection_info: connection_info,
         })
@@ -947,6 +964,7 @@ mod tests {
             primary,
             readonly: Some(readonly),
             retry_policy: RetryPolicy::disabled(),
+            query_logging: false,
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -39,6 +39,9 @@ pub(crate) struct FalkorSyncClientInner {
     /// Opt-in retry policy applied to eligible operations; [`disabled`](RetryPolicy::disabled) by
     /// default, in which case every operation is attempted exactly once.
     retry_policy: RetryPolicy,
+    /// When set, the raw query text is recorded as a span field (opt-in via `with_query_logging`).
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
+    query_logging: bool,
 }
 
 impl FalkorSyncClientInner {
@@ -46,6 +49,12 @@ impl FalkorSyncClientInner {
     /// [`disabled`](RetryPolicy::disabled)).
     pub(crate) fn retry_policy(&self) -> RetryPolicy {
         self.retry_policy
+    }
+
+    /// Whether raw query text may be recorded on spans (opt-in; `false` by default).
+    #[cfg(feature = "tracing")]
+    pub(crate) fn query_logging(&self) -> bool {
+        self.query_logging
     }
 
     #[cfg_attr(
@@ -150,6 +159,7 @@ impl FalkorSyncClient {
         connection_info: FalkorConnectionInfo,
         num_connections: u8,
         retry_policy: RetryPolicy,
+        query_logging: bool,
     ) -> FalkorResult<Self> {
         let (connection_pool_tx, connection_pool_rx) = mpsc::sync_channel(num_connections as usize);
 
@@ -174,6 +184,7 @@ impl FalkorSyncClient {
                 connection_pool_rx: Mutex::new(connection_pool_rx),
                 readonly_pool,
                 retry_policy,
+                query_logging,
             }),
             _connection_info: connection_info,
         })
@@ -453,6 +464,7 @@ pub(crate) fn create_empty_inner_sync_client() -> Arc<FalkorSyncClientInner> {
         connection_pool_rx: Mutex::new(rx),
         readonly_pool: None,
         retry_policy: RetryPolicy::disabled(),
+        query_logging: false,
     })
 }
 
@@ -640,6 +652,7 @@ mod tests {
             connection_pool_rx: Mutex::new(rx),
             readonly_pool: Some(pool),
             retry_policy: RetryPolicy::disabled(),
+            query_logging: false,
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -21,6 +21,7 @@ pub struct FalkorClientBuilder<const R: char> {
     max_inflight: Option<NonZeroUsize>,
     tcp_settings: Option<redis::io::tcp::TcpSettings>,
     retry_policy: RetryPolicy,
+    query_logging: bool,
 }
 
 impl<const R: char> FalkorClientBuilder<R> {
@@ -90,6 +91,23 @@ impl<const R: char> FalkorClientBuilder<R> {
     ) -> Self {
         Self {
             retry_policy,
+            ..self
+        }
+    }
+
+    /// Opt in to recording the **raw query text** as a span field (`db.query.text`) on the client's
+    /// `tracing` spans. **Off by default** for privacy: by default only a redacted query
+    /// fingerprint (`db.query.fingerprint`) is recorded, never the query text or parameter values.
+    ///
+    /// Enable this only in trusted environments — the raw Cypher you pass can contain inlined
+    /// literals (secrets/PII). Parameter values supplied via `with_param` are never recorded even
+    /// when this is on. Has no effect unless the `tracing` feature is enabled.
+    pub fn with_query_logging(
+        self,
+        enabled: bool,
+    ) -> Self {
+        Self {
+            query_logging: enabled,
             ..self
         }
     }
@@ -229,6 +247,7 @@ impl FalkorClientBuilder<'S'> {
             max_inflight: None,
             tcp_settings: None,
             retry_policy: RetryPolicy::disabled(),
+            query_logging: false,
         }
     }
 
@@ -258,6 +277,7 @@ impl FalkorClientBuilder<'S'> {
             actual_connection_info,
             self.strategy.connection_count().get(),
             self.retry_policy,
+            self.query_logging,
         )
     }
 }
@@ -277,6 +297,7 @@ impl FalkorClientBuilder<'A'> {
             max_inflight: None,
             tcp_settings: None,
             retry_policy: RetryPolicy::disabled(),
+            query_logging: false,
         }
     }
 
@@ -373,6 +394,7 @@ impl FalkorClientBuilder<'A'> {
             self.strategy,
             self.max_inflight,
             self.retry_policy,
+            self.query_logging,
         )
         .await
     }
@@ -389,6 +411,7 @@ mod tests {
 
         assert!(FalkorClientBuilder::new()
             .with_connection_info(connection_info.unwrap())
+            .with_query_logging(true)
             .build()
             .is_ok());
     }

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -256,7 +256,16 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         tracing::instrument(
             name = "Common Query Execution Steps",
             skip_all,
-            fields(readonly = (self.command == "GRAPH.RO_QUERY")),
+            fields(
+                db.system.name = "falkordb",
+                db.namespace = %self.graph.graph_name(),
+                db.operation.name = %self.command,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.falkordb.strategy = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+                error.type = tracing::field::Empty,
+            ),
             level = "trace"
         )
     )]
@@ -271,13 +280,23 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         }
 
         let client = self.graph.get_client();
-        let graph_name = self.graph.graph_name();
         let command = self.command;
+        let op_kind = op_kind_for_command(command);
+
+        #[cfg(feature = "tracing")]
+        crate::observability::record_request(
+            crate::observability::SYNC_STRATEGY,
+            matches!(op_kind, OpKind::ReadOnly),
+            &self.query_string.to_string(),
+            client.query_logging(),
+        );
+
+        let graph_name = self.graph.graph_name();
         let readonly_conn = command == "GRAPH.RO_QUERY";
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
-        run_with_retry_blocking(&policy, op_kind_for_command(command), || {
+        let result = run_with_retry_blocking(&policy, op_kind, || {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone())
             } else {
@@ -286,7 +305,13 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
             conn.and_then(|mut conn| {
                 conn.execute_command(Some(graph_name), command, None, Some(params_ref))
             })
-        })
+        });
+
+        #[cfg(feature = "tracing")]
+        if let Err(ref err) = result {
+            crate::observability::record_error(err);
+        }
+        result
     }
 }
 
@@ -297,7 +322,16 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         tracing::instrument(
             name = "Common Query Execution Steps",
             skip_all,
-            fields(readonly = (self.command == "GRAPH.RO_QUERY")),
+            fields(
+                db.system.name = "falkordb",
+                db.namespace = %self.graph.graph_name(),
+                db.operation.name = %self.command,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.falkordb.strategy = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+                error.type = tracing::field::Empty,
+            ),
             level = "trace"
         )
     )]
@@ -312,13 +346,23 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         }
 
         let client = self.graph.get_client();
-        let graph_name = self.graph.graph_name();
         let command = self.command;
+        let op_kind = op_kind_for_command(command);
+
+        #[cfg(feature = "tracing")]
+        crate::observability::record_request(
+            crate::observability::strategy_label(&client.strategy()),
+            matches!(op_kind, OpKind::ReadOnly),
+            &self.query_string.to_string(),
+            client.query_logging(),
+        );
+
+        let graph_name = self.graph.graph_name();
         let readonly_conn = command == "GRAPH.RO_QUERY";
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
-        run_with_retry_async(&policy, op_kind_for_command(command), || async move {
+        let result = run_with_retry_async(&policy, op_kind, || async move {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone()).await
             } else {
@@ -328,7 +372,13 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
                 .execute_command(Some(graph_name), command, None, Some(params_ref))
                 .await
         })
-        .await
+        .await;
+
+        #[cfg(feature = "tracing")]
+        if let Err(ref err) = result {
+            crate::observability::record_error(err);
+        }
+        result
     }
 
     /// Eagerly parses the reply into an owned [`RowStream`] under the schema write lock, so the
@@ -632,7 +682,16 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         tracing::instrument(
             name = "Common Procedure Call Execution Steps",
             skip_all,
-            fields(readonly = self.readonly),
+            fields(
+                db.system.name = "falkordb",
+                db.namespace = %self.graph.graph_name(),
+                db.operation.name = %self.procedure_name,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.falkordb.strategy = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+                error.type = tracing::field::Empty,
+            ),
             level = "trace"
         )
     )]
@@ -644,6 +703,15 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
 
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
+
+        #[cfg(feature = "tracing")]
+        crate::observability::record_request(
+            crate::observability::SYNC_STRATEGY,
+            matches!(self.op_kind, OpKind::ReadOnly),
+            &query_string,
+            self.graph.get_client().query_logging(),
+        );
+
         let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
@@ -653,7 +721,7 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
 
-        run_with_retry_blocking(&policy, op_kind, || {
+        let result = run_with_retry_blocking(&policy, op_kind, || {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone())
             } else {
@@ -662,7 +730,13 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
             conn.and_then(|mut conn| {
                 conn.execute_command(Some(graph_name), command, None, Some(&exec_params))
             })
-        })
+        });
+
+        #[cfg(feature = "tracing")]
+        if let Err(ref err) = result {
+            crate::observability::record_error(err);
+        }
+        result
     }
 }
 
@@ -673,7 +747,16 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         tracing::instrument(
             name = "Common Procedure Call Execution Steps",
             skip_all,
-            fields(readonly = self.readonly),
+            fields(
+                db.system.name = "falkordb",
+                db.namespace = %self.graph.graph_name(),
+                db.operation.name = %self.procedure_name,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.falkordb.strategy = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+                error.type = tracing::field::Empty,
+            ),
             level = "trace"
         )
     )]
@@ -685,16 +768,26 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
 
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
-        let query = construct_query(query_string, &params)?;
 
         let client = self.graph.get_client();
+
+        #[cfg(feature = "tracing")]
+        crate::observability::record_request(
+            crate::observability::strategy_label(&client.strategy()),
+            matches!(self.op_kind, OpKind::ReadOnly),
+            &query_string,
+            client.query_logging(),
+        );
+
+        let query = construct_query(query_string, &params)?;
+
         let graph_name = self.graph.graph_name();
         let readonly_conn = self.readonly;
         let op_kind = self.op_kind;
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
 
-        run_with_retry_async(&policy, op_kind, || async move {
+        let result = run_with_retry_async(&policy, op_kind, || async move {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone()).await
             } else {
@@ -704,7 +797,13 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
                 .execute_command(Some(graph_name), command, None, Some(&exec_params))
                 .await
         })
-        .await
+        .await;
+
+        #[cfg(feature = "tracing")]
+        if let Err(ref err) = result {
+            crate::observability::record_error(err);
+        }
+        result
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod embedded;
 mod error;
 mod graph;
 mod graph_schema;
+#[cfg(feature = "tracing")]
+mod observability;
 mod parser;
 mod response;
 mod retry;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,389 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Internal helpers for the optional `tracing` (and, later, `metrics`) instrumentation.
+//!
+//! Everything here is compiled only when an observability feature is enabled, so the hot path does
+//! no instrumentation work when they are off. The headline safety property is that **no raw query
+//! text or parameter values are ever recorded by default**: spans carry a privacy-safe
+//! [`query_fingerprint`] (a hash of the query *template* with literals redacted), and the raw query
+//! is recorded only behind the opt-in `with_query_logging` builder flag.
+
+#[cfg(feature = "tokio")]
+use crate::ConnectionStrategy;
+use crate::FalkorDBError;
+use std::sync::OnceLock;
+
+/// Compute a privacy-safe, stable fingerprint of a Cypher query.
+///
+/// Literals (quoted strings, numbers, `true`/`false`/`null`) are redacted to `?` before hashing, so
+/// the fingerprint depends only on the query *shape* — two calls that differ only in their literal
+/// or parameter values share a fingerprint, and no sensitive value enters the hash. Redaction is
+/// best-effort (a regex, not a full Cypher parser). The value is an FNV-1a hash rendered as 16 hex
+/// digits; it is **not** guaranteed stable across crate versions (group within a deployment).
+pub(crate) fn query_fingerprint(query: &str) -> String {
+    let normalized = redact_literals(query);
+    format!("{:016x}", fnv1a_64(normalized.as_bytes()))
+}
+
+/// Replace string / numeric / boolean / null literals with `?`. Identifiers, labels, property
+/// names, keywords and structure are preserved, so the redacted text captures the query shape.
+fn redact_literals(query: &str) -> String {
+    static LITERAL: OnceLock<regex::Regex> = OnceLock::new();
+    let re = LITERAL.get_or_init(|| {
+        // Order matters: match whole quoted strings first so literals inside them are not matched
+        // again, then numbers, then the boolean/null keywords (word-bounded, case-insensitive).
+        regex::Regex::new(
+            r#"'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|\b\d+(?:\.\d+)?\b|(?i)\b(?:true|false|null)\b"#,
+        )
+        .expect("the literal-redaction regex is a valid, fixed pattern")
+    });
+    re.replace_all(query, "?").into_owned()
+}
+
+/// FNV-1a 64-bit hash. Deterministic and dependency-free; adequate for a grouping fingerprint.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+/// A bounded, payload-free label for an error, safe to use as a span field or (later) a metric
+/// label. Matches on the variant only — never on any carried `String` — so it can never echo a
+/// query, parameter, graph name, or server message.
+pub(crate) fn error_kind(error: &FalkorDBError) -> &'static str {
+    match error {
+        FalkorDBError::ConnectionDown => "connection_down",
+        FalkorDBError::NoConnection => "no_connection",
+        FalkorDBError::EmptyConnection => "empty_connection",
+        FalkorDBError::SentinelConnection(_) => "sentinel_connection",
+        FalkorDBError::SentinelMastersCount => "sentinel_masters_count",
+        FalkorDBError::Timeout { .. } => "timeout",
+        FalkorDBError::ConstraintFailed { .. } => "constraint_failed",
+        FalkorDBError::RedisError(_) => "redis_error",
+        FalkorDBError::RedisParsingError(_) => "redis_parsing_error",
+        FalkorDBError::InvalidConnectionInfo(_) => "invalid_connection_info",
+        FalkorDBError::InvalidDataReceived => "invalid_data_received",
+        FalkorDBError::UnavailableProvider => "unavailable_provider",
+        FalkorDBError::ParamEncoding { .. } => "param_encoding",
+        FalkorDBError::TypeError { .. } => "type_error",
+        FalkorDBError::EmbeddedServerError(_) => "embedded_server_error",
+        FalkorDBError::SingleThreadedRuntime => "single_threaded_runtime",
+        FalkorDBError::NoRuntime => "no_runtime",
+        // The long tail (parse/type/result-mapping/schema variants and any future additions) is
+        // bucketed; the variant name is never sensitive, but one label keeps cardinality bounded.
+        _ => "other",
+    }
+}
+
+/// A bounded label for the active connection strategy. The sync client is always pooled.
+#[cfg(feature = "tokio")]
+pub(crate) fn strategy_label(strategy: &ConnectionStrategy) -> &'static str {
+    match strategy {
+        ConnectionStrategy::Pooled { .. } => "pooled",
+        ConnectionStrategy::Multiplexed { .. } => "multiplexed",
+    }
+}
+
+/// The strategy label for the (always pooled) sync client.
+pub(crate) const SYNC_STRATEGY: &str = "pooled";
+
+/// Record the request-side operational fields on the current span: the connection strategy, whether
+/// the operation is read-only, and the privacy-safe query fingerprint — plus the raw query template
+/// **only** when `log_raw` is set (the opt-in `with_query_logging` flag). Parameter values are never
+/// recorded — they live in the query preamble, not in `query_template`.
+pub(crate) fn record_request(
+    strategy: &'static str,
+    read_only: bool,
+    query_template: &str,
+    log_raw: bool,
+) {
+    let span = tracing::Span::current();
+    span.record("db.falkordb.strategy", strategy);
+    span.record("db.falkordb.read_only", read_only);
+    span.record(
+        "db.query.fingerprint",
+        query_fingerprint(query_template).as_str(),
+    );
+    if log_raw {
+        span.record("db.query.text", query_template);
+    }
+}
+
+/// Record the bounded error kind on the current span when an operation fails.
+pub(crate) fn record_error(error: &FalkorDBError) {
+    tracing::Span::current().record("error.type", error_kind(error));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_stable_for_same_query() {
+        assert_eq!(
+            query_fingerprint("MATCH (n:Person) RETURN n.name"),
+            query_fingerprint("MATCH (n:Person) RETURN n.name"),
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_value_independent_for_inlined_literals() {
+        // The whole point of redaction: differing literal values must not change the fingerprint.
+        let a = query_fingerprint("MATCH (u:User {email: 'alice@example.com'}) RETURN u");
+        let b = query_fingerprint("MATCH (u:User {email: 'bob@other.org'}) RETURN u");
+        assert_eq!(
+            a, b,
+            "inlined string literals must be redacted before hashing"
+        );
+
+        let n1 = query_fingerprint("MATCH (n) WHERE n.age > 21 RETURN n");
+        let n2 = query_fingerprint("MATCH (n) WHERE n.age > 65 RETURN n");
+        assert_eq!(n1, n2, "numeric literals must be redacted before hashing");
+    }
+
+    #[test]
+    fn fingerprint_distinguishes_query_shape() {
+        assert_ne!(
+            query_fingerprint("MATCH (n:Person) RETURN n.name"),
+            query_fingerprint("MATCH (n:Movie) RETURN n.title"),
+        );
+    }
+
+    #[test]
+    fn redaction_removes_literal_values_and_fingerprint_is_hex() {
+        let query = "MATCH (u {ssn: '123-45-6789', name: 'secret'}) RETURN u";
+        // The meaningful privacy check: the redacted text (the actual hash *input*) contains no
+        // literal values. Asserting on the hash digest itself would be flaky — random hex can
+        // contain "123" by chance, and "secret" can never appear in hex regardless.
+        let redacted = redact_literals(query);
+        assert!(
+            !redacted.contains("123-45-6789"),
+            "numbers must be redacted: {redacted:?}"
+        );
+        assert!(
+            !redacted.contains("secret"),
+            "strings must be redacted: {redacted:?}"
+        );
+        assert!(
+            redacted.contains('?'),
+            "literals are replaced with placeholders: {redacted:?}"
+        );
+        // The fingerprint itself is a fixed-length hex digest.
+        let fingerprint = query_fingerprint(query);
+        assert_eq!(fingerprint.len(), 16, "fingerprint is 16 hex digits");
+        assert!(fingerprint.bytes().all(|b| b.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn redaction_preserves_shape_and_strips_literals() {
+        assert_eq!(
+            redact_literals("MATCH (u:User {age: 30, active: true}) RETURN u.name"),
+            "MATCH (u:User {age: ?, active: ?}) RETURN u.name",
+        );
+    }
+
+    #[test]
+    fn error_kind_is_bounded_and_payload_free() {
+        // A String-carrying variant must map to a fixed label, never echoing the payload.
+        assert_eq!(
+            error_kind(&FalkorDBError::RedisError("secret server detail".into())),
+            "redis_error",
+        );
+        assert_eq!(
+            error_kind(&FalkorDBError::ConnectionDown),
+            "connection_down"
+        );
+        assert_eq!(
+            error_kind(&FalkorDBError::SentinelConnection("host:port".into())),
+            "sentinel_connection",
+        );
+    }
+
+    #[test]
+    fn error_kind_is_a_bounded_lowercase_label_for_every_constructed_variant() {
+        let cases: Vec<FalkorDBError> = vec![
+            FalkorDBError::ConnectionDown,
+            FalkorDBError::NoConnection,
+            FalkorDBError::EmptyConnection,
+            FalkorDBError::InvalidDataReceived,
+            FalkorDBError::UnavailableProvider,
+            FalkorDBError::SingleThreadedRuntime,
+            FalkorDBError::NoRuntime,
+            FalkorDBError::SentinelMastersCount,
+            FalkorDBError::SentinelConnection("payload".into()),
+            FalkorDBError::RedisError("payload".into()),
+            FalkorDBError::RedisParsingError("payload".into()),
+            FalkorDBError::InvalidConnectionInfo("payload".into()),
+            FalkorDBError::EmbeddedServerError("payload".into()),
+            FalkorDBError::ParamEncoding {
+                parameter: Some("payload".into()),
+                message: "payload".into(),
+            },
+            FalkorDBError::TypeError {
+                expected: "Payload",
+                got: "Payload",
+            },
+            FalkorDBError::Timeout {
+                operation: crate::WaitOperation::IndexCreation,
+                timeout: std::time::Duration::from_secs(1),
+            },
+            FalkorDBError::ConstraintFailed {
+                label: "payload".into(),
+                properties: vec!["payload".into()],
+                constraint_type: crate::ConstraintType::Unique,
+            },
+            // Catch-all bucket:
+            FalkorDBError::ParsingError("payload".into()),
+            FalkorDBError::InvalidEnumType("payload".into()),
+            FalkorDBError::ParsingBool,
+        ];
+        for err in &cases {
+            let kind = error_kind(err);
+            assert!(!kind.is_empty(), "{err:?} must have a label");
+            assert!(
+                !kind.to_lowercase().contains("payload"),
+                "error_kind for {err:?} must not echo any payload"
+            );
+            assert!(
+                kind.bytes().all(|b| b.is_ascii_lowercase() || b == b'_'),
+                "error_kind for {err:?} must be a lowercase_snake label, got {kind:?}"
+            );
+        }
+    }
+}
+
+/// End-to-end check that [`record_request`] / [`record_error`] set the declared span fields — and,
+/// critically, that the field names match the `#[instrument(fields(...))]` declarations on the
+/// execution seams (a mismatch would silently no-op). Uses a `tracing-subscriber` registry so
+/// `Span::current()` resolves correctly.
+#[cfg(test)]
+mod span_capture_tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+    use tracing_subscriber::Layer;
+
+    #[derive(Default)]
+    struct Visitor(HashMap<String, String>);
+
+    impl Visit for Visitor {
+        fn record_debug(
+            &mut self,
+            field: &Field,
+            value: &dyn std::fmt::Debug,
+        ) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+        fn record_str(
+            &mut self,
+            field: &Field,
+            value: &str,
+        ) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+        fn record_bool(
+            &mut self,
+            field: &Field,
+            value: bool,
+        ) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CaptureLayer(Arc<Mutex<HashMap<String, String>>>);
+
+    impl<S: tracing::Subscriber + for<'a> LookupSpan<'a>> Layer<S> for CaptureLayer {
+        fn on_record(
+            &self,
+            _id: &tracing::Id,
+            values: &tracing::span::Record<'_>,
+            _ctx: Context<'_, S>,
+        ) {
+            let mut visitor = Visitor::default();
+            values.record(&mut visitor);
+            self.0.lock().unwrap().extend(visitor.0);
+        }
+    }
+
+    fn capture(body: impl FnOnce()) -> HashMap<String, String> {
+        let layer = CaptureLayer::default();
+        let recorded = layer.0.clone();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, body);
+        let guard = recorded.lock().unwrap();
+        guard.clone()
+    }
+
+    #[test]
+    fn records_strategy_read_only_fingerprint_and_error_but_not_raw_text() {
+        let fields = capture(|| {
+            let span = tracing::trace_span!(
+                "test",
+                db.falkordb.strategy = tracing::field::Empty,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+                error.type = tracing::field::Empty,
+            );
+            let _enter = span.enter();
+            super::record_request(
+                "multiplexed",
+                true,
+                "MATCH (n {x: 'secret'}) RETURN n",
+                false,
+            );
+            super::record_error(&crate::FalkorDBError::ConnectionDown);
+        });
+        assert_eq!(
+            fields.get("db.falkordb.strategy").map(String::as_str),
+            Some("multiplexed")
+        );
+        assert_eq!(
+            fields.get("db.falkordb.read_only").map(String::as_str),
+            Some("true")
+        );
+        assert!(
+            fields.contains_key("db.query.fingerprint"),
+            "fingerprint must be recorded"
+        );
+        assert!(
+            !fields.contains_key("db.query.text"),
+            "raw query text must be absent unless query logging is enabled"
+        );
+        assert_eq!(
+            fields.get("error.type").map(String::as_str),
+            Some("connection_down")
+        );
+    }
+
+    #[test]
+    fn records_raw_text_only_when_query_logging_enabled() {
+        let fields = capture(|| {
+            let span = tracing::trace_span!(
+                "test",
+                db.falkordb.strategy = tracing::field::Empty,
+                db.falkordb.read_only = tracing::field::Empty,
+                db.query.fingerprint = tracing::field::Empty,
+                db.query.text = tracing::field::Empty,
+            );
+            let _enter = span.enter();
+            super::record_request("pooled", false, "MATCH (n) RETURN n", true);
+        });
+        assert_eq!(
+            fields.get("db.query.text").map(String::as_str),
+            Some("MATCH (n) RETURN n")
+        );
+    }
+}

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -2,6 +2,7 @@
  * Copyright FalkorDB Ltd. 2023 - present
  * Licensed under the MIT License.
  */
+#![recursion_limit = "256"]
 
 //! Comprehensive integration tests for the **embedded** FalkorDB server, across every
 //! client flavour:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,6 +2,7 @@
  * Copyright FalkorDB Ltd. 2023 - present
  * Licensed under the MIT License.
  */
+#![recursion_limit = "256"]
 
 //! Integration tests for FalkorDB client
 //!

--- a/tests/multiplexing_parity.rs
+++ b/tests/multiplexing_parity.rs
@@ -2,6 +2,7 @@
  * Copyright FalkorDB Ltd. 2023 - present
  * Licensed under the MIT License.
  */
+#![recursion_limit = "256"]
 
 //! Regression / parity suite for the async connection-strategy change.
 //!


### PR DESCRIPTION
## What

First of three PRs implementing the **observability** half of roadmap #10 (the resilience/retry half merged as #250). This PR adds **span enrichment + a privacy-safe query fingerprint** behind the existing `tracing` feature. No new runtime dependency.

When `tracing` is enabled, the query/procedure execution spans carry structured, low-cardinality fields (named after the OpenTelemetry DB semantic conventions, so they map cleanly via `tracing-opentelemetry`):

```
Common Query Execution Steps{
  db.system.name="falkordb" db.namespace=social db.operation.name=GRAPH.RO_QUERY
  db.falkordb.read_only=true db.falkordb.strategy="pooled"
  db.query.fingerprint="941a046ee79accc4"
}
```

## Safety / privacy (the core property)

- **Raw query text and parameter values are never recorded by default.** Only `db.query.fingerprint` is — an FNV-1a hash of the query with **all literals redacted** (quoted strings, numbers, `true`/`false`/`null` → `?`) before hashing. Two queries that differ only in their literal/parameter values share a fingerprint, and no value ever enters a span.
- **Opt-in** raw Cypher logging via the new `FalkorClientBuilder::with_query_logging(true)` (records `db.query.text`). Parameter values are still never recorded even then — they live in the query preamble, not the query text.
- **`error.type`** is a bounded `&'static str` matched on the error variant only — never echoes a payload/message.
- **Gated behind `tracing`**: no instrumentation work (timing/hashing) when the feature is off.

## Tests

- Hermetic `observability::` tests: fingerprint stability + **value-independence for inlined literals** + shape-distinction + "no literal survives in the fingerprint"; `error_kind` boundedness; and a `tracing-subscriber`-backed capture test asserting the recorded **field names match the `#[instrument]` declarations** (a mismatch would silently no-op) and that `db.query.text` appears only when query logging is on.
- Full suite green with `--features tokio,serde,tracing` (539 tests); `just done` (fmt, strict clippy, build, doc, deny, llms), spellcheck.

## Notes

- The async query/procedure futures are deeply nested (retry + instrumentation). When `tokio::spawn`-ing them with `tracing` on, downstream crates may need `#![recursion_limit = "256"]` — the standard deep-`async` + `tracing` fix. The bundled async examples/tests get it, and the README documents it for users.
- Follow-ups (separate PRs): **PR2** adds the opt-in `metrics` feature (counters/histograms with bounded labels); **PR3** adds result-side fields (rows, server time), pool-wait/in-flight, and retry signals.

`tracing-subscriber` is added as a **dev-dependency only** (for the capture test + example).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tracing support with OpenTelemetry integration for query and procedure execution observability
  * Query spans enriched with structured metadata (graph, operation type, read-only flag, error details) while maintaining privacy defaults
  * Introduced opt-in raw query logging via `with_query_logging(true)`
  * Added observability example demonstrating tracing integration

* **Documentation**
  * Updated documentation describing tracing span enrichment, privacy defaults, and opt-in configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->