### PR TITLE
ci: compile README doctests and examples in CI

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,10 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+reviews:
+  pre_merge_checks:
+    # Disable the docstring-coverage check. It reports 0% (against an 80% threshold) on
+    # example- or CI-only PRs because example `main()` functions are documented with
+    # module-level `//!` docs — the convention every example in this repo follows — which
+    # the check does not count. Docstrings here are enforced by `cargo doc` + review, not
+    # this check, so leaving it on only produces false positives.
+    docstrings:
+      mode: "off"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,8 +70,12 @@ jobs:
 
   check-doctest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
         with:
           tool: just
@@ -86,8 +90,12 @@ jobs:
 
   check-examples:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
         with:
           tool: just

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ env:
   CARGO_HTTP_MULTIPLEXING: "false"
 
 # Every job runs a single `just` recipe so the exact command can be reproduced
-# locally (see the Justfile / README "Development" section).
+# locally (see the Justfile / CONTRIBUTING.md).
 jobs:
   check-clippy:
     runs-on: ubuntu-latest
@@ -67,6 +67,38 @@ jobs:
           cache-bin: "false"
       - name: Doc
         run: just doc
+
+  check-doctest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Cache only dependency sources (registry/git), not target/ or ~/.cargo/bin:
+          # prevents the crates.io refetch that flaked, with no stale-artifact risk.
+          cache-targets: "false"
+          cache-bin: "false"
+      - name: Doc tests (README + doc comments)
+        run: just doctest
+
+  check-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Cache only dependency sources (registry/git), not target/ or ~/.cargo/bin:
+          # prevents the crates.io refetch that flaked, with no stale-artifact risk.
+          cache-targets: "false"
+          cache-bin: "false"
+      - name: Build examples
+        run: just build-examples
 
   check-fmt:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,261 @@
+# Contributing to falkordb-rs
+
+Thanks for contributing! This guide covers the local development workflow, the
+[`just`](https://github.com/casey/just) recipes that mirror CI, and how to run the test
+suites and benchmarks.
+
+Before opening a PR, run `just done` (every required CI gate, no server needed) — plus
+`just verify` if you have a server — and keep the documentation in sync with your changes.
+See also the repository engineering conventions in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+## Development
+
+This repository ships a [`just`](https://github.com/casey/just) file that automates the
+whole development cycle — formatting, linting, building, docs, tests, coverage,
+benchmarks, the dependency audit and a Dockerized FalkorDB server. It is the recommended
+entry point for day-to-day work and mirrors the commands the CI gates run.
+
+Install the runner once with `cargo install just` (or `brew install just`), then list
+every available recipe:
+
+```bash
+just            # or: just --list
+```
+
+### Common recipes
+
+```bash
+# Fast inner loop (no server needed): format, lint and build.
+just check
+
+# Run every required CI gate locally (no server needed):
+# fmt-check, clippy, build, doc, doctest, build-examples, deny, check-llms.
+just ci
+
+# Post-task gate: every CI gate PLUS strict clippy over all targets/features
+# (examples, tests, benches). Run this before declaring work done.
+just done
+
+# Format / lint / docs individually.
+just fmt
+just clippy
+just doc
+
+# Full validation including the server-backed test suite (manages Docker for you):
+# spins up FalkorDB, populates the fixture, runs the suite, tears it down.
+just verify
+```
+
+### Server-backed recipes
+
+Tests, coverage and benchmarks need a reachable FalkorDB instance. The `db-*` recipes
+manage one via Docker, and the `*-local` wrappers do it for you automatically:
+
+```bash
+# Manage a FalkorDB container yourself.
+just db-up          # start a server (and wait until it is ready)
+just db-populate    # load the IMDB fixture graph the lib tests use
+just db-down        # stop and remove the container
+
+# Or let a single recipe manage the container lifecycle end-to-end.
+just test-local       # start DB, populate, run the full suite, tear down
+just coverage-local   # same, but produce Codecov JSON
+just bench-local      # start DB, run all benchmarks, tear down
+```
+
+Targeted recipes are available too, e.g. `just test-parity`, `just test-embedded`,
+`just test-one <filter>`, `just proptest`, `just bench-one '<criterion-id>'`, and
+`just coverage-html`.
+
+The host, port, Docker image and feature set can be overridden on the command line, for
+example `just port=6380 test` or `just image=falkordb/falkordb:latest db-up`.
+
+### Regenerating `llms.txt`
+
+The repository ships an [`llms.txt`](llms.txt) — a curated, machine-readable summary of the public
+API, idioms and pitfalls for AI coding assistants (the [llmstxt.org](https://llmstxt.org)
+convention). Its narrative lives in [`docs/llms.template.md`](docs/llms.template.md); the
+`## Public API` block is generated from `src/lib.rs`. **Whenever you change the public API,
+regenerate it and commit the result:**
+
+```bash
+just llms        # rewrite llms.txt from the template + the current public API
+just check-llms  # drift gate: fails if the committed llms.txt is stale
+```
+
+A `check-llms` CI job runs `just check-llms` on every pull request (and before a release), so a
+stale `llms.txt` fails the build.
+
+### Reproducing CI locally
+
+The GitHub Actions workflows invoke these same recipes, so a failing CI job can be
+reproduced with a single command:
+
+| CI job | Recipe |
+| --- | --- |
+| `check-fmt` | `just fmt-check` |
+| `check-clippy` | `just clippy` |
+| `check-build` | `just build` |
+| `check-doc` | `just doc` |
+| `check-doctest` | `just doctest` |
+| `check-examples` | `just build-examples` |
+| `check-deny` | `just deny` |
+| `check-proptest` | `just proptest` |
+| `integration-tests` | `just integration` and `just integration --all-features` |
+| `integration-tests-tokio` | `just integration --features tokio` |
+| `coverage` | `just coverage` |
+| `check-llms` | `just check-llms` |
+
+Run `just ci` to execute every required no-server gate at once, or `just verify` to also
+run the server-backed suite. The integration and coverage recipes need a reachable
+FalkorDB instance (use `just db-up` first, or the `*-local` wrappers).
+
+## Testing
+
+### Running Tests
+
+This project includes both unit tests and integration tests.
+
+#### Unit Tests
+
+Unit tests don't require a running FalkorDB instance:
+
+```bash
+# Run all unit tests
+cargo test --lib
+
+# Run unit tests with embedded feature
+cargo test --lib --features embedded
+```
+
+#### Property-Based Tests
+
+The crate ships [`proptest`](https://docs.rs/proptest) suites that need no running server:
+`src/value/param_proptest.rs` checks query-parameter encoding (encoding arbitrary values never
+panics, string escaping is lossless, NUL is rejected), and `src/value/de_proptest.rs` checks the
+optional `serde` mapping (agreement with `serde_json`, no panics, malformed-row rejection). Run
+just these:
+
+```bash
+# 256 cases per property (the proptest default)
+just proptest
+
+# crank the generated case count up (or set PROPTEST_CASES yourself)
+just proptest 4096
+
+# equivalent raw cargo command
+cargo nextest run --lib --features serde proptest
+```
+
+They also run in CI: as the dedicated `check-proptest` job, and within the `coverage` job.
+
+#### Integration Tests
+
+Integration tests require a running FalkorDB instance. The easiest way to run them is using Docker:
+
+```bash
+# Using the provided script (requires Docker)
+./run_integration_tests.sh
+
+# Or manually start FalkorDB and run tests
+docker run -d --name falkordb-test -p 6379:6379 falkordb/falkordb:latest
+cargo test --test integration_tests
+
+# With async support
+cargo test --test integration_tests --features tokio
+
+# Clean up
+docker stop falkordb-test && docker rm falkordb-test
+```
+
+#### CI Integration Tests
+
+Integration tests are automatically run in GitHub Actions using Docker services. See `.github/workflows/integration-tests.yml` for the CI configuration.
+
+### Benchmarks
+
+The crate ships a [criterion](https://docs.rs/criterion) benchmark,
+`benches/async_strategies.rs`, that compares the two async connection strategies
+(`Pooled` vs `Multiplexed`) across a range of connection counts (1, 8, 32) and
+concurrency levels (1, 8, 64, 256). Benchmarks are developer/PR-time tools and are **not**
+part of the required CI gates.
+
+They require a running FalkorDB instance and the `tokio` feature:
+
+```bash
+# Start a server (configure with FALKORDB_HOST / FALKORDB_PORT; defaults to 127.0.0.1:6379)
+docker run -d --name falkordb-bench -p 6379:6379 falkordb/falkordb:latest
+
+# Run the full benchmark suite
+cargo bench --features tokio --bench async_strategies
+
+# Run a single case (criterion accepts a filter on the benchmark id)
+cargo bench --features tokio --bench async_strategies -- 'async_read_throughput/multiplexed_8/8'
+
+# Clean up
+docker stop falkordb-bench && docker rm falkordb-bench
+```
+
+When no server is reachable the benchmark prints a notice and skips its work, so it stays
+runnable in serverless CI.
+
+#### Interpreting the results
+
+Each case reports the wall-clock time to complete a batch of `concurrency` read queries,
+and the corresponding throughput (`Kelem/s`). criterion writes a full HTML report to
+`target/criterion/report/index.html`.
+
+What to expect:
+
+- **At concurrency = 1** the two strategies are close: a single in-flight command cannot
+  benefit from multiplexing, so the per-request latency dominates.
+- **As concurrency rises (64, 256)** the `multiplexed` strategy should pull ahead of
+  `pooled` at the same connection count, because many commands are pipelined over each
+  shared socket instead of waiting for an exclusive connection from the pool. The gap is
+  largest at low connection counts (e.g. `multiplexed_1` vs `pooled_1`), where the pool
+  becomes a hard bottleneck while a single multiplexed socket keeps absorbing work.
+- **Higher connection counts narrow the gap**: a large pool (e.g. `pooled_32`) hides much
+  of its borrow/return cost, approaching multiplexed throughput at the expense of holding
+  more sockets open.
+
+Absolute numbers depend heavily on your hardware, the server, and network latency, so
+treat them as relative comparisons between strategies on the *same* machine rather than
+portable figures.
+
+#### Memory and CPU usage
+
+`benches/async_strategies.rs` measures wall-clock throughput. A second, non-criterion
+harness, `benches/resource_usage.rs`, measures **peak memory (RSS)** and **CPU time**
+(user/system) per strategy. Because peak RSS is a process-wide high-water mark that cannot
+be reset between iterations, the harness runs each strategy in its own subprocess and
+prints a table:
+
+```bash
+docker run -d --name falkordb-bench -p 6379:6379 falkordb/falkordb:latest
+cargo bench --features tokio --bench resource_usage
+docker stop falkordb-bench && docker rm falkordb-bench
+```
+
+Example output (numbers are illustrative — they vary by machine and server):
+
+```text
+strategy         peak_rss_MiB  cpu_user_ms   cpu_sys_ms      wall_ms    queries/sec
+pooled:1               ...
+multiplexed:1          ...
+...
+```
+
+What to expect:
+
+- **Memory:** at the *same* connection count, peak RSS is comparable — both strategies hold
+  that many sockets. The real saving is that `multiplexed` sustains high concurrency with
+  *far fewer* connections (e.g. `multiplexed:1` vs a large `pooled:N`), and each connection
+  carries its own read/write buffers, so cutting connection count cuts RSS.
+- **CPU:** `multiplexed` removes the borrow/return machinery — the `mpsc` channel, the
+  `Mutex`, and the per-command task spawn the pool uses to return a connection — so it
+  generally spends less CPU per request and produces less transient allocation churn.
+
+When no server is reachable the harness prints a notice and exits cleanly, so it stays
+runnable in serverless CI.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,19 @@ name = "rows"
 [[example]]
 name = "observability"
 required-features = ["tracing"]
+
+[[example]]
+name = "readonly_replica"
+
+[[example]]
+name = "retry"
+
+[[example]]
+name = "udf_usage"
+
+[[example]]
+name = "waiting_ops"
+
+[[example]]
+name = "tls"
+required-features = ["rustls"]

--- a/Justfile
+++ b/Justfile
@@ -57,6 +57,13 @@ build:
 build-all:
     cargo build --all-targets --features {{features}}
 
+# Compile every example under the features it needs. CI gate; no server needed. Examples aren't
+# built by `just build`, so this is what keeps them compiling. The TLS example is built in a
+# separate pass with the sync `rustls` backend, which can't coexist with `tokio` in one build.
+build-examples:
+    cargo build --examples --features {{features}}
+    cargo build --example tls --features rustls
+
 # Build the API docs (matches the `check-doc` CI gate).
 doc:
     cargo doc --all
@@ -64,6 +71,11 @@ doc:
 # Build docs (no deps) and open them in a browser.
 doc-open:
     cargo doc --all --no-deps --open
+
+# Run documentation tests — the README (it's the crate-level doc via `include_str!`) and every
+# doc-comment code block — with the dev feature set. No server needed (blocks are `no_run`/pure).
+doctest:
+    cargo test --doc --features {{features}}
 
 # === Test ====================================================================
 # These need a reachable FalkorDB server. Use `just test-local` to manage one.
@@ -207,7 +219,7 @@ db-populate:
 check: fmt clippy build
 
 # Run every required CI gate locally (no server required).
-ci: fmt-check clippy build doc deny check-llms
+ci: fmt-check clippy build doc doctest build-examples deny check-llms
 
 # Full post-task gate (no server required): strict clippy-all plus every CI gate.
 # Must be green before a task is declared done.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ have distinct columns; if a `Row` ever does hold duplicates, the access paths ar
 (`get`/`try_get` return the first match, `get_all` returns every match, `into_map` keeps the last).
 To opt back into the pre-0.7 behavior (bare `Vec<FalkorValue>` rows, parse errors collapsed to
 `FalkorValue::Unparseable`), call `result.data.into_values_lossy()`. A runnable version lives in
-[`examples/rows.rs`](examples/rows.rs). Upgrading from 0.6? See the
-[0.7 migration guide](docs/migrating-to-0.7.md).
+[`examples/rows.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/rows.rs). Upgrading from 0.6? See the
+[0.7 migration guide](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.7.md).
 
 ### Type-safe query parameters
 
@@ -187,7 +187,7 @@ Key points:
 - **Owned queries.** To build queries ahead of time, construct `BatchQuery::write(..)` /
   `BatchQuery::read(..)`, attach params/timeout, and `batch.push(query)`.
 
-A runnable version lives in [`examples/batch.rs`](examples/batch.rs).
+A runnable version lives in [`examples/batch.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/batch.rs).
 
 ### Waiting for background operations
 
@@ -364,7 +364,7 @@ let enriched: Vec<i64> = graph
     .await?;
 ```
 
-A runnable version lives in [`examples/async_stream.rs`](examples/async_stream.rs).
+A runnable version lives in [`examples/async_stream.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/async_stream.rs).
 
 
 ### Connection Strategy and Multiplexing
@@ -417,7 +417,7 @@ Notes and caveats:
   transparently falls back to the pooled strategy (which re-resolves on reconnect).
   `connection_strategy()` returns this *effective* strategy.
 
-A runnable example is provided in [`examples/multiplexed_async.rs`](examples/multiplexed_async.rs).
+A runnable example is provided in [`examples/multiplexed_async.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/multiplexed_async.rs).
 
 ### SSL/TLS Support
 
@@ -520,7 +520,7 @@ let mut nodes = graph.ro_query("MATCH (a:Actor) RETURN a.name").execute().expect
 This behavior is fully backward compatible: against a single node (or any
 deployment without readable replicas), `ro_query` / `call_procedure_ro`
 transparently fall back to the primary connection, and `reads_from_replicas()`
-returns `false`. See [`examples/readonly_replica.rs`](examples/readonly_replica.rs)
+returns `false`. See [`examples/readonly_replica.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/readonly_replica.rs)
 for a complete working example.
 
 ### Resilience / automatic retries
@@ -569,7 +569,7 @@ read-only ones are eligible). Direct client/admin calls (`list_graphs`, configur
 are **not** wrapped yet, so a transient failure there still surfaces even with a policy enabled.
 Broadening the coverage is a planned follow-up.
 
-See [`examples/retry.rs`](examples/retry.rs) for a complete, runnable example.
+See [`examples/retry.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/retry.rs) for a complete, runnable example.
 
 ### Tracing
 
@@ -626,7 +626,7 @@ Parameter values supplied via `with_param` are never recorded even when query lo
 > `overflow evaluating ... Send` error, add `#![recursion_limit = "256"]` to your crate root — the
 > standard fix for deep `async` + `tracing` stacks.
 
-See [`examples/observability.rs`](examples/observability.rs) for a complete, runnable example.
+See [`examples/observability.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/observability.rs) for a complete, runnable example.
 
 ### Metrics
 
@@ -701,7 +701,7 @@ for row in result.data.by_ref() {
 }
 ```
 
-A runnable version lives in [`examples/typed_mapping.rs`](examples/typed_mapping.rs).
+A runnable version lives in [`examples/typed_mapping.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/typed_mapping.rs).
 
 To map a whole result set in one shot, call `query_as::<T>()` before `execute()`. Each row is
 deserialized into a `T`, and the result's `data` becomes an iterator of `FalkorResult<T>`, so it
@@ -826,251 +826,7 @@ if let Some(hint) = err.mitigation_hint() {
 }
 ```
 
-## Development
+## Contributing
 
-This repository ships a [`just`](https://github.com/casey/just) file that automates the
-whole development cycle — formatting, linting, building, docs, tests, coverage,
-benchmarks, the dependency audit and a Dockerized FalkorDB server. It is the recommended
-entry point for day-to-day work and mirrors the commands the CI gates run.
-
-Install the runner once with `cargo install just` (or `brew install just`), then list
-every available recipe:
-
-```bash
-just            # or: just --list
-```
-
-### Common recipes
-
-```bash
-# Fast inner loop (no server needed): format, lint and build.
-just check
-
-# Run every required CI gate locally (no server needed):
-# fmt-check, clippy, build, doc, deny.
-just ci
-
-# Post-task gate: every CI gate PLUS strict clippy over all targets/features
-# (examples, tests, benches). Run this before declaring work done.
-just done
-
-# Format / lint / docs individually.
-just fmt
-just clippy
-just doc
-
-# Full validation including the server-backed test suite (manages Docker for you):
-# spins up FalkorDB, populates the fixture, runs the suite, tears it down.
-just verify
-```
-
-### Server-backed recipes
-
-Tests, coverage and benchmarks need a reachable FalkorDB instance. The `db-*` recipes
-manage one via Docker, and the `*-local` wrappers do it for you automatically:
-
-```bash
-# Manage a FalkorDB container yourself.
-just db-up          # start a server (and wait until it is ready)
-just db-populate    # load the IMDB fixture graph the lib tests use
-just db-down        # stop and remove the container
-
-# Or let a single recipe manage the container lifecycle end-to-end.
-just test-local       # start DB, populate, run the full suite, tear down
-just coverage-local   # same, but produce Codecov JSON
-just bench-local      # start DB, run all benchmarks, tear down
-```
-
-Targeted recipes are available too, e.g. `just test-parity`, `just test-embedded`,
-`just test-one <filter>`, `just proptest`, `just bench-one '<criterion-id>'`, and
-`just coverage-html`.
-
-The host, port, Docker image and feature set can be overridden on the command line, for
-example `just port=6380 test` or `just image=falkordb/falkordb:latest db-up`.
-
-### Regenerating `llms.txt`
-
-The repository ships an [`llms.txt`](llms.txt) — a curated, machine-readable summary of the public
-API, idioms and pitfalls for AI coding assistants (the [llmstxt.org](https://llmstxt.org)
-convention). Its narrative lives in [`docs/llms.template.md`](docs/llms.template.md); the
-`## Public API` block is generated from `src/lib.rs`. **Whenever you change the public API,
-regenerate it and commit the result:**
-
-```bash
-just llms        # rewrite llms.txt from the template + the current public API
-just check-llms  # drift gate: fails if the committed llms.txt is stale
-```
-
-A `check-llms` CI job runs `just check-llms` on every pull request (and before a release), so a
-stale `llms.txt` fails the build.
-
-### Reproducing CI locally
-
-The GitHub Actions workflows invoke these same recipes, so a failing CI job can be
-reproduced with a single command:
-
-| CI job | Recipe |
-| --- | --- |
-| `check-fmt` | `just fmt-check` |
-| `check-clippy` | `just clippy` |
-| `check-build` | `just build` |
-| `check-doc` | `just doc` |
-| `check-deny` | `just deny` |
-| `check-proptest` | `just proptest` |
-| `integration-tests` | `just integration` and `just integration --all-features` |
-| `integration-tests-tokio` | `just integration --features tokio` |
-| `coverage` | `just coverage` |
-| `check-llms` | `just check-llms` |
-
-Run `just ci` to execute every required no-server gate at once, or `just verify` to also
-run the server-backed suite. The integration and coverage recipes need a reachable
-FalkorDB instance (use `just db-up` first, or the `*-local` wrappers).
-
-## Testing
-
-### Running Tests
-
-This project includes both unit tests and integration tests.
-
-#### Unit Tests
-
-Unit tests don't require a running FalkorDB instance:
-
-```bash
-# Run all unit tests
-cargo test --lib
-
-# Run unit tests with embedded feature
-cargo test --lib --features embedded
-```
-
-#### Property-Based Tests
-
-The crate ships [`proptest`](https://docs.rs/proptest) suites that need no running server:
-`src/value/param_proptest.rs` checks query-parameter encoding (encoding arbitrary values never
-panics, string escaping is lossless, NUL is rejected), and `src/value/de_proptest.rs` checks the
-optional `serde` mapping (agreement with `serde_json`, no panics, malformed-row rejection). Run
-just these:
-
-```bash
-# 256 cases per property (the proptest default)
-just proptest
-
-# crank the generated case count up (or set PROPTEST_CASES yourself)
-just proptest 4096
-
-# equivalent raw cargo command
-cargo nextest run --lib --features serde proptest
-```
-
-They also run in CI: as the dedicated `check-proptest` job, and within the `coverage` job.
-
-#### Integration Tests
-
-Integration tests require a running FalkorDB instance. The easiest way to run them is using Docker:
-
-```bash
-# Using the provided script (requires Docker)
-./run_integration_tests.sh
-
-# Or manually start FalkorDB and run tests
-docker run -d --name falkordb-test -p 6379:6379 falkordb/falkordb:latest
-cargo test --test integration_tests
-
-# With async support
-cargo test --test integration_tests --features tokio
-
-# Clean up
-docker stop falkordb-test && docker rm falkordb-test
-```
-
-#### CI Integration Tests
-
-Integration tests are automatically run in GitHub Actions using Docker services. See `.github/workflows/integration-tests.yml` for the CI configuration.
-
-### Benchmarks
-
-The crate ships a [criterion](https://docs.rs/criterion) benchmark,
-`benches/async_strategies.rs`, that compares the two async connection strategies
-(`Pooled` vs `Multiplexed`) across a range of connection counts (1, 8, 32) and
-concurrency levels (1, 8, 64, 256). Benchmarks are developer/PR-time tools and are **not**
-part of the required CI gates.
-
-They require a running FalkorDB instance and the `tokio` feature:
-
-```bash
-# Start a server (configure with FALKORDB_HOST / FALKORDB_PORT; defaults to 127.0.0.1:6379)
-docker run -d --name falkordb-bench -p 6379:6379 falkordb/falkordb:latest
-
-# Run the full benchmark suite
-cargo bench --features tokio --bench async_strategies
-
-# Run a single case (criterion accepts a filter on the benchmark id)
-cargo bench --features tokio --bench async_strategies -- 'async_read_throughput/multiplexed_8/8'
-
-# Clean up
-docker stop falkordb-bench && docker rm falkordb-bench
-```
-
-When no server is reachable the benchmark prints a notice and skips its work, so it stays
-runnable in serverless CI.
-
-#### Interpreting the results
-
-Each case reports the wall-clock time to complete a batch of `concurrency` read queries,
-and the corresponding throughput (`Kelem/s`). criterion writes a full HTML report to
-`target/criterion/report/index.html`.
-
-What to expect:
-
-- **At concurrency = 1** the two strategies are close: a single in-flight command cannot
-  benefit from multiplexing, so the per-request latency dominates.
-- **As concurrency rises (64, 256)** the `multiplexed` strategy should pull ahead of
-  `pooled` at the same connection count, because many commands are pipelined over each
-  shared socket instead of waiting for an exclusive connection from the pool. The gap is
-  largest at low connection counts (e.g. `multiplexed_1` vs `pooled_1`), where the pool
-  becomes a hard bottleneck while a single multiplexed socket keeps absorbing work.
-- **Higher connection counts narrow the gap**: a large pool (e.g. `pooled_32`) hides much
-  of its borrow/return cost, approaching multiplexed throughput at the expense of holding
-  more sockets open.
-
-Absolute numbers depend heavily on your hardware, the server, and network latency, so
-treat them as relative comparisons between strategies on the *same* machine rather than
-portable figures.
-
-#### Memory and CPU usage
-
-`benches/async_strategies.rs` measures wall-clock throughput. A second, non-criterion
-harness, `benches/resource_usage.rs`, measures **peak memory (RSS)** and **CPU time**
-(user/system) per strategy. Because peak RSS is a process-wide high-water mark that cannot
-be reset between iterations, the harness runs each strategy in its own subprocess and
-prints a table:
-
-```bash
-docker run -d --name falkordb-bench -p 6379:6379 falkordb/falkordb:latest
-cargo bench --features tokio --bench resource_usage
-docker stop falkordb-bench && docker rm falkordb-bench
-```
-
-Example output (numbers are illustrative — they vary by machine and server):
-
-```text
-strategy         peak_rss_MiB  cpu_user_ms   cpu_sys_ms      wall_ms    queries/sec
-pooled:1               ...
-multiplexed:1          ...
-...
-```
-
-What to expect:
-
-- **Memory:** at the *same* connection count, peak RSS is comparable — both strategies hold
-  that many sockets. The real saving is that `multiplexed` sustains high concurrency with
-  *far fewer* connections (e.g. `multiplexed:1` vs a large `pooled:N`), and each connection
-  carries its own read/write buffers, so cutting connection count cuts RSS.
-- **CPU:** `multiplexed` removes the borrow/return machinery — the `mpsc` channel, the
-  `Mutex`, and the per-command task spawn the pool uses to return a connection — so it
-  generally spends less CPU per request and produces less transient allocation churn.
-
-When no server is reachable the harness prints a notice and exits cleanly, so it stays
-runnable in serverless CI.
-
+Development setup, the full `just` recipe reference, and how to run the tests and benchmarks live in
+[`CONTRIBUTING.md`](https://github.com/FalkorDB/falkordb-rs/blob/main/CONTRIBUTING.md).

--- a/examples/tls.rs
+++ b/examples/tls.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Demonstrates connecting to FalkorDB over TLS.
+//!
+//! TLS is provided by the underlying `redis` crate and is opt-in behind a cargo
+//! feature: `rustls` (used here, pure Rust) or `native-tls` — and the `tokio-*`
+//! variants for the async client. Use a `falkors://` connection URL (it maps to
+//! `rediss://`); everything else is identical to a plain connection.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example tls --features rustls
+//! ```
+//!
+//! Set `FALKORDB_TLS_CONNECTION` to override the default `falkors://127.0.0.1:6379`.
+
+use falkordb::{FalkorClientBuilder, FalkorResult};
+
+fn main() -> FalkorResult<()> {
+    let connection_info = std::env::var("FALKORDB_TLS_CONNECTION")
+        .unwrap_or_else(|_| "falkors://127.0.0.1:6379".to_string());
+
+    // A `falkors://` URL negotiates TLS using the enabled backend (`rustls` here).
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info.as_str().try_into()?)
+        .build()?;
+
+    let mut graph = client.select_graph("tls_example");
+
+    let mut greetings = graph
+        .query("CREATE (g:Greeting {text: 'hello over TLS'}) RETURN g.text")
+        .execute()?;
+
+    for row in greetings.data.by_ref() {
+        println!("{row:?}");
+    }
+
+    graph.delete()?;
+
+    Ok(())
+}

--- a/examples/waiting_ops.rs
+++ b/examples/waiting_ops.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Demonstrates waiting for background operations to take effect.
+//!
+//! Some FalkorDB operations finish *after* the command that starts them returns:
+//! creating or dropping an index/constraint populates it on a background worker,
+//! and `GRAPH.COPY` can fail transiently while the server cannot `fork`. The eager
+//! methods (`create_index`, `create_unique_constraint`, `copy_graph`, …) stay
+//! fire-and-forget; each also has an additive `*_op` builder that keeps the
+//! non-blocking `.execute()` terminal and adds explicit, opt-in `.wait()` /
+//! `.wait_with(WaitOptions)` terminals.
+//!
+//! Set `FALKORDB_CONNECTION` to override the default `falkor://127.0.0.1:6379`.
+
+use std::time::Duration;
+
+use falkordb::{
+    EntityType, FalkorClientBuilder, FalkorDBError, FalkorResult, IndexType, WaitOptions,
+};
+
+fn main() -> FalkorResult<()> {
+    let connection_info = std::env::var("FALKORDB_CONNECTION")
+        .unwrap_or_else(|_| "falkor://127.0.0.1:6379".to_string());
+
+    let client = FalkorClientBuilder::new()
+        .with_connection_info(connection_info.as_str().try_into()?)
+        .build()?;
+
+    let mut graph = client.select_graph("waiting_ops_example");
+
+    // Fire-and-forget, exactly like `create_index` (returns as soon as the server accepts it).
+    graph
+        .create_index_op(IndexType::Range, EntityType::Node, "Person", &["age"], None)
+        .execute()?;
+
+    // Block until the index is actually operational (default 30s readiness timeout).
+    graph
+        .create_index_op(
+            IndexType::Range,
+            EntityType::Node,
+            "Person",
+            &["name"],
+            None,
+        )
+        .wait()?;
+
+    // A unique constraint reports a *distinct* error if existing data violates it.
+    match graph
+        .create_unique_constraint_op(EntityType::Node, "Person", &["email"])
+        .wait_with(WaitOptions::with_timeout(Duration::from_secs(10)))
+    {
+        Ok(()) => println!("constraint is enforced"),
+        Err(FalkorDBError::ConstraintFailed { .. }) => println!("data violates the constraint"),
+        Err(other) => return Err(other),
+    }
+
+    // Copy a graph, retrying transient `could not fork` failures with backoff.
+    let _copy = client
+        .copy_graph_op("waiting_ops_example", "waiting_ops_backup")
+        .wait()?;
+
+    graph.delete()?;
+
+    Ok(())
+}

--- a/examples/waiting_ops.rs
+++ b/examples/waiting_ops.rs
@@ -62,6 +62,8 @@ fn main() -> FalkorResult<()> {
         .copy_graph_op("waiting_ops_example", "waiting_ops_backup")
         .wait()?;
 
+    // Tidy up both graphs so re-running the example leaves nothing behind.
+    client.select_graph("waiting_ops_backup").delete()?;
     graph.delete()?;
 
     Ok(())

--- a/scripts/post-checks.sh
+++ b/scripts/post-checks.sh
@@ -22,6 +22,8 @@ run just clippy
 run just clippy-all
 run just build
 run just doc
+run just doctest
+run just build-examples
 run just deny
 run just check-llms
 

--- a/src/response/row_stream.rs
+++ b/src/response/row_stream.rs
@@ -26,6 +26,7 @@ use std::task::{Context, Poll};
 /// `map(..).buffer_unordered(..)`, …).
 ///
 /// ```rust,no_run
+/// # #![recursion_limit = "256"]
 /// # async fn run(mut graph: falkordb::AsyncGraph) -> Result<(), falkordb::FalkorDBError> {
 /// use futures::TryStreamExt;
 /// let movies: Vec<falkordb::Row> = graph

--- a/src/response/typed_row_stream.rs
+++ b/src/response/typed_row_stream.rs
@@ -19,6 +19,7 @@ use std::task::{Context, Poll};
 /// [`futures_core::Stream`], yielding one `FalkorResult<T>` per row.
 ///
 /// ```rust,no_run
+/// # #![recursion_limit = "256"]
 /// # use serde::Deserialize;
 /// # #[derive(Deserialize)] struct Movie { title: String }
 /// # async fn run(mut graph: falkordb::AsyncGraph) -> Result<(), falkordb::FalkorDBError> {


### PR DESCRIPTION
First of two PRs restructuring the README (plan agreed separately). This **foundation** PR adds the
verification safety net and the examples/CONTRIBUTING groundwork so the README **reflow** (PR2) is
safe. No README *structure* change yet beyond moving the contributor docs out.

## Why
The README is the crate-level docs (`#![doc = include_str!("../README.md")]`) and its code blocks are
doctests — but **nothing in CI ran `cargo test --doc`**, and **no job compiled `examples/`**. So both
could rot silently. Indeed, two `no_run` doctests were already broken (the async-stream examples
overflow the recursion limit once the `tracing` feature deepens the future).

## What
- **Verification gate**: `just doctest` (`cargo test --doc --features tokio,embedded,serde,tracing,metrics`)
  and `just build-examples`; wired into `just ci` + `scripts/post-checks.sh`; new `check-doctest` and
  `check-examples` CI jobs.
- **Fix the 2 broken doctests** with a hidden `#![recursion_limit = "256"]` (the established pattern).
- **Examples contract**: declare *every* example in `Cargo.toml` (the 3 previously auto-discovered +
  2 new) with correct `required-features`. The TLS example builds in its own pass (sync `rustls`
  can't coexist with `tokio` in one build).
- **New examples**: `examples/waiting_ops.rs` (background-op waiting) and `examples/tls.rs`.
- **CONTRIBUTING.md**: move Development/Testing/Benchmarks (~250 lines) out of the README, leave a
  pointer. README drops from 1076 → 832 lines.
- **Absolute links**: example/doc links now use full GitHub URLs so they resolve on docs.rs too.

## Validation (local)
`just done` green (incl. the new `doctest` + `build-examples`), `just doctest` = 24 passed / 0 failed
/ 14 ignored, `just build-examples` compiles all 15 examples, `just spellcheck` clean.

> Leaving merge to a maintainer per repo policy. PR2 (the README reflow) follows once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new runnable examples demonstrating TLS connections, waiting for background operations, readonly replicas, retry patterns, and UDF usage.

* **Documentation**
  * Introduced comprehensive CONTRIBUTING.md guide with local development workflows and testing instructions.
  * Updated README to direct contributors to contribution guidelines.
  * Enhanced documentation validation in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->