### PR TITLE
feat: add optional metrics feature with bounded counters and histograms

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -158,3 +158,7 @@ millis
 jitter
 getters
 OpenTelemetry
+allowlist
+Prometheus
+prometheus
+PrometheusBuilder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional `metrics` feature: emits per-operation counters and a duration histogram through the
+  [`metrics`](https://docs.rs/metrics) facade (so the application installs any exporter) —
+  `falkordb_queries_total`, `falkordb_query_duration_seconds`, and `falkordb_query_errors_total`. All
+  labels are **bounded, low-cardinality** (`command` allowlist, `operation`, `strategy`, `error_kind`);
+  the graph name, query text and fingerprint are never used as labels. No-op until a recorder is
+  installed.
 - Observability: when the `tracing` feature is enabled, the query- and procedure-execution spans are
   enriched with structured, low-cardinality fields (named after the OpenTelemetry database semantic
   conventions): `db.system.name`, `db.namespace` (graph), `db.operation.name`, `db.falkordb.read_only`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,8 @@ dependencies = [
  "futures",
  "futures-core",
  "libc",
+ "metrics",
+ "metrics-util",
  "parking_lot",
  "proptest",
  "redis",
@@ -462,6 +464,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -639,7 +647,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -647,6 +655,9 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -869,6 +880,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "metrics",
+ "ordered-float",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1000,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1082,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1171,6 +1225,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1483,6 +1555,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", default-features = false, features = ["std", "std-blocking-sleep"] }
 futures-core = { version = "0.3", default-features = false, optional = true }
+metrics = { version = "0.24", optional = true }
 parking_lot = { version = "0.12.5", default-features = false }
 redis = { version = "1.2.2", default-features = false, features = ["sentinel"] }
 regex = { version = "1.12.3", default-features = false, features = ["std", "perf", "unicode-bool", "unicode-perl"] }
@@ -38,6 +39,7 @@ proptest = "1"
 serde_json = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std", "fmt"] }
+metrics-util = { version = "0.20", default-features = false, features = ["debugging"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2"
@@ -63,6 +65,10 @@ tokio-native-tls = ["tokio", "redis/tokio-native-tls-comp"]
 tokio-rustls = ["tokio", "redis/tokio-rustls-comp"]
 
 tracing = ["dep:tracing"]
+
+# Optional `metrics` integration: emit counters/histograms (queries, durations, errors) with
+# bounded labels via the `metrics` facade, so the application can install any exporter.
+metrics = ["dep:metrics"]
 
 embedded = ["dep:which", "dep:ureq", "dep:sha2"]
 

--- a/Justfile
+++ b/Justfile
@@ -17,7 +17,7 @@ image := "falkordb/falkordb:edge"
 container := "falkordb-rs-dev"
 
 # Feature set exercised by the full local suite (mirrors the coverage CI job).
-features := "tokio,embedded,serde"
+features := "tokio,embedded,serde,tracing,metrics"
 
 # Default recipe: list everything.
 default:

--- a/README.md
+++ b/README.md
@@ -626,6 +626,36 @@ Parameter values supplied via `with_param` are never recorded even when query lo
 
 See [`examples/observability.rs`](examples/observability.rs) for a complete, runnable example.
 
+### Metrics
+
+Enable the `metrics` feature to emit counters and histograms through the
+[`metrics`](https://docs.rs/metrics/latest/metrics/) facade, so your application can install any
+exporter (Prometheus, OpenTelemetry, …):
+
+```bash
+cargo add falkordb --features metrics
+```
+
+Each query and procedure execution records:
+
+| Metric | Type | Labels |
+|---|---|---|
+| `falkordb_queries_total` | counter | `command`, `operation` (`read`/`write`), `strategy` |
+| `falkordb_query_duration_seconds` | histogram | `command`, `operation` |
+| `falkordb_query_errors_total` | counter | `command`, `error_kind` |
+
+All labels are **bounded, low-cardinality** values: `command` is an allowlist of known commands
+(unknown ⇒ `other`), `operation`/`strategy`/`error_kind` are small fixed sets. The graph name, query
+text, and query fingerprint are **never** used as labels (they are unbounded and would explode metric
+cardinality) — those belong on `tracing` spans, not metrics. Like `tracing`, recording is a no-op
+until you install a recorder; for example, with `metrics-exporter-prometheus`:
+
+```rust,ignore
+let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+builder.install().expect("failed to install Prometheus recorder");
+// ... use the client; metrics are now exported on the configured endpoint.
+```
+
 ### Typed result mapping (serde)
 
 Enable the optional `serde` feature to map query results straight into your own types instead of hand-matching every

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -83,8 +83,8 @@ impl FalkorAsyncClientInner {
         self.retry_policy
     }
 
-    /// The active connection strategy (used for observability span fields).
-    #[cfg(feature = "tracing")]
+    /// The active connection strategy (used for observability span fields and metric labels).
+    #[cfg(any(feature = "tracing", feature = "metrics"))]
     pub(crate) fn strategy(&self) -> ConnectionStrategy {
         self.strategy
     }

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -283,9 +283,11 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         let command = self.command;
         let op_kind = op_kind_for_command(command);
 
+        #[cfg(any(feature = "tracing", feature = "metrics"))]
+        let strategy = crate::observability::SYNC_STRATEGY;
         #[cfg(feature = "tracing")]
         crate::observability::record_request(
-            crate::observability::SYNC_STRATEGY,
+            strategy,
             matches!(op_kind, OpKind::ReadOnly),
             &self.query_string.to_string(),
             client.query_logging(),
@@ -296,6 +298,8 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
+        #[cfg(feature = "metrics")]
+        let metrics_start = std::time::Instant::now();
         let result = run_with_retry_blocking(&policy, op_kind, || {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone())
@@ -311,6 +315,14 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         if let Err(ref err) = result {
             crate::observability::record_error(err);
         }
+        #[cfg(feature = "metrics")]
+        crate::observability::record_query_metrics(
+            command,
+            matches!(op_kind, OpKind::ReadOnly),
+            strategy,
+            metrics_start.elapsed(),
+            result.as_ref().err(),
+        );
         result
     }
 }
@@ -349,9 +361,11 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         let command = self.command;
         let op_kind = op_kind_for_command(command);
 
+        #[cfg(any(feature = "tracing", feature = "metrics"))]
+        let strategy = crate::observability::strategy_label(&client.strategy());
         #[cfg(feature = "tracing")]
         crate::observability::record_request(
-            crate::observability::strategy_label(&client.strategy()),
+            strategy,
             matches!(op_kind, OpKind::ReadOnly),
             &self.query_string.to_string(),
             client.query_logging(),
@@ -362,6 +376,8 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
+        #[cfg(feature = "metrics")]
+        let metrics_start = std::time::Instant::now();
         let result = run_with_retry_async(&policy, op_kind, || async move {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone()).await
@@ -378,6 +394,14 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         if let Err(ref err) = result {
             crate::observability::record_error(err);
         }
+        #[cfg(feature = "metrics")]
+        crate::observability::record_query_metrics(
+            command,
+            matches!(op_kind, OpKind::ReadOnly),
+            strategy,
+            metrics_start.elapsed(),
+            result.as_ref().err(),
+        );
         result
     }
 
@@ -704,9 +728,11 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         let (query_string, params) =
             generate_procedure_call(self.procedure_name, self.args, self.yields);
 
+        #[cfg(any(feature = "tracing", feature = "metrics"))]
+        let strategy = crate::observability::SYNC_STRATEGY;
         #[cfg(feature = "tracing")]
         crate::observability::record_request(
-            crate::observability::SYNC_STRATEGY,
+            strategy,
             matches!(self.op_kind, OpKind::ReadOnly),
             &query_string,
             self.graph.get_client().query_logging(),
@@ -721,6 +747,8 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
 
+        #[cfg(feature = "metrics")]
+        let metrics_start = std::time::Instant::now();
         let result = run_with_retry_blocking(&policy, op_kind, || {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone())
@@ -736,6 +764,14 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         if let Err(ref err) = result {
             crate::observability::record_error(err);
         }
+        #[cfg(feature = "metrics")]
+        crate::observability::record_query_metrics(
+            command,
+            matches!(op_kind, OpKind::ReadOnly),
+            strategy,
+            metrics_start.elapsed(),
+            result.as_ref().err(),
+        );
         result
     }
 }
@@ -771,9 +807,11 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
 
         let client = self.graph.get_client();
 
+        #[cfg(any(feature = "tracing", feature = "metrics"))]
+        let strategy = crate::observability::strategy_label(&client.strategy());
         #[cfg(feature = "tracing")]
         crate::observability::record_request(
-            crate::observability::strategy_label(&client.strategy()),
+            strategy,
             matches!(self.op_kind, OpKind::ReadOnly),
             &query_string,
             client.query_logging(),
@@ -787,6 +825,8 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
 
+        #[cfg(feature = "metrics")]
+        let metrics_start = std::time::Instant::now();
         let result = run_with_retry_async(&policy, op_kind, || async move {
             let conn = if readonly_conn {
                 client.borrow_readonly_connection(client.clone()).await
@@ -803,6 +843,14 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         if let Err(ref err) = result {
             crate::observability::record_error(err);
         }
+        #[cfg(feature = "metrics")]
+        crate::observability::record_query_metrics(
+            command,
+            matches!(op_kind, OpKind::ReadOnly),
+            strategy,
+            metrics_start.elapsed(),
+            result.as_ref().err(),
+        );
         result
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod embedded;
 mod error;
 mod graph;
 mod graph_schema;
-#[cfg(feature = "tracing")]
+#[cfg(any(feature = "tracing", feature = "metrics"))]
 mod observability;
 mod parser;
 mod response;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -14,6 +14,7 @@
 #[cfg(feature = "tokio")]
 use crate::ConnectionStrategy;
 use crate::FalkorDBError;
+#[cfg(feature = "tracing")]
 use std::sync::OnceLock;
 
 /// Compute a privacy-safe, stable fingerprint of a Cypher query.
@@ -23,6 +24,7 @@ use std::sync::OnceLock;
 /// or parameter values share a fingerprint, and no sensitive value enters the hash. Redaction is
 /// best-effort (a regex, not a full Cypher parser). The value is an FNV-1a hash rendered as 16 hex
 /// digits; it is **not** guaranteed stable across crate versions (group within a deployment).
+#[cfg(feature = "tracing")]
 pub(crate) fn query_fingerprint(query: &str) -> String {
     let normalized = redact_literals(query);
     format!("{:016x}", fnv1a_64(normalized.as_bytes()))
@@ -30,6 +32,7 @@ pub(crate) fn query_fingerprint(query: &str) -> String {
 
 /// Replace string / numeric / boolean / null literals with `?`. Identifiers, labels, property
 /// names, keywords and structure are preserved, so the redacted text captures the query shape.
+#[cfg(feature = "tracing")]
 fn redact_literals(query: &str) -> String {
     static LITERAL: OnceLock<regex::Regex> = OnceLock::new();
     let re = LITERAL.get_or_init(|| {
@@ -44,6 +47,7 @@ fn redact_literals(query: &str) -> String {
 }
 
 /// FNV-1a 64-bit hash. Deterministic and dependency-free; adequate for a grouping fingerprint.
+#[cfg(feature = "tracing")]
 fn fnv1a_64(bytes: &[u8]) -> u64 {
     const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
@@ -99,6 +103,7 @@ pub(crate) const SYNC_STRATEGY: &str = "pooled";
 /// the operation is read-only, and the privacy-safe query fingerprint — plus the raw query template
 /// **only** when `log_raw` is set (the opt-in `with_query_logging` flag). Parameter values are never
 /// recorded — they live in the query preamble, not in `query_template`.
+#[cfg(feature = "tracing")]
 pub(crate) fn record_request(
     strategy: &'static str,
     read_only: bool,
@@ -118,14 +123,73 @@ pub(crate) fn record_request(
 }
 
 /// Record the bounded error kind on the current span when an operation fails.
+#[cfg(feature = "tracing")]
 pub(crate) fn record_error(error: &FalkorDBError) {
     tracing::Span::current().record("error.type", error_kind(error));
+}
+
+/// A bounded label for a wire command, for use as a metric label. An allowlist of known commands
+/// (unknown ⇒ `"other"`), so a metric label can never carry a user-controlled or high-cardinality
+/// string. Procedure calls are labeled by their wire command (`GRAPH.QUERY`/`GRAPH.RO_QUERY`), never
+/// by the procedure name.
+#[cfg(feature = "metrics")]
+pub(crate) fn command_label(command: &str) -> &'static str {
+    match command {
+        "GRAPH.QUERY" => "GRAPH.QUERY",
+        "GRAPH.RO_QUERY" => "GRAPH.RO_QUERY",
+        "GRAPH.PROFILE" => "GRAPH.PROFILE",
+        "GRAPH.EXPLAIN" => "GRAPH.EXPLAIN",
+        "GRAPH.DELETE" => "GRAPH.DELETE",
+        "GRAPH.COPY" => "GRAPH.COPY",
+        "GRAPH.SLOWLOG" => "GRAPH.SLOWLOG",
+        "GRAPH.CONFIG" => "GRAPH.CONFIG",
+        "INFO" => "INFO",
+        _ => "other",
+    }
+}
+
+/// Emit the per-operation metrics with **bounded** labels: `command` (allowlisted), `operation`
+/// (`read`/`write`), `strategy`, and `error_kind` on failure. The graph name, query text and
+/// fingerprint are deliberately **never** used as labels — they are unbounded and belong on spans,
+/// not metrics, where they would explode cardinality.
+#[cfg(feature = "metrics")]
+pub(crate) fn record_query_metrics(
+    command: &str,
+    read_only: bool,
+    strategy: &'static str,
+    duration: std::time::Duration,
+    error: Option<&FalkorDBError>,
+) {
+    let command = command_label(command);
+    let operation = if read_only { "read" } else { "write" };
+    metrics::counter!(
+        "falkordb_queries_total",
+        "command" => command,
+        "operation" => operation,
+        "strategy" => strategy,
+    )
+    .increment(1);
+    metrics::histogram!(
+        "falkordb_query_duration_seconds",
+        "command" => command,
+        "operation" => operation,
+    )
+    .record(duration.as_secs_f64());
+    if let Some(err) = error {
+        metrics::counter!(
+            "falkordb_query_errors_total",
+            "command" => command,
+            "error_kind" => error_kind(err),
+        )
+        .increment(1);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn fingerprint_is_stable_for_same_query() {
         assert_eq!(
@@ -134,6 +198,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn fingerprint_is_value_independent_for_inlined_literals() {
         // The whole point of redaction: differing literal values must not change the fingerprint.
@@ -149,6 +214,7 @@ mod tests {
         assert_eq!(n1, n2, "numeric literals must be redacted before hashing");
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn fingerprint_distinguishes_query_shape() {
         assert_ne!(
@@ -157,6 +223,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn redaction_removes_literal_values_and_fingerprint_is_hex() {
         let query = "MATCH (u {ssn: '123-45-6789', name: 'secret'}) RETURN u";
@@ -182,6 +249,7 @@ mod tests {
         assert!(fingerprint.bytes().all(|b| b.is_ascii_hexdigit()));
     }
 
+    #[cfg(feature = "tracing")]
     #[test]
     fn redaction_preserves_shape_and_strips_literals() {
         assert_eq!(
@@ -264,7 +332,7 @@ mod tests {
 /// critically, that the field names match the `#[instrument(fields(...))]` declarations on the
 /// execution seams (a mismatch would silently no-op). Uses a `tracing-subscriber` registry so
 /// `Span::current()` resolves correctly.
-#[cfg(test)]
+#[cfg(all(test, feature = "tracing"))]
 mod span_capture_tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -385,5 +453,65 @@ mod span_capture_tests {
             fields.get("db.query.text").map(String::as_str),
             Some("MATCH (n) RETURN n")
         );
+    }
+}
+
+/// Tests for the `metrics` emission: the labels must be a bounded set and must never carry a graph
+/// name, query text, fingerprint, or error payload.
+#[cfg(all(test, feature = "metrics"))]
+mod metrics_tests {
+    use super::*;
+    use metrics_util::debugging::DebuggingRecorder;
+    use std::time::Duration;
+
+    #[test]
+    fn command_label_is_a_bounded_allowlist() {
+        assert_eq!(command_label("GRAPH.RO_QUERY"), "GRAPH.RO_QUERY");
+        assert_eq!(command_label("GRAPH.QUERY"), "GRAPH.QUERY");
+        assert_eq!(command_label("GRAPH.PROFILE"), "GRAPH.PROFILE");
+        // Anything not on the allowlist (incl. a procedure name or a hostile string) is bucketed.
+        assert_eq!(command_label("DB.INDEXES"), "other");
+        assert_eq!(command_label("'; DROP graph --"), "other");
+    }
+
+    #[test]
+    fn record_query_metrics_emits_three_series_with_only_bounded_labels() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            record_query_metrics(
+                "GRAPH.QUERY",
+                false,
+                "pooled",
+                Duration::from_millis(5),
+                Some(&crate::FalkorDBError::RedisError(
+                    "secret server detail".into(),
+                )),
+            );
+        });
+
+        let mut names = Vec::new();
+        for (composite, _unit, _desc, _value) in snapshotter.snapshot().into_vec() {
+            let key = composite.key();
+            names.push(key.name().to_string());
+            for label in key.labels() {
+                // Labels must be from the bounded set; never a payload / graph / query / fingerprint.
+                assert!(
+                    matches!(
+                        label.key(),
+                        "command" | "operation" | "strategy" | "error_kind"
+                    ),
+                    "unexpected (potentially unbounded) metric label: {:?}",
+                    label.key()
+                );
+                assert!(
+                    !label.value().contains("secret"),
+                    "metric label leaked an error payload: {label:?}"
+                );
+            }
+        }
+        assert!(names.iter().any(|n| n == "falkordb_queries_total"));
+        assert!(names.iter().any(|n| n == "falkordb_query_duration_seconds"));
+        assert!(names.iter().any(|n| n == "falkordb_query_errors_total"));
     }
 }


### PR DESCRIPTION
## What

Second of the observability PRs (after #252). Adds an opt-in **`metrics` feature** that emits per-operation counters and a duration histogram through the [`metrics`](https://docs.rs/metrics) facade, so the application installs any exporter (Prometheus, OpenTelemetry, …).

| Metric | Type | Labels |
|---|---|---|
| `falkordb_queries_total` | counter | `command`, `operation`, `strategy` |
| `falkordb_query_duration_seconds` | histogram | `command`, `operation` |
| `falkordb_query_errors_total` | counter | `command`, `error_kind` |

## Cardinality safety (the core property)

- **All labels are bounded, low-cardinality.** `command` is an **allowlist** of known wire commands (unknown ⇒ `"other"`); `operation` (`read`/`write`), `strategy` (`pooled`/`multiplexed`), and `error_kind` are small fixed sets matched on the error *variant* only (never a payload).
- The **graph name, query text, and query fingerprint are never used as labels** — they are unbounded and would explode metric cardinality. They belong on `tracing` spans (PR #252), not metrics.
- A hermetic test installs a thread-local debugging recorder and asserts the emitted series carry **only** the bounded label set (`command`/`operation`/`strategy`/`error_kind`) and never echo an error payload. Plus a `command_label` allowlist test.
- Procedure calls are labeled by their wire command (`GRAPH.QUERY`/`GRAPH.RO_QUERY`), **never** by the (high-cardinality) procedure name.

## Implementation

- Emission is wired into the same four query/procedure execution seams as the tracing enrichment, behind `#[cfg(feature = "metrics")]`, timing the whole operation (including retries). No work when the feature is off; recording is a no-op until a recorder is installed.
- The shared `observability` module is now gated on `any(feature = "tracing", feature = "metrics")`, with the tracing-specific helpers (fingerprint, span recording) gated on `tracing` and the metrics helpers on `metrics`. `error_kind` is shared by both (span `error.type` + metric label).
- `metrics-util` is a **dev-dependency only** (the debugging recorder for the test).

## Tests / validation

- Full suite green with `--features tokio,serde,tracing,metrics` (542 tests); builds verified across `metrics`, `metrics,tokio`, tracing-only, and all-features combos; `just done` (fmt, strict clippy, build, doc, deny, llms), spellcheck. `metrics` is added to the gate features so CI lints + covers it.
- No public API change (a feature flag only) — `llms.txt` unchanged.

Follow-up: **PR3** adds result-side span fields (rows, server time), pool-wait/in-flight, and retry signals.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
