### PR TITLE
ci: also cut releases for documentation changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,10 +103,10 @@ don't pile up.
 - **Don't hardcode the next version** — let `release-plz` compute it from the commits.
 - Use **Conventional Commits** (`feat`, `fix`, `ci`, `docs`, `perf`, `chore`, …) — they drive the
   version bump. Mark breaking changes with `feat!` / a `[**breaking**]` note.
-- **Only `feat:` / `fix:` commits cut a release** (`release_commits` in `release-plz.toml`);
-  `ci` / `docs` / `chore` / `refactor` changes ride along with the next feature/fix release instead
-  of cutting an empty one. (release-plz runs from the `main.yml` workflow on pushes to `main`.) To
-  release such changes sooner, land them with a `feat`/`fix` commit or temporarily relax
+- **Only `feat:` / `fix:` / `docs:` commits cut a release** (`release_commits` in `release-plz.toml`);
+  `ci` / `chore` / `refactor` / `test` / `build` changes ride along with the next release instead
+  of cutting one on their own. (release-plz runs from the `main.yml` workflow on pushes to `main`.) To
+  release such changes sooner, land them with a `feat`/`fix`/`docs` commit or temporarily relax
   `release_commits`.
 - Include a `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer on
   agent-authored commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- restructure the README into chapters with a table of contents, a Cargo feature-flags table, and a
+  runnable-examples index ([#262](https://github.com/FalkorDB/falkordb-rs/pull/262))
+- compile the README doctests and every example in CI so the documentation and examples can't
+  silently drift ([#261](https://github.com/FalkorDB/falkordb-rs/pull/261))
+
 ## [0.8.8](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.7...v0.8.8) - 2026-06-19
 
 ### Other

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,15 +1,16 @@
 [workspace]
 semver_check = false # disable API breaking changes checks, I suggest this becomes 'true' after we release 1.0
 
-# Only open a release PR when there's an actual feature or fix. ci/docs/chore/refactor-only
-# changes don't cut a release on their own — they ride along with the next `feat`/`fix` release.
+# Only open a release PR for user-facing changes: features, fixes, and docs (the README is the
+# crates.io / docs.rs landing page, so a docs change is worth releasing). ci/chore/refactor/test/
+# build-only changes don't cut a release on their own — they ride along with the next release.
 # Because the [changelog] body below is header-only, such commits are NOT auto-listed anywhere;
 # they appear in CHANGELOG.md only through the hand-written `## [Unreleased]` entry you add. The
-# regex matches a Conventional-Commit `feat`/`fix` subject with an optional `(scope)` and optional
-# `!`, requiring the `:` (so a malformed subject like `feat(x) …` without a colon won't trigger a
-# release). To release such changes sooner, land them with a feat/fix commit or temporarily relax
-# this filter.
-release_commits = '^(feat|fix)(\(.+?\))?!?:'
+# regex matches a Conventional-Commit `feat`/`fix`/`docs` subject with an optional `(scope)` and
+# optional `!`, requiring the `:` (so a malformed subject like `feat(x) …` without a colon won't
+# trigger a release). To release other changes sooner, land them with a feat/fix/docs commit or
+# temporarily relax this filter.
+release_commits = '^(feat|fix|docs)(\(.+?\))?!?:'
 
 [changelog]
 # Changelog entries are hand-written under "## [Unreleased]" in CHANGELOG.md (see the

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,8 +2,9 @@
 semver_check = false # disable API breaking changes checks, I suggest this becomes 'true' after we release 1.0
 
 # Only open a release PR for user-facing changes: features, fixes, and docs (the README is the
-# crates.io / docs.rs landing page, so a docs change is worth releasing). ci/chore/refactor/test/
-# build-only changes don't cut a release on their own — they ride along with the next release.
+# crates.io / docs.rs landing page, so a docs change is worth releasing). Internal-only changes
+# (`ci`, `chore`, `refactor`, `test`, `build`) don't cut a release on their own — they ride along
+# with the next release.
 # Because the [changelog] body below is header-only, such commits are NOT auto-listed anywhere;
 # they appear in CHANGELOG.md only through the hand-written `## [Unreleased]` entry you add. The
 # regex matches a Conventional-Commit `feat`/`fix`/`docs` subject with an optional `(scope)` and


### PR DESCRIPTION
## Why

The README restructure (#262) is merged but there's **no release PR**: the `release_commits` filter
(from #260) is `^(feat|fix)…`, so `docs`/`ci`-only changes don't trigger a release. The README is the
crates.io / docs.rs landing page, so a docs change is worth releasing on its own.

## What

- Widen `release_commits` to `^(feat|fix|docs)…` so **features, fixes, and docs** cut a release;
  `ci`/`chore`/`refactor`/`test`/`build`-only changes still ride along with the next release.
- Add the hand-written `CHANGELOG.md` `[Unreleased]` entries for #261 and #262 so the release notes
  aren't empty (Model B — entries are hand-written).
- Update the policy note in `.github/copilot-instructions.md`.

## Validated locally (release-plz 0.3.159)

Against the current `main` state (commits since `v0.8.8` = #261 `ci`, #262 `docs`):

- Before: `no commit matches the release_commits regex` (no release).
- After: `next version is 0.8.9`, and the generated `## [0.8.9]` section is populated with the README
  + CI-gate entries (not empty). Regex truth table confirms `feat`/`fix`/`docs` match while
  `ci`/`chore`/`refactor`/`test`/`build` (and `documentation:`/`doc:`/malformed `docs(x)`) do not.

## After this merges

release-plz will open a **`0.8.9` release PR** that ships the new README. Merge that PR to publish.

> Leaving both this PR and the release PR for you to merge, per repo policy.
