### PR TITLE
feat: add retry, in-flight and pool-wait observability signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional `metrics` feature: emits per-operation counters and a duration histogram through the
+- Optional `metrics` feature: emits per-operation counters, histograms and a gauge through the
   [`metrics`](https://docs.rs/metrics) facade (so the application installs any exporter) —
-  `falkordb_queries_total`, `falkordb_query_duration_seconds`, and `falkordb_query_errors_total`. All
-  labels are **bounded, low-cardinality** (`command` allowlist, `operation`, `strategy`, `error_kind`);
-  the graph name, query text and fingerprint are never used as labels. No-op until a recorder is
-  installed.
+  `falkordb_queries_total`, `falkordb_query_duration_seconds`, `falkordb_query_errors_total`,
+  `falkordb_retries_total`, `falkordb_connections_in_flight`, and `falkordb_connection_pool_wait_seconds`.
+  All labels are **bounded, low-cardinality** (`command` allowlist, `operation`, `strategy`,
+  `error_kind`, `route`); the graph name, query text and fingerprint are never used as labels. Retries
+  also emit a low-cardinality `tracing` debug event. No-op until a recorder is installed.
 - Observability: when the `tracing` feature is enabled, the query- and procedure-execution spans are
   enriched with structured, low-cardinality fields (named after the OpenTelemetry database semantic
   conventions): `db.system.name`, `db.namespace` (graph), `db.operation.name`, `db.falkordb.read_only`,

--- a/README.md
+++ b/README.md
@@ -643,6 +643,9 @@ Each query and procedure execution records:
 | `falkordb_queries_total` | counter | `command`, `operation` (`read`/`write`), `strategy` |
 | `falkordb_query_duration_seconds` | histogram | `command`, `operation` |
 | `falkordb_query_errors_total` | counter | `command`, `error_kind` |
+| `falkordb_retries_total` | counter | `operation`, `error_kind` |
+| `falkordb_connections_in_flight` | gauge | `route` (`primary`/`replica`) |
+| `falkordb_connection_pool_wait_seconds` | histogram | `route` (pooled strategy only) |
 
 All labels are **bounded, low-cardinality** values: `command` is an allowlist of known commands
 (unknown ⇒ `other`), `operation`/`strategy`/`error_kind` are small fixed sets. The graph name, query

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -104,17 +104,25 @@ impl FalkorAsyncClientInner {
         readonly: bool,
     ) -> FalkorResult<BorrowedAsyncConnection> {
         match executor {
-            AsyncExecutor::Pooled(pool) => Ok(BorrowedAsyncConnection::new(
-                pool.rx
+            AsyncExecutor::Pooled(pool) => {
+                #[cfg(feature = "metrics")]
+                let wait_start = std::time::Instant::now();
+                let conn = pool
+                    .rx
                     .lock()
                     .await
                     .recv()
                     .await
-                    .ok_or(FalkorDBError::EmptyConnection)?,
-                pool.tx.clone(),
-                pool_owner,
-                readonly,
-            )),
+                    .ok_or(FalkorDBError::EmptyConnection)?;
+                #[cfg(feature = "metrics")]
+                crate::observability::record_pool_wait(readonly, wait_start.elapsed());
+                Ok(BorrowedAsyncConnection::new(
+                    conn,
+                    pool.tx.clone(),
+                    pool_owner,
+                    readonly,
+                ))
+            }
             AsyncExecutor::Multiplexed(executor) => Ok(BorrowedAsyncConnection::new_multiplexed(
                 executor.pick(),
                 pool_owner,

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -69,11 +69,17 @@ impl FalkorSyncClientInner {
         &self,
         pool_owner: Arc<Self>,
     ) -> FalkorResult<BorrowedSyncConnection> {
+        #[cfg(feature = "metrics")]
+        let wait_start = std::time::Instant::now();
+        let conn = self
+            .connection_pool_rx
+            .lock()
+            .recv()
+            .map_err(|_| FalkorDBError::EmptyConnection)?;
+        #[cfg(feature = "metrics")]
+        crate::observability::record_pool_wait(false, wait_start.elapsed());
         Ok(BorrowedSyncConnection::new(
-            self.connection_pool_rx
-                .lock()
-                .recv()
-                .map_err(|_| FalkorDBError::EmptyConnection)?,
+            conn,
             self.connection_pool_tx.clone(),
             pool_owner,
             false,
@@ -96,15 +102,23 @@ impl FalkorSyncClientInner {
         pool_owner: Arc<Self>,
     ) -> FalkorResult<BorrowedSyncConnection> {
         match &self.readonly_pool {
-            Some(pool) => Ok(BorrowedSyncConnection::new(
-                pool.rx
+            Some(pool) => {
+                #[cfg(feature = "metrics")]
+                let wait_start = std::time::Instant::now();
+                let conn = pool
+                    .rx
                     .lock()
                     .recv()
-                    .map_err(|_| FalkorDBError::EmptyConnection)?,
-                pool.tx.clone(),
-                pool_owner,
-                true,
-            )),
+                    .map_err(|_| FalkorDBError::EmptyConnection)?;
+                #[cfg(feature = "metrics")]
+                crate::observability::record_pool_wait(true, wait_start.elapsed());
+                Ok(BorrowedSyncConnection::new(
+                    conn,
+                    pool.tx.clone(),
+                    pool_owner,
+                    true,
+                ))
+            }
             None => self.borrow_connection(pool_owner),
         }
     }

--- a/src/connection/asynchronous.rs
+++ b/src/connection/asynchronous.rs
@@ -136,6 +136,8 @@ impl BorrowedAsyncConnection {
         client: Arc<FalkorAsyncClientInner>,
         readonly: bool,
     ) -> Self {
+        #[cfg(feature = "metrics")]
+        crate::observability::connection_borrow_started(readonly);
         Self {
             conn: Some(conn),
             return_to: ConnReturn::Pool(return_tx),
@@ -151,6 +153,8 @@ impl BorrowedAsyncConnection {
         client: Arc<FalkorAsyncClientInner>,
         readonly: bool,
     ) -> Self {
+        #[cfg(feature = "metrics")]
+        crate::observability::connection_borrow_started(readonly);
         Self {
             conn: Some(conn),
             return_to: ConnReturn::Discard,
@@ -229,6 +233,8 @@ impl Drop for BorrowedAsyncConnection {
     /// bounded channel, which always has a free slot because this borrow consumed one;
     /// multiplexed clones are cheap shared handles and are simply dropped.
     fn drop(&mut self) {
+        #[cfg(feature = "metrics")]
+        crate::observability::connection_borrow_finished(self.readonly);
         if let (Some(conn), ConnReturn::Pool(return_tx)) = (self.conn.take(), &self.return_to) {
             match return_tx.try_send(conn) {
                 Ok(()) => {}

--- a/src/connection/blocking.rs
+++ b/src/connection/blocking.rs
@@ -112,6 +112,8 @@ impl BorrowedSyncConnection {
         client: Arc<FalkorSyncClientInner>,
         readonly: bool,
     ) -> Self {
+        #[cfg(feature = "metrics")]
+        crate::observability::connection_borrow_started(readonly);
         Self {
             conn: Some(conn),
             return_tx,
@@ -190,6 +192,8 @@ impl BorrowedSyncConnection {
 
 impl Drop for BorrowedSyncConnection {
     fn drop(&mut self) {
+        #[cfg(feature = "metrics")]
+        crate::observability::connection_borrow_finished(self.readonly);
         if let Some(conn) = self.conn.take() {
             self.return_tx.send(conn).ok();
         }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -185,6 +185,79 @@ pub(crate) fn record_query_metrics(
     }
 }
 
+/// Record a single retry of a transient failure: a low-cardinality `tracing` debug event and a
+/// `falkordb_retries_total` counter increment. Never includes the query text or error payload.
+#[cfg(any(feature = "tracing", feature = "metrics"))]
+pub(crate) fn record_retry(
+    read_only: bool,
+    error: &FalkorDBError,
+) {
+    let operation = if read_only { "read" } else { "write" };
+    let kind = error_kind(error);
+    #[cfg(feature = "tracing")]
+    tracing::debug!(
+        target: "falkordb",
+        operation,
+        error_kind = kind,
+        "retrying transient connection failure"
+    );
+    #[cfg(feature = "metrics")]
+    metrics::counter!(
+        "falkordb_retries_total",
+        "operation" => operation,
+        "error_kind" => kind,
+    )
+    .increment(1);
+}
+
+/// The bounded `route` metric label for a borrow: whether it came from the replica-routed pool or
+/// the primary. (The borrow's read-only flag means "served from a replica", not "read operation" —
+/// a read-only query falls back to the primary when no replica route exists.)
+#[cfg(feature = "metrics")]
+fn route_label(from_replica: bool) -> &'static str {
+    if from_replica {
+        "replica"
+    } else {
+        "primary"
+    }
+}
+
+/// Increment the in-flight-connections gauge as a connection is borrowed. Paired with
+/// [`connection_borrow_finished`] in the borrow's `Drop`, so the gauge reflects connections
+/// currently checked out (pooled) / concurrently borrowed (multiplexed).
+#[cfg(feature = "metrics")]
+pub(crate) fn connection_borrow_started(from_replica: bool) {
+    metrics::gauge!(
+        "falkordb_connections_in_flight",
+        "route" => route_label(from_replica),
+    )
+    .increment(1.0);
+}
+
+/// Decrement the in-flight-connections gauge as a borrowed connection is returned/dropped.
+#[cfg(feature = "metrics")]
+pub(crate) fn connection_borrow_finished(from_replica: bool) {
+    metrics::gauge!(
+        "falkordb_connections_in_flight",
+        "route" => route_label(from_replica),
+    )
+    .decrement(1.0);
+}
+
+/// Record how long a pooled borrow waited for a connection. Only emitted for the pooled strategy
+/// (a multiplexed borrow is a near-instant clone, so timing it would dilute the histogram).
+#[cfg(feature = "metrics")]
+pub(crate) fn record_pool_wait(
+    from_replica: bool,
+    waited: std::time::Duration,
+) {
+    metrics::histogram!(
+        "falkordb_connection_pool_wait_seconds",
+        "route" => route_label(from_replica),
+    )
+    .record(waited.as_secs_f64());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -513,5 +586,35 @@ mod metrics_tests {
         assert!(names.iter().any(|n| n == "falkordb_queries_total"));
         assert!(names.iter().any(|n| n == "falkordb_query_duration_seconds"));
         assert!(names.iter().any(|n| n == "falkordb_query_errors_total"));
+    }
+
+    #[test]
+    fn retry_and_connection_metrics_use_only_bounded_labels() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            record_retry(true, &crate::FalkorDBError::ConnectionDown);
+            connection_borrow_started(false);
+            record_pool_wait(true, Duration::from_micros(50));
+            connection_borrow_finished(false);
+        });
+
+        let mut names = Vec::new();
+        for (composite, _unit, _desc, _value) in snapshotter.snapshot().into_vec() {
+            let key = composite.key();
+            names.push(key.name().to_string());
+            for label in key.labels() {
+                assert!(
+                    matches!(label.key(), "operation" | "error_kind" | "route"),
+                    "unexpected (potentially unbounded) metric label: {:?}",
+                    label.key()
+                );
+            }
+        }
+        assert!(names.iter().any(|n| n == "falkordb_retries_total"));
+        assert!(names.iter().any(|n| n == "falkordb_connections_in_flight"));
+        assert!(names
+            .iter()
+            .any(|n| n == "falkordb_connection_pool_wait_seconds"));
     }
 }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -388,6 +388,12 @@ pub(crate) fn run_with_retry_blocking<T>(
     attempt
         .retry(policy.backon_builder())
         .when(|err: &FalkorDBError| policy.should_retry(kind, err))
+        .notify(|err: &FalkorDBError, _delay: Duration| {
+            #[cfg(any(feature = "tracing", feature = "metrics"))]
+            crate::observability::record_retry(matches!(kind, OpKind::ReadOnly), err);
+            #[cfg(not(any(feature = "tracing", feature = "metrics")))]
+            let _ = err;
+        })
         .call()
 }
 
@@ -409,6 +415,12 @@ where
     attempt
         .retry(policy.backon_builder())
         .when(|err: &FalkorDBError| policy.should_retry(kind, err))
+        .notify(|err: &FalkorDBError, _delay: Duration| {
+            #[cfg(any(feature = "tracing", feature = "metrics"))]
+            crate::observability::record_retry(matches!(kind, OpKind::ReadOnly), err);
+            #[cfg(not(any(feature = "tracing", feature = "metrics")))]
+            let _ = err;
+        })
         .await
 }
 


### PR DESCRIPTION
## What

The third and final observability PR adds **connection- and retry-level depth** on top of the per-query spans (#252) and metrics (#253), all behind `#[cfg(feature = "metrics")]` (retry event also behind `tracing`).

- **Retry signals** — each retried transient failure emits a low-cardinality `tracing` debug event and increments `falkordb_retries_total{operation, error_kind}`, driven from the central retry runner via backon's `notify` hook (no signature changes; only fires on actual retries).
- **In-flight gauge** — `falkordb_connections_in_flight{operation}` is incremented when a connection is borrowed and decremented in the borrow's `Drop`, so it reflects connections currently checked out (pooled) / concurrently borrowed (multiplexed). RAII-paired, so a failed borrow can't leak it (the connection handle already exists at `new`).
- **Pool-wait histogram** — `falkordb_connection_pool_wait_seconds{operation}` times how long a *pooled* borrow waited for a connection. Emitted **only for the pooled strategy** (a multiplexed borrow is a near-instant clone, which would dilute the histogram).

## Safety

- All new labels are **bounded** (`operation`, `error_kind`); the graph name, query text and fingerprint are never used as labels.
- Zero work when the features are off (everything `#[cfg]`-gated).
- A hermetic test installs a thread-local debugging recorder and asserts the new series carry only the bounded label set.

## Validation

- Builds verified across `metrics`, `metrics,tokio`, and all-features combos; full suite green with `--features tokio,serde,tracing,metrics` (543 tests); `just done` (fmt, strict clippy, build, doc, deny, llms), spellcheck. No public API change — `llms.txt` unchanged.

## Deferred

Result-side span fields (returned rows, server execution time) remain a possible future enhancement: the async `RowStream` is parsed eagerly into the result, so counting rows without consuming the stream needs care, and it is a span-only nicety. Documented in the commit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
