### PR TITLE
docs: require explicit human approval before merging to main

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,10 +43,10 @@ Tests need a running server; prefer the `*-local` wrappers, which manage Docker 
 4. Open a PR on a `feat:` / `fix:` / `ci:` / `docs:` branch.
 5. **Resolve every AI review thread** (Copilot **and** CodeRabbit) — reply *and* mark resolved —
    before merge. Copilot auto-reviews on push here.
-6. **Never merge to `main` yourself — wait for explicit human approval.** Do **not** run
-   `gh pr merge` / `--admin --squash` to self-merge, even when every check is green and all AI
-   threads are resolved. Open the PR, get it green, and **stop** until the maintainer reviews and
-   approves the merge. After a human merges, `release-plz` handles the release.
+6. **Never merge to `main` yourself — wait for explicit human approval.** Do **not** run any
+   `gh pr merge …` variant (e.g. `gh pr merge --admin --squash`) to self-merge, even when every
+   check is green and all AI threads are resolved. Open the PR, get it green, and **stop** until the
+   maintainer reviews and approves the merge. After a human merges, `release-plz` handles the release.
 
 ## Keep documentation in sync
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,10 @@ Tests need a running server; prefer the `*-local` wrappers, which manage Docker 
 4. Open a PR on a `feat:` / `fix:` / `ci:` / `docs:` branch.
 5. **Resolve every AI review thread** (Copilot **and** CodeRabbit) — reply *and* mark resolved —
    before merge. Copilot auto-reviews on push here.
-6. A human merges; `release-plz` handles the release.
+6. **Never merge to `main` yourself — wait for explicit human approval.** Do **not** run
+   `gh pr merge` / `--admin --squash` to self-merge, even when every check is green and all AI
+   threads are resolved. Open the PR, get it green, and **stop** until the maintainer reviews and
+   approves the merge. After a human merges, `release-plz` handles the release.
 
 ## Keep documentation in sync
 


### PR DESCRIPTION
Makes the "a human merges" rule in the agent instructions (`.github/copilot-instructions.md`) explicit and strong: AI agents must **never self-merge** (`gh pr merge` / `--admin --squash`), even when every check is green and all AI review threads are resolved. Open the PR, get it green, and **stop** until the maintainer reviews and approves the merge.

Requested by the maintainer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
