### PR TITLE
feat: record returned rows and server execution time on the execute span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Observability: when the `tracing` feature is enabled, the query- and procedure-execution spans are
   enriched with structured, low-cardinality fields (named after the OpenTelemetry database semantic
   conventions): `db.system.name`, `db.namespace` (graph), `db.operation.name`, `db.falkordb.read_only`,
-  `db.falkordb.strategy`, a privacy-safe `db.query.fingerprint`, and `error.type` on failure. The raw
-  query text and parameter values are **never** recorded by default — the fingerprint is a hash of the
-  query with all literals redacted. Opt in to recording the raw Cypher (`db.query.text`) with the new
+  `db.falkordb.strategy`, a privacy-safe `db.query.fingerprint`, and `error.type` on failure. The outer
+  `execute` span additionally records `db.response.returned_rows` and `db.falkordb.server_time_ms` (the
+  server's internal execution time, when reported). The raw query text and parameter values are
+  **never** recorded by default — the fingerprint is a hash of the query with all literals redacted.
+  Opt in to recording the raw Cypher (`db.query.text`) with the new
   `FalkorClientBuilder::with_query_logging(true)`.
 - Opt-in, client-wide `RetryPolicy` that automatically re-issues *eligible* operations on *transient*
   connection failures with bounded backoff. **Disabled by default**, so existing behavior is

--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ map cleanly when exported via `tracing-opentelemetry`):
 | `db.falkordb.strategy` | `multiplexed` | the active connection strategy |
 | `db.query.fingerprint` | `a1b2c3d4e5f60718` | a privacy-safe hash of the query *shape* |
 | `error.type` | `connection_down` | a bounded error kind, recorded on failure |
+| `db.response.returned_rows` | `42` | rows the server returned (on the outer `execute` span) |
+| `db.falkordb.server_time_ms` | `1.18` | the server's internal execution time, when reported |
 
 **Privacy by default.** The raw query text and parameter values are **never** recorded by default —
 only the `db.query.fingerprint`, which is a hash of the query with all literals (strings, numbers,

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -916,8 +916,8 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
 }
 
 impl ProcedureQueryBuilder<'_, QueryResult<Vec<FalkorIndex>>, SyncGraph> {
-    /// Executes the procedure call and return a [`QueryResult`] type containing a result set of [`FalkorIndex`]s
-    /// This functions consumes self
+    /// Executes the procedure call and returns a [`QueryResult`] type containing a result set of [`FalkorIndex`]s
+    /// This function consumes self.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -945,8 +945,8 @@ impl ProcedureQueryBuilder<'_, QueryResult<Vec<FalkorIndex>>, SyncGraph> {
 
 #[cfg(feature = "tokio")]
 impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<FalkorIndex>>, AsyncGraph> {
-    /// Executes the procedure call and return a [`QueryResult`] type containing a result set of [`FalkorIndex`]s
-    /// This functions consumes self
+    /// Executes the procedure call and returns a [`QueryResult`] type containing a result set of [`FalkorIndex`]s
+    /// This function consumes self.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -976,8 +976,8 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<FalkorIndex>>, AsyncGraph> {
 }
 
 impl ProcedureQueryBuilder<'_, QueryResult<Vec<Constraint>>, SyncGraph> {
-    /// Executes the procedure call and return a [`QueryResult`] type containing a result set of [`Constraint`]s
-    /// This functions consumes self
+    /// Executes the procedure call and returns a [`QueryResult`] type containing a result set of [`Constraint`]s
+    /// This function consumes self.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -1005,8 +1005,8 @@ impl ProcedureQueryBuilder<'_, QueryResult<Vec<Constraint>>, SyncGraph> {
 
 #[cfg(feature = "tokio")]
 impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<Constraint>>, AsyncGraph> {
-    /// Executes the procedure call and return a [`QueryResult`] type containing a result set of [`Constraint`]s
-    /// This functions consumes self
+    /// Executes the procedure call and returns a [`QueryResult`] type containing a result set of [`Constraint`]s
+    /// This function consumes self.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -426,11 +426,26 @@ impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, SyncGra
     /// Executes the query, retuning a [`QueryResult`], with a [`LazyResultSet`] as its `data` member
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Lazy Result Set Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Lazy Result Set Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub fn execute(mut self) -> FalkorResult<QueryResult<LazyResultSet<'a>>> {
-        self.common_execute_steps()
-            .and_then(|res| self.generate_query_result_set(res))
+        let result = self
+            .common_execute_steps()
+            .and_then(|res| self.generate_query_result_set(res))?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -440,12 +455,27 @@ impl<'a, T: Display> QueryBuilder<'a, QueryResult<RowStream>, T, AsyncGraph> {
     /// `Send + 'static` [`futures_core::Stream`] of `FalkorResult<Row>`.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Row Stream Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Row Stream Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<RowStream>> {
-        self.common_execute_steps()
+        let result = self
+            .common_execute_steps()
             .await
-            .and_then(|res| self.generate_async_result_set(res))
+            .and_then(|res| self.generate_async_result_set(res))?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -493,12 +523,27 @@ where
     /// [`TypedLazyResultSet`] that deserializes each row into `U`.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Typed Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Typed Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub fn execute(mut self) -> FalkorResult<QueryResult<TypedLazyResultSet<'a, U>>> {
-        self.common_execute_steps()
+        let result = self
+            .common_execute_steps()
             .and_then(|res| self.generate_query_result_set(res))
-            .map(|result| result.into_typed::<U>())
+            .map(|result| result.into_typed::<U>())?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -531,13 +576,28 @@ where
     /// deserializes each row into `U`.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Typed Row Stream Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Typed Row Stream Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<TypedRowStream<U>>> {
-        self.common_execute_steps()
+        let result = self
+            .common_execute_steps()
             .await
             .and_then(|res| self.generate_async_result_set(res))
-            .map(|result| result.into_typed::<U>())
+            .map(|result| result.into_typed::<U>())?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -860,11 +920,26 @@ impl ProcedureQueryBuilder<'_, QueryResult<Vec<FalkorIndex>>, SyncGraph> {
     /// This functions consumes self
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute FalkorIndex Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute FalkorIndex Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub fn execute(mut self) -> FalkorResult<QueryResult<Vec<FalkorIndex>>> {
-        self.common_execute_steps()
-            .and_then(|res| self.parse_query_result_of_type(res))
+        let result = self
+            .common_execute_steps()
+            .and_then(|res| self.parse_query_result_of_type(res))?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -874,13 +949,29 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<FalkorIndex>>, AsyncGraph> {
     /// This functions consumes self
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute FalkorIndex Query", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute FalkorIndex Query",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<Vec<FalkorIndex>>> {
         let res = self.common_execute_steps().await?;
-        let schema = self.graph.schema_handle();
-        let mut guard = schema.write();
-        parse_procedure_result(res, &mut guard)
+        let result = {
+            let schema = self.graph.schema_handle();
+            let mut guard = schema.write();
+            parse_procedure_result(res, &mut guard)?
+        };
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -889,11 +980,26 @@ impl ProcedureQueryBuilder<'_, QueryResult<Vec<Constraint>>, SyncGraph> {
     /// This functions consumes self
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Constraint Procedure Call", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Constraint Procedure Call",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub fn execute(mut self) -> FalkorResult<QueryResult<Vec<Constraint>>> {
-        self.common_execute_steps()
-            .and_then(|res| self.parse_query_result_of_type(res))
+        let result = self
+            .common_execute_steps()
+            .and_then(|res| self.parse_query_result_of_type(res))?;
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 
@@ -903,13 +1009,29 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<Constraint>>, AsyncGraph> {
     /// This functions consumes self
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(name = "Execute Constraint Procedure Call", skip_all, level = "info")
+        tracing::instrument(
+            name = "Execute Constraint Procedure Call",
+            skip_all,
+            fields(
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            ),
+            level = "info"
+        )
     )]
     pub async fn execute(mut self) -> FalkorResult<QueryResult<Vec<Constraint>>> {
         let res = self.common_execute_steps().await?;
-        let schema = self.graph.schema_handle();
-        let mut guard = schema.write();
-        parse_procedure_result(res, &mut guard)
+        let result = {
+            let schema = self.graph.schema_handle();
+            let mut guard = schema.write();
+            parse_procedure_result(res, &mut guard)?
+        };
+        #[cfg(feature = "tracing")]
+        crate::observability::record_result(
+            result.data.len(),
+            result.get_internal_execution_time(),
+        );
+        Ok(result)
     }
 }
 

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -423,7 +423,7 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
 }
 
 impl<'a, T: Display> QueryBuilder<'a, QueryResult<LazyResultSet<'a>>, T, SyncGraph> {
-    /// Executes the query, retuning a [`QueryResult`], with a [`LazyResultSet`] as its `data` member
+    /// Executes the query, returning a [`QueryResult`], with a [`LazyResultSet`] as its `data` member
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -128,6 +128,22 @@ pub(crate) fn record_error(error: &FalkorDBError) {
     tracing::Span::current().record("error.type", error_kind(error));
 }
 
+/// Record the result-side fields on the current (outer `execute`) span, once the response has been
+/// parsed into a result: the number of rows the server returned and its internal execution time (in
+/// milliseconds, when the server reports it). These are only known after the seam span has closed,
+/// so they live on the outer span rather than on `Common Query Execution Steps`.
+#[cfg(feature = "tracing")]
+pub(crate) fn record_result(
+    returned_rows: usize,
+    server_time_ms: Option<f64>,
+) {
+    let span = tracing::Span::current();
+    span.record("db.response.returned_rows", returned_rows as u64);
+    if let Some(ms) = server_time_ms {
+        span.record("db.falkordb.server_time_ms", ms);
+    }
+}
+
 /// A bounded label for a wire command, for use as a metric label. An allowlist of known commands
 /// (unknown ⇒ `"other"`), so a metric label can never carry a user-controlled or high-cardinality
 /// string. Procedure calls are labeled by their wire command (`GRAPH.QUERY`/`GRAPH.RO_QUERY`), never
@@ -526,6 +542,45 @@ mod span_capture_tests {
             fields.get("db.query.text").map(String::as_str),
             Some("MATCH (n) RETURN n")
         );
+    }
+
+    #[test]
+    fn records_returned_rows_and_server_time() {
+        let fields = capture(|| {
+            let span = tracing::trace_span!(
+                "test",
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            );
+            let _enter = span.enter();
+            super::record_result(42, Some(1.5));
+        });
+        assert_eq!(
+            fields.get("db.response.returned_rows").map(String::as_str),
+            Some("42")
+        );
+        assert_eq!(
+            fields.get("db.falkordb.server_time_ms").map(String::as_str),
+            Some("1.5")
+        );
+    }
+
+    #[test]
+    fn omits_server_time_when_the_server_does_not_report_it() {
+        let fields = capture(|| {
+            let span = tracing::trace_span!(
+                "test",
+                db.response.returned_rows = tracing::field::Empty,
+                db.falkordb.server_time_ms = tracing::field::Empty,
+            );
+            let _enter = span.enter();
+            super::record_result(0, None);
+        });
+        assert_eq!(
+            fields.get("db.response.returned_rows").map(String::as_str),
+            Some("0")
+        );
+        assert!(!fields.contains_key("db.falkordb.server_time_ms"));
     }
 }
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -138,7 +138,12 @@ pub(crate) fn record_result(
     server_time_ms: Option<f64>,
 ) {
     let span = tracing::Span::current();
-    span.record("db.response.returned_rows", returned_rows as u64);
+    // `usize` fits `u64` on every supported target; saturate defensively rather than truncate on a
+    // hypothetical wider-than-64-bit platform.
+    span.record(
+        "db.response.returned_rows",
+        u64::try_from(returned_rows).unwrap_or(u64::MAX),
+    );
     if let Some(ms) = server_time_ms {
         span.record("db.falkordb.server_time_ms", ms);
     }


### PR DESCRIPTION
## What

Implements the **result-side observability fields** that were deferred from the earlier observability PRs (#252–#254). Once a query/procedure response is parsed into a `QueryResult`, the outer `execute` span records:

- **`db.response.returned_rows`** — the number of rows the server returned (`result.data.len()`).
- **`db.falkordb.server_time_ms`** — the server's internal execution time from the response stats (`QueryResult::get_internal_execution_time`), when reported.

```
Execute Lazy Result Set Query{db.response.returned_rows=1 db.falkordb.server_time_ms=0.18}
└─ Common Query Execution Steps{db.namespace=… db.operation.name=GRAPH.RO_QUERY db.query.fingerprint=…}
```

## Why these were deferred (and why it's clean now)

They are *result-side* — they only exist after the raw `redis::Value` is parsed into a `QueryResult`, which happens in the outer `execute()` method, **after** the inner `Common Query Execution Steps` seam span (where the request fields live) has already closed. So they're recorded on the outer span, across the ~8 `QueryResult`-returning `execute()` methods (lazy / stream / typed×2 / procedure×4).

The row count is cheaply available on **every** result type — `LazyResultSet`, `RowStream`, the typed wrappers, and the procedure `Vec`s are all eagerly buffered with a `len()`, so no stream is consumed. `len()` tracks *remaining* rows, so it's recorded at construction (before the caller iterates).

## Notes

- The two `ExecutionPlan` paths (`explain` / `profile`) return no `QueryResult` and are intentionally left unchanged (no rows/stats).
- Everything is behind `#[cfg(feature = "tracing")]` — no work when the feature is off.
- Adds subscriber-backed tests asserting the fields are recorded, and that server time is omitted when the server doesn't report it. Verified against a live server (`returned_rows=0` for a write, `server_time_ms` populated).

## Validation

Full suite green with `--features tokio,serde,tracing,metrics` (545 tests); `just done`, spellcheck. No public API change — `llms.txt` unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tracing with new database response fields: returned row counts and server execution time metrics.

* **Documentation**
  * Updated tracing documentation to include newly available metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->