### PR TITLE
ci: only release on feat or fix and warn against header tokens in entries

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,7 +105,9 @@ don't pile up.
   version bump. Mark breaking changes with `feat!` / a `[**breaking**]` note.
 - **Only `feat:` / `fix:` commits cut a release** (`release_commits` in `release-plz.toml`);
   `ci` / `docs` / `chore` / `refactor` changes ride along with the next feature/fix release instead
-  of cutting an empty one. To force a release without a `feat`/`fix`, push to a `release-plz-…` branch.
+  of cutting an empty one. (release-plz runs from the `main.yml` workflow on pushes to `main`.) To
+  release such changes sooner, land them with a `feat`/`fix` commit or temporarily relax
+  `release_commits`.
 - Include a `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer on
   agent-authored commits.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,9 +96,16 @@ don't pile up.
   single hand-written `### Added` is the only source of truth; there is no second auto-generated one.
 - **Every entry must carry its PR link** — `… ([#123](https://github.com/FalkorDB/falkordb-rs/pull/123))` —
   because `release-plz` no longer appends it for you. Add it once the PR number is known.
+- **Never put literal Markdown-header markup inside a bullet** — a `## [` or `###` in the *text* of an
+  entry. `release-plz`'s changelog parser matches those anywhere (not just at line start) and treats
+  them as a version/section boundary, so it stamps the new release header in the wrong place and
+  leaves the release section empty. Write "the Added section", not a backticked `###`-prefixed name.
 - **Don't hardcode the next version** — let `release-plz` compute it from the commits.
 - Use **Conventional Commits** (`feat`, `fix`, `ci`, `docs`, `perf`, `chore`, …) — they drive the
   version bump. Mark breaking changes with `feat!` / a `[**breaking**]` note.
+- **Only `feat:` / `fix:` commits cut a release** (`release_commits` in `release-plz.toml`);
+  `ci` / `docs` / `chore` / `refactor` changes ride along with the next feature/fix release instead
+  of cutting an empty one. To force a release without a `feat`/`fix`, push to a `release-plz-…` branch.
 - Include a `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer on
   agent-authored commits.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,11 +2,13 @@
 semver_check = false # disable API breaking changes checks, I suggest this becomes 'true' after we release 1.0
 
 # Only open a release PR when there's an actual feature or fix. ci/docs/chore/refactor-only
-# changes then ride along with the next `feat`/`fix` release instead of cutting a thin or empty
-# one (the regex matches `feat:`/`feat(scope)`/`feat!:` and the same for `fix`). Filtered commits
-# are still listed in the changelog of the next release. To force a release without a feat/fix,
-# push to a `release-plz-…` branch.
-release_commits = "^(feat|fix)[(!:]"
+# changes don't cut a release on their own — they ride along with the next `feat`/`fix` release.
+# Because the [changelog] body below is header-only, such commits are NOT auto-listed anywhere;
+# they appear in CHANGELOG.md only through the hand-written `## [Unreleased]` entry you add. The
+# regex matches a Conventional-Commit `feat`/`fix` subject with an optional `(scope)` and optional
+# `!`, requiring the `:` (so a malformed subject like `feat(x) …` without a colon won't trigger a
+# release). To force a release without a feat/fix, push to a `release-plz-…` branch.
+release_commits = '^(feat|fix)(\(.+?\))?!?:'
 
 [changelog]
 # Changelog entries are hand-written under "## [Unreleased]" in CHANGELOG.md (see the

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,13 @@
 [workspace]
 semver_check = false # disable API breaking changes checks, I suggest this becomes 'true' after we release 1.0
 
+# Only open a release PR when there's an actual feature or fix. ci/docs/chore/refactor-only
+# changes then ride along with the next `feat`/`fix` release instead of cutting a thin or empty
+# one (the regex matches `feat:`/`feat(scope)`/`feat!:` and the same for `fix`). Filtered commits
+# are still listed in the changelog of the next release. To force a release without a feat/fix,
+# push to a `release-plz-…` branch.
+release_commits = "^(feat|fix)[(!:]"
+
 [changelog]
 # Changelog entries are hand-written under "## [Unreleased]" in CHANGELOG.md (see the
 # "CHANGELOG & releases" section of .github/copilot-instructions.md). On release, release-plz

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,7 +7,8 @@ semver_check = false # disable API breaking changes checks, I suggest this becom
 # they appear in CHANGELOG.md only through the hand-written `## [Unreleased]` entry you add. The
 # regex matches a Conventional-Commit `feat`/`fix` subject with an optional `(scope)` and optional
 # `!`, requiring the `:` (so a malformed subject like `feat(x) …` without a colon won't trigger a
-# release). To force a release without a feat/fix, push to a `release-plz-…` branch.
+# release). To release such changes sooner, land them with a feat/fix commit or temporarily relax
+# this filter.
 release_commits = '^(feat|fix)(\(.+?\))?!?:'
 
 [changelog]


### PR DESCRIPTION
## Why

Follow-up hardening after the #258/#259 episode, where a tooling-only change cut an
empty `0.8.8` release section. Two root issues, two guards:

### 1. `release_commits = "^(feat|fix)[(!:]"`

release-plz now only opens a release PR when there's an actual `feat`/`fix` commit.
`ci` / `docs` / `chore` / `refactor`-only changes ride along with the next real
release instead of cutting a thin or empty one. This would have prevented #259
entirely (#258 was ci-only). The regex matches `feat:` / `feat(scope)` / `feat!:`
and the same for `fix`. To force a release without a feat/fix, push to a
`release-plz-…` branch.

**Validated locally** with release-plz 0.3.159:
- ci-only commits → `no commit matches the release_commits regex` (no release). ✅
- a `feat:` commit → `next version is 0.8.8` (release cut). ✅

### 2. Header-token caveat in the changelog convention

Documented the Model-B footgun that broke #259: a literal `## [` or `###` in the
*text* of a changelog bullet confuses release-plz's changelog parser (it matches
those tokens anywhere, not just at line start) into stamping the new version header
in the wrong place, leaving the release section empty. Entries must avoid
Markdown-header markup in their text.

## Notes

- No `CHANGELOG.md` entry on purpose: this is ci-only (won't cut a release under the
  new filter), and #259 currently owns the `[Unreleased]` → `0.8.8` move — keeping
  this PR out of `CHANGELOG.md` avoids a merge conflict with #259 regardless of merge
  order.
- Merge #259 (the `0.8.8` release fix) first; this PR can merge any time after.

> Leaving merge to a maintainer per repo policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal release and changelog documentation to clarify commit filtering rules and markdown formatting guidelines for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->