### PR TITLE
ci: stop generating a duplicate Added section on release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,22 +79,26 @@ don't pile up.
 ## Spellcheck, commit subjects & PR titles
 
 - **PR titles must be spellcheck-clean** — the `PRTitle` CI task checks every PR title against the
-  same wordlist and fails it at PR time. This matters because `release-plz` copies merged commit
-  subjects (squashed PR titles) **verbatim** into `CHANGELOG.md` (itself spellchecked), so an
-  unknown word would otherwise only surface — too late — on the release PR. Keep titles clean at
-  the source.
+  same wordlist and fails it at PR time. Titles become the squashed-merge commit subject (git
+  history) and their Conventional-Commit prefix drives the release, so keep them clean at the
+  source. **`CHANGELOG.md` entries are hand-written and spellchecked too** — an unknown word there
+  fails the `spellcheck` gate, so backtick code/type names or add them to the wordlist.
 - When you add or rename a **public type / term**, add its name to **`.github/wordlist.txt`**.
 - In Markdown/docs, **backtick** code and type names (`` `ConnectionDown` ``) — backticked spans
   are ignored by the spellchecker.
 
 ## CHANGELOG & releases
 
-- Keep a `## [Unreleased]` section; `release-plz` promotes it on release. **Don't hardcode the
-  next version** — let `release-plz` compute it.
-- Entry style (per the existing changelog): the `release-plz` short line + PR link, **followed by
-  detailed manual entries** under the same `### Added` / `### Fixed` heading.
-- Use **Conventional Commits** (`feat`, `fix`, `ci`, `docs`, `perf`, `chore`, …). Mark breaking
-  changes with `feat!` / a `[**breaking**]` note.
+- Keep a `## [Unreleased]` section and **hand-write every entry there yourself**, under the right
+  `### Added` / `### Changed` / `### Fixed` / `### Other` heading (Keep a Changelog). On release,
+  `release-plz` only stamps the version header below `## [Unreleased]` — it does **not** generate
+  its own bullets from commits (see the `[changelog]` `body` in `release-plz.toml`). This is why a
+  single hand-written `### Added` is the only source of truth; there is no second auto-generated one.
+- **Every entry must carry its PR link** — `… ([#123](https://github.com/FalkorDB/falkordb-rs/pull/123))` —
+  because `release-plz` no longer appends it for you. Add it once the PR number is known.
+- **Don't hardcode the next version** — let `release-plz` compute it from the commits.
+- Use **Conventional Commits** (`feat`, `fix`, `ci`, `docs`, `perf`, `chore`, …) — they drive the
+  version bump. Mark breaking changes with `feat!` / a `[**breaking**]` note.
 - Include a `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer on
   agent-authored commits.
 

--- a/.github/spellcheck-settings.yml
+++ b/.github/spellcheck-settings.yml
@@ -28,8 +28,8 @@ matrix:
   - 'docs/*.md'
   - 'llms.txt'
 # PRTitle: spellcheck a single pull-request title (written to .pr-title.md by the
-# `spellcheck-pr-title` just recipe / the Spellcheck workflow). Catches words that
-# would otherwise reach the auto-generated release changelog and fail the gate above.
+# `spellcheck-pr-title` just recipe / the Spellcheck workflow). PR titles become the
+# squashed-merge commit subject (git history), so this keeps them typo-free at the source.
 - name: PRTitle
   expect_match: false
   aspell:

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -19,10 +19,9 @@ jobs:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown
 
-  # Spellcheck the pull-request title with the same wordlist/dictionary. Because
-  # release-plz copies merged commit subjects (= squashed PR titles) verbatim into
-  # CHANGELOG.md, an unknown word in a title would only surface — too late — on the
-  # release PR. Catching it here keeps every release PR's spellcheck green.
+  # Spellcheck the pull-request title with the same wordlist/dictionary. The title becomes
+  # the squashed-merge commit subject (git history) and its Conventional-Commit prefix drives
+  # the release, so catch unknown words here at the source.
   pr-title:
     name: PR title spelling
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- stop `release-plz` from generating a second, duplicate `### Added` section: it now only stamps the
+  version header, and `CHANGELOG.md` entries are hand-written under `## [Unreleased]` ([#258](https://github.com/FalkorDB/falkordb-rs/pull/258))
+
 ## [0.8.7](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.6...v0.8.7) - 2026-06-19
 
 ### Added

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,15 @@
 [workspace]
 semver_check = false # disable API breaking changes checks, I suggest this becomes 'true' after we release 1.0
+
+[changelog]
+# Changelog entries are hand-written under "## [Unreleased]" in CHANGELOG.md (see the
+# "CHANGELOG & releases" section of .github/copilot-instructions.md). On release, release-plz
+# only stamps the version header below "## [Unreleased]" — this `body` has no commit loop, so it
+# must NOT emit its own commit-derived bullets. That avoids the duplicate "### Added" section we
+# used to get when release-plz's generated bullets landed next to the hand-written ones.
+# `trim = false` keeps the surrounding blank lines so the stamped header stays Keep-a-Changelog
+# formatted. The header expression matches release-plz's default (compare-link + date).
+trim = false
+body = """
+## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+"""


### PR DESCRIPTION
## Problem

On every release, `release-plz` generated its own commit-derived bullets (`### Added` from PR
titles, `### Other` from `docs:`/`ci:` commits) and inserted them **above** the detailed
`[Unreleased]` entries we hand-write. The result was two `### Added` headings in each release
section (e.g. v0.8.7), which AI reviewers flagged on #251 and #257 and which we kept fixing by hand.

Root cause: **two sources of truth** — release-plz's auto bullets *and* the hand-written
`[Unreleased]` bullets.

## Fix

Override the release-plz `[changelog].body` with a **header-only** template (no commit loop), so
release-plz only stamps the version header below `## [Unreleased]`. The hand-written `[Unreleased]`
entries become the single source of truth — no second auto-generated section.

- `trim = false` preserves Keep-a-Changelog blank-line spacing around the stamped header.
- The header expression is byte-for-byte release-plz's default (`## [version](compare-link) - date`).

## Verified locally (release-plz 0.3.159)

Reproduced the duplication on a clone, then confirmed the override produces a single, correctly
spaced `### Added`:

```
## [Unreleased]

## [0.8.8] - 2026-06-19

### Added

- A shiny new widget API … ([#999](…))
```

Also confirmed the empty-`[Unreleased]` case stays valid, and that GitHub Release notes are taken
from the CHANGELOG.md section (so they keep the hand-written detail).

## Convention update

`.github/copilot-instructions.md` + `.github/spellcheck-settings.yml`: hand-write every entry under
`[Unreleased]` with its PR link (release-plz no longer appends one), and corrected the now-obsolete
notes that said release-plz copies PR titles into the changelog.

> Note: leaving merge to a maintainer per repo policy.
