### PR TITLE
feat!: decode temporal values and fix vector index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Decode FalkorDB temporal values (`datetime`, `date`, `time`/`localtime`, `duration`) into the new
   typed `DateTime`, `Date`, `Time` and `Duration` values instead of surfacing them as `Unparseable`.
-  Each preserves the raw FalkorDB scalar (`.raw()`), and `Duration` adds `.as_seconds()` /
+  Each exposes its scalar as a typed `Seconds` (`.seconds()`), and `DateTime`/`Duration` support a
+  type-safe algebra (`DateTime - DateTime → Duration`, `DateTime ± Duration → DateTime`, and
+  `Duration` add/subtract/negate) with overflow-checked `checked_*` variants; `Duration` also offers
   `.as_std_duration()` ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 - Typed vector-index helpers `create_node_vector_index` / `create_edge_vector_index` (sync and
   async) plus a `VectorSimilarity` enum, so a correct `OPTIONS { dimension: N, similarityFunction:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.as_std_duration()` ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 - Typed vector-index helpers `create_node_vector_index` / `create_edge_vector_index` (sync and
   async) plus a `VectorSimilarity` enum, so a correct `OPTIONS { dimension: N, similarityFunction:
-  '…' }` clause is generated for you ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
+  '…' }` clause is generated for you. Matching `create_node_vector_index_op` /
+  `create_edge_vector_index_op` builders integrate with the wait ergonomics (`.wait()` blocks until
+  the vector index is operational) ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Decode FalkorDB temporal values (`datetime`, `date`, `time`/`localtime`, `duration`) into the new
+  typed `DateTime`, `Date`, `Time` and `Duration` values instead of surfacing them as `Unparseable`.
+  Each preserves the raw FalkorDB scalar (`.raw()`), and `Duration` adds `.as_seconds()` /
+  `.as_std_duration()`.
+- Typed vector-index helpers `create_node_vector_index` / `create_edge_vector_index` (sync and
+  async) plus a `VectorSimilarity` enum, so a correct `OPTIONS { dimension: N, similarityFunction:
+  '…' }` clause is generated for you.
+
+### Fixed
+
+- Vector index creation generated invalid Cypher (`OPTIONS { 'dimension':'4' }`) that FalkorDB
+  rejected with a parse error; index `OPTIONS` now use unquoted identifier keys and emit numeric
+  values (such as a vector `dimension`) unquoted, so vector indexes can actually be created.
+
+### Changed
+
+- **Breaking:** `FalkorValue` is now `#[non_exhaustive]` and gained `DateTime`, `Date`, `Time` and
+  `Duration` variants. Exhaustive `match` expressions over a `FalkorValue` must add a wildcard
+  (`_ => …`) arm.
+
 ## [0.8.9](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.8...v0.8.9) - 2026-06-20
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decode FalkorDB temporal values (`datetime`, `date`, `time`/`localtime`, `duration`) into the new
   typed `DateTime`, `Date`, `Time` and `Duration` values instead of surfacing them as `Unparseable`.
   Each preserves the raw FalkorDB scalar (`.raw()`), and `Duration` adds `.as_seconds()` /
-  `.as_std_duration()`.
+  `.as_std_duration()` ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 - Typed vector-index helpers `create_node_vector_index` / `create_edge_vector_index` (sync and
   async) plus a `VectorSimilarity` enum, so a correct `OPTIONS { dimension: N, similarityFunction:
-  '…' }` clause is generated for you.
+  '…' }` clause is generated for you ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 
 ### Fixed
 
 - Vector index creation generated invalid Cypher (`OPTIONS { 'dimension':'4' }`) that FalkorDB
   rejected with a parse error; index `OPTIONS` now use unquoted identifier keys and emit numeric
-  values (such as a vector `dimension`) unquoted, so vector indexes can actually be created.
+  values (such as a vector `dimension`) unquoted, so vector indexes can actually be created
+  ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 
 ### Changed
 
 - **Breaking:** `FalkorValue` is now `#[non_exhaustive]` and gained `DateTime`, `Date`, `Time` and
   `Duration` variants. Exhaustive `match` expressions over a `FalkorValue` must add a wildcard
-  (`_ => …`) arm.
+  (`_ => …`) arm ([#265](https://github.com/FalkorDB/falkordb-rs/pull/265))
 
 ## [0.8.9](https://github.com/FalkorDB/falkordb-rs/compare/v0.8.8...v0.8.9) - 2026-06-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,9 @@ name = "waiting_ops"
 [[example]]
 name = "tls"
 required-features = ["rustls"]
+
+[[example]]
+name = "temporal"
+
+[[example]]
+name = "vector_index"

--- a/README.md
+++ b/README.md
@@ -531,7 +531,11 @@ The same builders exist on the async client — just `await` the terminals. See
 
 For vector indexes, the typed helpers `create_node_vector_index` / `create_edge_vector_index` take a
 `dimension` and a `VectorSimilarity` (`Euclidean` or `Cosine`) and generate the correct
-`OPTIONS { dimension: N, similarityFunction: '…' }` clause for you. A runnable version lives in
+`OPTIONS { dimension: N, similarityFunction: '…' }` clause for you. Like the other index operations
+they are fire-and-forget, and they have matching `create_node_vector_index_op` /
+`create_edge_vector_index_op` builders that integrate with the waiting ergonomics above —
+`.wait()` blocks until the vector index is operational (and `.execute()` is the non-blocking
+equivalent). A runnable version lives in
 [`examples/vector_index.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/vector_index.rs).
 
 [`FalkorDBError::Timeout`]: https://docs.rs/falkordb/latest/falkordb/enum.FalkorDBError.html

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ graph.query("RETURN point($p)").with_param("p", coords).execute()?;
 If you really need a raw Cypher expression, `with_raw_param("key", "…")` is the explicit escape
 hatch — no escaping is applied to the value (the parameter name is still validated).
 
+Temporal values returned by queries — `datetime`, `date`, `time`/`localtime` and `duration` —
+decode into the typed `DateTime`, `Date`, `Time` and `Duration` values (each preserving the raw
+FalkorDB scalar via `.raw()`; `Duration` also offers `.as_seconds()` / `.as_std_duration()`). They
+are read from results but cannot be bound back as parameters — build them in the query with the
+matching Cypher function (e.g. `date($s)`).
+
 #### Typed result mapping with serde
 
 Enable the optional `serde` feature to map query results straight into your own types instead of hand-matching every
@@ -520,6 +526,10 @@ let _copy = client.copy_graph_op("social", "social_backup")
 
 The same builders exist on the async client — just `await` the terminals. See
 [`examples/waiting_ops.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/waiting_ops.rs) for a complete, runnable example.
+
+For vector indexes, the typed helpers `create_node_vector_index` / `create_edge_vector_index` take a
+`dimension` and a `VectorSimilarity` (`Euclidean` or `Cosine`) and generate the correct
+`OPTIONS { dimension: N, similarityFunction: '…' }` clause for you.
 
 [`FalkorDBError::Timeout`]: https://docs.rs/falkordb/latest/falkordb/enum.FalkorDBError.html
 

--- a/README.md
+++ b/README.md
@@ -200,10 +200,12 @@ If you really need a raw Cypher expression, `with_raw_param("key", "…")` is th
 hatch — no escaping is applied to the value (the parameter name is still validated).
 
 Temporal values returned by queries — `datetime`, `date`, `time`/`localtime` and `duration` —
-decode into the typed `DateTime`, `Date`, `Time` and `Duration` values (each preserving the raw
-FalkorDB scalar via `.raw()`; `Duration` also offers `.as_seconds()` / `.as_std_duration()`). They
-are read from results but cannot be bound back as parameters — build them in the query with the
-matching Cypher function (e.g. `date($s)`).
+decode into the typed `DateTime`, `Date`, `Time` and `Duration` values. Each exposes its scalar as a
+typed `Seconds` (`value.seconds()`), and `DateTime`/`Duration` support a small type-safe algebra
+(`DateTime - DateTime` → `Duration`, `DateTime ± Duration` → `DateTime`, plus `Duration`
+add/subtract/negate) with overflow-checked `checked_*` variants. They are read from results but
+cannot be bound back as parameters — build them in the query with the matching Cypher function (e.g.
+`date($s)`).
 
 #### Typed result mapping with serde
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ typed `Seconds` (`value.seconds()`), and `DateTime`/`Duration` support a small t
 (`DateTime - DateTime` → `Duration`, `DateTime ± Duration` → `DateTime`, plus `Duration`
 add/subtract/negate) with overflow-checked `checked_*` variants. They are read from results but
 cannot be bound back as parameters — build them in the query with the matching Cypher function (e.g.
-`date($s)`).
+`date($s)`). A runnable version lives in [`examples/temporal.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/temporal.rs).
 
 #### Typed result mapping with serde
 
@@ -531,7 +531,8 @@ The same builders exist on the async client — just `await` the terminals. See
 
 For vector indexes, the typed helpers `create_node_vector_index` / `create_edge_vector_index` take a
 `dimension` and a `VectorSimilarity` (`Euclidean` or `Cosine`) and generate the correct
-`OPTIONS { dimension: N, similarityFunction: '…' }` clause for you.
+`OPTIONS { dimension: N, similarityFunction: '…' }` clause for you. A runnable version lives in
+[`examples/vector_index.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/vector_index.rs).
 
 [`FalkorDBError::Timeout`]: https://docs.rs/falkordb/latest/falkordb/enum.FalkorDBError.html
 
@@ -896,6 +897,8 @@ Run one with `cargo run` plus the flags shown:
 | [`rows`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/rows.rs) | Header-aware rows: read columns by name or index with strict typed access | `--example rows` |
 | [`typed_params`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/typed_params.rs) | Type-safe, injection-proof query parameters | `--example typed_params` |
 | [`typed_mapping`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/typed_mapping.rs) | Map query results into your own `serde` types | `--features serde --example typed_mapping` |
+| [`temporal`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/temporal.rs) | Decode temporal values and use the type-safe `DateTime`/`Duration` algebra | `--example temporal` |
+| [`vector_index`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/vector_index.rs) | Create vector indexes with the typed helpers and `VectorSimilarity` | `--example vector_index` |
 | [`batch`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/batch.rs) | Batch / pipelined execution: many queries in one round-trip | `--example batch` |
 | [`waiting_ops`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/waiting_ops.rs) | Wait for background index / constraint / copy operations to take effect | `--example waiting_ops` |
 | [`udf_usage`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/udf_usage.rs) | Load a user-defined-function (UDF) library | `--example udf_usage` |

--- a/examples/temporal.rs
+++ b/examples/temporal.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Decoding FalkorDB temporal values and using the type-safe temporal algebra.
+//!
+//! Run with: `cargo run --example temporal` (needs a FalkorDB server on 127.0.0.1:6379).
+
+use falkordb::{Date, DateTime, Duration, FalkorClientBuilder, FalkorResult, Time};
+
+fn main() -> FalkorResult<()> {
+    let client = FalkorClientBuilder::new()
+        .with_connection_info("falkor://127.0.0.1:6379".try_into()?)
+        .build()?;
+
+    let mut graph = client.select_graph("temporal_example");
+    let _ = graph.delete();
+
+    // FalkorDB returns `date` / `time` / `duration` as typed, seconds-based scalars. The client
+    // decodes them into the `Date` / `Time` / `Duration` value types rather than leaving them
+    // `Unparseable`, so you can read them with strict typed access.
+    let mut result = graph
+        .query("RETURN date('1947-11-29') AS d, localtime() AS t, duration({days: 3}) AS dur")
+        .execute()?;
+    let row = result.data.next().expect("expected a row")?;
+
+    let d: Date = row.try_get("d")?;
+    let t: Time = row.try_get("t")?;
+    let dur: Duration = row.try_get("dur")?;
+
+    // Each value exposes its scalar as a typed `Seconds` (not a bare `i64`) — call `.get()` for the
+    // underlying integer. This keeps a temporal scalar from being silently mixed with a plain int.
+    println!("date is {} seconds since the Unix epoch", d.seconds().get());
+    println!("localtime is {} seconds", t.seconds());
+    println!("duration is {} seconds", dur.seconds().get());
+    println!(
+        "duration as std::time::Duration: {:?}",
+        dur.as_std_duration()
+    );
+
+    // `DateTime` and `Duration` support a small, type-safe algebra. Subtracting two instants yields
+    // a `Duration`; shifting an instant by a `Duration` yields another `DateTime`.
+    let instant = DateTime::new(d.seconds().get());
+    let earlier = DateTime::new(d.seconds().get() - 60);
+
+    let elapsed: Duration = instant - earlier;
+    assert_eq!(elapsed.seconds().get(), 60);
+    println!("instant is {} seconds after `earlier`", elapsed.seconds());
+
+    // Shifting forward by a duration and back again is a no-op.
+    assert_eq!(instant + dur - dur, instant);
+
+    // Overflow-checked variants return `None` instead of panicking.
+    assert!(DateTime::new(i64::MAX).checked_add(dur).is_none());
+
+    // Nonsensical combinations simply have no impl and fail to compile, e.g.:
+    //     let _ = instant + earlier; // error: cannot add two instants
+
+    graph.delete()?;
+    Ok(())
+}

--- a/examples/vector_index.rs
+++ b/examples/vector_index.rs
@@ -1,0 +1,52 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Creating vector indexes with the typed helpers and `VectorSimilarity`.
+//!
+//! Run with: `cargo run --example vector_index` (needs a FalkorDB server on 127.0.0.1:6379).
+
+use falkordb::{EntityType, FalkorClientBuilder, FalkorResult, IndexType, VectorSimilarity};
+
+fn main() -> FalkorResult<()> {
+    let client = FalkorClientBuilder::new()
+        .with_connection_info("falkor://127.0.0.1:6379".try_into()?)
+        .build()?;
+
+    let mut graph = client.select_graph("vector_index_example");
+    let _ = graph.delete();
+
+    // Seed a couple of nodes with 4-dimensional embeddings.
+    graph
+        .query(
+            "CREATE (:Product {name: 'a', embedding: vecf32([0.1, 0.2, 0.3, 0.4])}),
+                    (:Product {name: 'b', embedding: vecf32([0.9, 0.8, 0.7, 0.6])})",
+        )
+        .execute()?;
+
+    // The typed helper builds a correct `OPTIONS { dimension: 4, similarityFunction: 'euclidean' }`
+    // clause for you — no hand-built options map, and no risk of the quoted-key Cypher the server
+    // rejects.
+    graph.create_node_vector_index("Product", &["embedding"], 4, VectorSimilarity::Euclidean)?;
+
+    // Edge vectors and cosine similarity work the same way.
+    graph.create_edge_vector_index("SIMILAR_TO", &["weight"], 4, VectorSimilarity::Cosine)?;
+
+    // Indexes build asynchronously; once ready, `Product.embedding` is listed as a VECTOR index.
+    let indices = graph.list_indices()?;
+    let has_vector_index = indices.data.iter().any(|index| {
+        index.entity_type == EntityType::Node
+            && index
+                .field_types
+                .get("embedding")
+                .is_some_and(|types| types.contains(&IndexType::Vector))
+    });
+    println!("Product.embedding vector index present: {has_vector_index}");
+
+    // You then run vector similarity searches in Cypher (e.g. `CALL db.idx.vector.queryNodes(...)`
+    // or by ordering on a distance function), using `vecf32([...])` to build query vectors.
+
+    graph.delete()?;
+    Ok(())
+}

--- a/examples/vector_index.rs
+++ b/examples/vector_index.rs
@@ -7,7 +7,9 @@
 //!
 //! Run with: `cargo run --example vector_index` (needs a FalkorDB server on 127.0.0.1:6379).
 
-use falkordb::{EntityType, FalkorClientBuilder, FalkorResult, IndexType, VectorSimilarity};
+use falkordb::{
+    EntityType, FalkorClientBuilder, FalkorResult, IndexStatus, IndexType, VectorSimilarity,
+};
 
 fn main() -> FalkorResult<()> {
     let client = FalkorClientBuilder::new()
@@ -27,30 +29,27 @@ fn main() -> FalkorResult<()> {
 
     // The typed helper builds a correct `OPTIONS { dimension: 4, similarityFunction: 'euclidean' }`
     // clause for you — no hand-built options map, and no risk of the quoted-key Cypher the server
-    // rejects.
-    graph.create_node_vector_index("Product", &["embedding"], 4, VectorSimilarity::Euclidean)?;
-
-    // Edge vectors and cosine similarity work the same way.
+    // rejects. This eager form is fire-and-forget (it returns as soon as the server accepts it).
     graph.create_edge_vector_index("SIMILAR_TO", &["weight"], 4, VectorSimilarity::Cosine)?;
 
-    // Indexes build asynchronously, so poll (up to ~5s) until the node vector index is listed
-    // rather than reading once and risking a false negative right after creation.
-    let mut has_vector_index = false;
-    for _ in 0..50 {
-        let indices = graph.list_indices()?;
-        has_vector_index = indices.data.iter().any(|index| {
-            index.entity_type == EntityType::Node
-                && index
-                    .field_types
-                    .get("embedding")
-                    .is_some_and(|types| types.contains(&IndexType::Vector))
-        });
-        if has_vector_index {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-    println!("Product.embedding vector index present: {has_vector_index}");
+    // Indexes build asynchronously. The typed helpers also have `_op` builders that integrate with
+    // the wait ergonomics: `.wait()` blocks until the index is actually operational (and `.execute()`
+    // is the non-blocking equivalent), so you don't have to poll `list_indices()` yourself.
+    graph
+        .create_node_vector_index_op("Product", &["embedding"], 4, VectorSimilarity::Euclidean)
+        .wait()?;
+
+    // After `.wait()` returns, the node index is guaranteed to be operational.
+    let indices = graph.list_indices()?;
+    let has_vector_index = indices.data.iter().any(|index| {
+        index.entity_type == EntityType::Node
+            && index.status == IndexStatus::Active
+            && index
+                .field_types
+                .get("embedding")
+                .is_some_and(|types| types.contains(&IndexType::Vector))
+    });
+    println!("Product.embedding vector index operational: {has_vector_index}");
 
     // You then run vector similarity searches in Cypher (e.g. `CALL db.idx.vector.queryNodes(...)`
     // or by ordering on a distance function), using `vecf32([...])` to build query vectors.

--- a/examples/vector_index.rs
+++ b/examples/vector_index.rs
@@ -27,7 +27,7 @@ fn main() -> FalkorResult<()> {
         )
         .execute()?;
 
-    // The typed helper builds a correct `OPTIONS { dimension: 4, similarityFunction: 'euclidean' }`
+    // The typed helper builds a correct `OPTIONS { dimension: 4, similarityFunction: 'cosine' }`
     // clause for you — no hand-built options map, and no risk of the quoted-key Cypher the server
     // rejects. This eager form is fire-and-forget (it returns as soon as the server accepts it).
     graph.create_edge_vector_index("SIMILAR_TO", &["weight"], 4, VectorSimilarity::Cosine)?;

--- a/examples/vector_index.rs
+++ b/examples/vector_index.rs
@@ -33,15 +33,23 @@ fn main() -> FalkorResult<()> {
     // Edge vectors and cosine similarity work the same way.
     graph.create_edge_vector_index("SIMILAR_TO", &["weight"], 4, VectorSimilarity::Cosine)?;
 
-    // Indexes build asynchronously; once ready, `Product.embedding` is listed as a VECTOR index.
-    let indices = graph.list_indices()?;
-    let has_vector_index = indices.data.iter().any(|index| {
-        index.entity_type == EntityType::Node
-            && index
-                .field_types
-                .get("embedding")
-                .is_some_and(|types| types.contains(&IndexType::Vector))
-    });
+    // Indexes build asynchronously, so poll (up to ~5s) until the node vector index is listed
+    // rather than reading once and risking a false negative right after creation.
+    let mut has_vector_index = false;
+    for _ in 0..50 {
+        let indices = graph.list_indices()?;
+        has_vector_index = indices.data.iter().any(|index| {
+            index.entity_type == EntityType::Node
+                && index
+                    .field_types
+                    .get("embedding")
+                    .is_some_and(|types| types.contains(&IndexType::Vector))
+        });
+        if has_vector_index {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
     println!("Product.embedding vector index present: {has_vector_index}");
 
     // You then run vector similarity searches in Cypher (e.g. `CALL db.idx.vector.queryNodes(...)`

--- a/llms.txt
+++ b/llms.txt
@@ -109,6 +109,7 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `Row`
 - `RowStream` — requires `tokio`
 - `SchemaType`
+- `Seconds`
 - `SlowlogEntry`
 - `SyncGraph`
 - `Time`

--- a/llms.txt
+++ b/llms.txt
@@ -71,6 +71,9 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `ConstraintStatus`
 - `ConstraintType`
 - `CopyGraphBuilder`
+- `Date`
+- `DateTime`
+- `Duration`
 - `Edge`
 - `EmbeddedConfig` — requires `embedded`
 - `EmbeddedServer` — requires `embedded`
@@ -108,8 +111,10 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `SchemaType`
 - `SlowlogEntry`
 - `SyncGraph`
+- `Time`
 - `TypedLazyResultSet` — requires `serde`
 - `TypedRowStream` — requires `serde` + `tokio`
+- `VectorSimilarity`
 - `WaitOperation`
 - `WaitOptions`
 - `from_falkor_row` — requires `serde`

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -164,6 +164,15 @@ pub enum FalkorDBError {
         /// A human-readable description of why encoding failed.
         message: String,
     },
+    /// An index `OPTIONS` key was not a valid Cypher identifier, so it could not be safely
+    /// interpolated into the `OPTIONS` map.
+    #[error("invalid index option key '{key}': {message}")]
+    InvalidIndexOption {
+        /// The offending option key.
+        key: String,
+        /// A human-readable description of why the key is invalid.
+        message: String,
+    },
     /// A result row did not contain a column with the requested name.
     #[error("result row has no column named '{name}'")]
     MissingColumn {

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -253,7 +253,7 @@ impl AsyncGraph {
     ) -> FalkorResult<QueryResult<RowStream>> {
         // Create index from these properties
         let query_str =
-            generate_create_index_query(index_field_type, entity_type, label, properties, options);
+            generate_create_index_query(index_field_type, entity_type, label, properties, options)?;
 
         QueryBuilder::<QueryResult<RowStream>, String, Self>::new(self, "GRAPH.QUERY", query_str)
             .execute()

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -750,6 +750,50 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_vector_index_op_wait() {
+        let mut graph = open_empty_async_test_graph("test_vector_index_op_wait_async").await;
+
+        // The typed vector `_op` builders integrate with the wait ergonomics: `.wait()` awaits
+        // until the vector index is actually operational.
+        graph
+            .inner
+            .create_node_vector_index_op("Item", &["embedding"], 4, VectorSimilarity::Euclidean)
+            .wait()
+            .await
+            .expect("node vector index did not become operational");
+        graph
+            .inner
+            .create_edge_vector_index_op("SIMILAR", &["v"], 8, VectorSimilarity::Cosine)
+            .wait()
+            .await
+            .expect("edge vector index did not become operational");
+
+        // After `wait()` returns, both vector indices are listed and Active.
+        let indices = graph
+            .inner
+            .list_indices()
+            .await
+            .expect("Could not list indices")
+            .data;
+        assert!(indices.iter().any(|index| {
+            index.entity_type == EntityType::Node
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("embedding")
+                    .is_some_and(|types| types.contains(&IndexType::Vector))
+        }));
+        assert!(indices.iter().any(|index| {
+            index.entity_type == EntityType::Edge
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("v")
+                    .is_some_and(|types| types.contains(&IndexType::Vector))
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_create_drop_index_op_wait() {
         let mut graph = open_empty_async_test_graph("test_create_index_op_wait_async").await;
 

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     client::asynchronous::FalkorAsyncClientInner,
-    graph::{generate_create_index_query, generate_drop_index_query},
+    graph::{
+        generate_create_index_query, generate_drop_index_query, vector_index_options,
+        VectorSimilarity,
+    },
     Constraint, ConstraintType, EntityType, ExecutionPlan, FalkorIndex, FalkorResult, GraphSchema,
     IndexType, ProcedureQueryBuilder, QueryBuilder, QueryResult, RowStream, SlowlogEntry,
 };
@@ -255,6 +258,70 @@ impl AsyncGraph {
         QueryBuilder::<QueryResult<RowStream>, String, Self>::new(self, "GRAPH.QUERY", query_str)
             .execute()
             .await
+    }
+
+    /// Creates a vector index on a node label, for similarity search over the given properties.
+    ///
+    /// This is a typed convenience wrapper over [`create_index`](Self::create_index) that emits a
+    /// valid `OPTIONS { dimension: N, similarityFunction: '…' }` clause.
+    ///
+    /// # Arguments
+    /// * `label`: Nodes with this label will be indexed.
+    /// * `properties`: The vector properties to index.
+    /// * `dimension`: The dimensionality of the indexed vectors.
+    /// * `similarity_function`: The [`VectorSimilarity`] function to compare vectors with.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Graph Create Node Vector Index", skip_all, level = "info")
+    )]
+    pub async fn create_node_vector_index<P: Display>(
+        &mut self,
+        label: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> FalkorResult<QueryResult<RowStream>> {
+        let options = vector_index_options(dimension, similarity_function);
+        self.create_index(
+            IndexType::Vector,
+            EntityType::Node,
+            label,
+            properties,
+            Some(&options),
+        )
+        .await
+    }
+
+    /// Creates a vector index on a relationship type, for similarity search over the given properties.
+    ///
+    /// This is a typed convenience wrapper over [`create_index`](Self::create_index) that emits a
+    /// valid `OPTIONS { dimension: N, similarityFunction: '…' }` clause.
+    ///
+    /// # Arguments
+    /// * `relation`: Relationships of this type will be indexed.
+    /// * `properties`: The vector properties to index.
+    /// * `dimension`: The dimensionality of the indexed vectors.
+    /// * `similarity_function`: The [`VectorSimilarity`] function to compare vectors with.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Graph Create Edge Vector Index", skip_all, level = "info")
+    )]
+    pub async fn create_edge_vector_index<P: Display>(
+        &mut self,
+        relation: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> FalkorResult<QueryResult<RowStream>> {
+        let options = vector_index_options(dimension, similarity_function);
+        self.create_index(
+            IndexType::Vector,
+            EntityType::Edge,
+            relation,
+            properties,
+            Some(&options),
+        )
+        .await
     }
 
     /// Drop an existing index, by specifying its type, entity, label and specific properties
@@ -611,6 +678,75 @@ mod tests {
             .await
             .expect("Could not drop index");
         assert_eq!(res.get_indices_deleted(), Some(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_create_vector_index_node_and_edge() {
+        let mut graph = open_empty_async_test_graph("test_vector_index_helpers_async").await;
+
+        // With the OPTIONS-encoding fix the server accepts these; previously it rejected the
+        // quoted `'dimension'` key with a parse error.
+        graph
+            .inner
+            .create_node_vector_index("Item", &["embedding"], 4, VectorSimilarity::Euclidean)
+            .await
+            .expect("node vector index creation should succeed");
+        graph
+            .inner
+            .create_edge_vector_index("SIMILAR", &["v"], 8, VectorSimilarity::Cosine)
+            .await
+            .expect("edge vector index creation should succeed");
+
+        // Indices build asynchronously; wait until both vector indices are listed.
+        let indices = retry_until_async(
+            &mut graph.inner,
+            |graph| {
+                Box::pin(async move {
+                    graph
+                        .list_indices()
+                        .await
+                        .expect("Could not list indices")
+                        .data
+                })
+            },
+            |indices| {
+                indices.iter().any(|index| {
+                    index.entity_type == EntityType::Node
+                        && index
+                            .field_types
+                            .get("embedding")
+                            .is_some_and(|types| types.contains(&IndexType::Vector))
+                }) && indices.iter().any(|index| {
+                    index.entity_type == EntityType::Edge
+                        && index
+                            .field_types
+                            .get("v")
+                            .is_some_and(|types| types.contains(&IndexType::Vector))
+                })
+            },
+        )
+        .await;
+
+        assert!(
+            indices.iter().any(|index| {
+                index.entity_type == EntityType::Node
+                    && index
+                        .field_types
+                        .get("embedding")
+                        .is_some_and(|types| types.contains(&IndexType::Vector))
+            }),
+            "node vector index should be listed"
+        );
+        assert!(
+            indices.iter().any(|index| {
+                index.entity_type == EntityType::Edge
+                    && index
+                        .field_types
+                        .get("v")
+                        .is_some_and(|types| types.contains(&IndexType::Vector))
+            }),
+            "edge vector index should be listed"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -5,7 +5,10 @@
 
 use crate::{
     client::blocking::FalkorSyncClientInner,
-    graph::{generate_create_index_query, generate_drop_index_query, HasGraphSchema},
+    graph::{
+        generate_create_index_query, generate_drop_index_query, vector_index_options,
+        HasGraphSchema, VectorSimilarity,
+    },
     Constraint, ConstraintType, EntityType, ExecutionPlan, FalkorIndex, FalkorResult, GraphSchema,
     IndexType, LazyResultSet, ProcedureQueryBuilder, QueryBuilder, QueryResult, SlowlogEntry,
 };
@@ -246,6 +249,68 @@ impl SyncGraph {
             query_str,
         )
         .execute()
+    }
+
+    /// Creates a vector index on a node label, for similarity search over the given properties.
+    ///
+    /// This is a typed convenience wrapper over [`create_index`](Self::create_index) that emits a
+    /// valid `OPTIONS { dimension: N, similarityFunction: '…' }` clause.
+    ///
+    /// # Arguments
+    /// * `label`: Nodes with this label will be indexed.
+    /// * `properties`: The vector properties to index.
+    /// * `dimension`: The dimensionality of the indexed vectors.
+    /// * `similarity_function`: The [`VectorSimilarity`] function to compare vectors with.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Graph Create Node Vector Index", skip_all, level = "info")
+    )]
+    pub fn create_node_vector_index<P: Display>(
+        &mut self,
+        label: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> FalkorResult<QueryResult<LazyResultSet>> {
+        let options = vector_index_options(dimension, similarity_function);
+        self.create_index(
+            IndexType::Vector,
+            EntityType::Node,
+            label,
+            properties,
+            Some(&options),
+        )
+    }
+
+    /// Creates a vector index on a relationship type, for similarity search over the given properties.
+    ///
+    /// This is a typed convenience wrapper over [`create_index`](Self::create_index) that emits a
+    /// valid `OPTIONS { dimension: N, similarityFunction: '…' }` clause.
+    ///
+    /// # Arguments
+    /// * `relation`: Relationships of this type will be indexed.
+    /// * `properties`: The vector properties to index.
+    /// * `dimension`: The dimensionality of the indexed vectors.
+    /// * `similarity_function`: The [`VectorSimilarity`] function to compare vectors with.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "Graph Create Edge Vector Index", skip_all, level = "info")
+    )]
+    pub fn create_edge_vector_index<P: Display>(
+        &mut self,
+        relation: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> FalkorResult<QueryResult<LazyResultSet>> {
+        let options = vector_index_options(dimension, similarity_function);
+        self.create_index(
+            IndexType::Vector,
+            EntityType::Edge,
+            relation,
+            properties,
+            Some(&options),
+        )
     }
 
     /// Drop an existing index, by specifying its type, entity, label and specific properties
@@ -585,6 +650,55 @@ mod tests {
             .execute()
             .expect("Could not drop index");
         assert_eq!(res.get_indices_deleted(), Some(1));
+    }
+
+    #[test]
+    fn test_create_vector_index_node_and_edge() {
+        let mut graph = open_empty_test_graph("test_vector_index_helpers");
+
+        // With the OPTIONS-encoding fix the server accepts these; previously it rejected the
+        // quoted `'dimension'` key with a parse error.
+        graph
+            .inner
+            .create_node_vector_index("Item", &["embedding"], 4, VectorSimilarity::Euclidean)
+            .expect("node vector index creation should succeed");
+        graph
+            .inner
+            .create_edge_vector_index("SIMILAR", &["v"], 8, VectorSimilarity::Cosine)
+            .expect("edge vector index creation should succeed");
+
+        let node_vec = |indices: &Vec<FalkorIndex>| {
+            indices.iter().any(|index| {
+                index.entity_type == EntityType::Node
+                    && index
+                        .field_types
+                        .get("embedding")
+                        .is_some_and(|types| types.contains(&IndexType::Vector))
+            })
+        };
+        let edge_vec = |indices: &Vec<FalkorIndex>| {
+            indices.iter().any(|index| {
+                index.entity_type == EntityType::Edge
+                    && index
+                        .field_types
+                        .get("v")
+                        .is_some_and(|types| types.contains(&IndexType::Vector))
+            })
+        };
+
+        // Indices build asynchronously; wait until both vector indices are listed.
+        let indices = retry_until(
+            || {
+                graph
+                    .inner
+                    .list_indices()
+                    .expect("Could not list indices")
+                    .data
+            },
+            |indices| node_vec(indices) && edge_vec(indices),
+        );
+        assert!(node_vec(&indices), "node vector index should be listed");
+        assert!(edge_vec(&indices), "edge vector index should be listed");
     }
 
     #[test]

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -702,6 +702,47 @@ mod tests {
     }
 
     #[test]
+    fn test_create_vector_index_op_wait() {
+        let mut graph = open_empty_test_graph("test_vector_index_op_wait");
+
+        // The typed vector `_op` builders integrate with the wait ergonomics: `.wait()` blocks
+        // until the vector index is actually operational.
+        graph
+            .inner
+            .create_node_vector_index_op("Item", &["embedding"], 4, VectorSimilarity::Euclidean)
+            .wait()
+            .expect("node vector index did not become operational");
+        graph
+            .inner
+            .create_edge_vector_index_op("SIMILAR", &["v"], 8, VectorSimilarity::Cosine)
+            .wait()
+            .expect("edge vector index did not become operational");
+
+        // After `wait()` returns, both vector indices are listed and Active.
+        let indices = graph
+            .inner
+            .list_indices()
+            .expect("Could not list indices")
+            .data;
+        assert!(indices.iter().any(|index| {
+            index.entity_type == EntityType::Node
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("embedding")
+                    .is_some_and(|types| types.contains(&IndexType::Vector))
+        }));
+        assert!(indices.iter().any(|index| {
+            index.entity_type == EntityType::Edge
+                && index.status == IndexStatus::Active
+                && index
+                    .field_types
+                    .get("v")
+                    .is_some_and(|types| types.contains(&IndexType::Vector))
+        }));
+    }
+
+    #[test]
     fn test_create_drop_index_op_wait() {
         let mut graph = open_empty_test_graph("test_create_index_op_wait");
 

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -241,7 +241,7 @@ impl SyncGraph {
         // Create index from these properties
 
         let query_str =
-            generate_create_index_query(index_field_type, entity_type, label, properties, options);
+            generate_create_index_query(index_field_type, entity_type, label, properties, options)?;
 
         QueryBuilder::<QueryResult<LazyResultSet>, String, Self>::new(
             self,

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-use crate::{EntityType, GraphSchema, IndexType};
+use crate::{EntityType, FalkorResult, GraphSchema, IndexType};
 use std::{collections::HashMap, fmt::Display};
 
 pub(crate) mod blocking;
@@ -41,7 +41,7 @@ pub(crate) fn generate_create_index_query<P: Display>(
     label: &str,
     properties: &[P],
     options: Option<&HashMap<String, String>>,
-) -> String {
+) -> FalkorResult<String> {
     let properties_string = properties
         .iter()
         .map(|element| format!("l.{}", element))
@@ -59,39 +59,41 @@ pub(crate) fn generate_create_index_query<P: Display>(
         IndexType::Fulltext => "FULLTEXT ",
     };
 
-    let options_string = options
-        .map(|hashmap| {
+    let options_string = match options {
+        Some(hashmap) => {
             let mut entries = hashmap
                 .iter()
-                .map(|(key, val)| format!("{key}: {}", format_index_option_value(val)))
-                .collect::<Vec<_>>();
+                .map(|(key, val)| Ok(format!("{key}: {}", format_index_option_value(val)?)))
+                .collect::<FalkorResult<Vec<_>>>()?;
             // Sort for deterministic output regardless of HashMap iteration order.
             entries.sort();
-            entries.join(", ")
-        })
-        .map(|options_string| format!(" OPTIONS {{ {} }}", options_string))
-        .unwrap_or_default();
+            format!(" OPTIONS {{ {} }}", entries.join(", "))
+        }
+        None => String::new(),
+    };
 
-    format!(
+    Ok(format!(
         "CREATE {idx_type}INDEX FOR {pattern} ON ({}){}",
         properties_string, options_string
-    )
+    ))
 }
 
 /// Formats a single index `OPTIONS` value as a Cypher map value.
 ///
 /// FalkorDB's `OPTIONS` map uses unquoted identifier keys and rejects quoted ones, and it expects
 /// numeric options (e.g. a vector index `dimension`) to be bare numbers rather than quoted strings.
-/// Integer-looking values are therefore emitted verbatim, while everything else is single-quoted
-/// with embedded backslashes and single quotes escaped (e.g. `'euclidean'`). The only options
-/// FalkorDB accepts today are an integer `dimension` and a string `similarityFunction`, both handled
-/// correctly here.
-fn format_index_option_value(value: &str) -> String {
+/// Integer-looking values are therefore emitted verbatim, while everything else is encoded as a
+/// single-quoted Cypher string literal via the same escaping as query parameters (see
+/// [`encode_str`](crate::value::param::encode_str)), so option values stay consistent with
+/// `to_cypher_param`. The only options FalkorDB accepts today are an integer `dimension` and a
+/// string `similarityFunction`, both handled correctly here.
+fn format_index_option_value(value: &str) -> FalkorResult<String> {
     if value.parse::<i64>().is_ok() {
-        value.to_string()
+        Ok(value.to_string())
     } else {
-        let escaped = value.replace('\\', "\\\\").replace('\'', "\\'");
-        format!("'{escaped}'")
+        let mut out = String::new();
+        crate::value::param::encode_str(value, &mut out)?;
+        Ok(out)
     }
 }
 
@@ -151,7 +153,8 @@ mod tests {
             "Person",
             &["name"],
             None,
-        );
+        )
+        .unwrap();
         assert!(query.contains("CREATE INDEX"));
         assert!(query.contains("(l:Person)"));
         assert!(query.contains("l.name"));
@@ -165,7 +168,8 @@ mod tests {
             "KNOWS",
             &["since"],
             None,
-        );
+        )
+        .unwrap();
         assert!(query.contains("CREATE INDEX"));
         assert!(query.contains("()-[l:KNOWS]->()"));
         assert!(query.contains("l.since"));
@@ -179,7 +183,8 @@ mod tests {
             "Item",
             &["embedding"],
             None,
-        );
+        )
+        .unwrap();
         assert!(query.contains("CREATE VECTOR INDEX"));
         assert!(query.contains("(l:Item)"));
         assert!(query.contains("l.embedding"));
@@ -193,7 +198,8 @@ mod tests {
             "Document",
             &["content"],
             None,
-        );
+        )
+        .unwrap();
         assert!(query.contains("CREATE FULLTEXT INDEX"));
         assert!(query.contains("(l:Document)"));
         assert!(query.contains("l.content"));
@@ -210,7 +216,8 @@ mod tests {
             "Test",
             &["field"],
             Some(&options),
-        );
+        )
+        .unwrap();
         assert!(query.contains("OPTIONS"));
         assert!(query.contains("option1"));
         assert!(query.contains("value1"));
@@ -225,7 +232,8 @@ mod tests {
             "Item",
             &["embedding"],
             Some(&options),
-        );
+        )
+        .unwrap();
         assert!(query.contains("CREATE VECTOR INDEX"));
         // Keys are unquoted, the numeric dimension is bare, and the function name is single-quoted —
         // the form FalkorDB accepts. Sorting makes the option order deterministic.
@@ -239,13 +247,20 @@ mod tests {
 
     #[test]
     fn test_format_index_option_value() {
-        assert_eq!(format_index_option_value("128"), "128");
-        assert_eq!(format_index_option_value("-3"), "-3");
-        assert_eq!(format_index_option_value("euclidean"), "'euclidean'");
+        assert_eq!(format_index_option_value("128").unwrap(), "128");
+        assert_eq!(format_index_option_value("-3").unwrap(), "-3");
+        assert_eq!(
+            format_index_option_value("euclidean").unwrap(),
+            "'euclidean'"
+        );
         // Non-integer numerics are treated as strings (quoted), keeping the emitter simple and safe.
-        assert_eq!(format_index_option_value("1.5"), "'1.5'");
-        // Embedded single quotes and backslashes are escaped.
-        assert_eq!(format_index_option_value("a'b\\c"), "'a\\'b\\\\c'");
+        assert_eq!(format_index_option_value("1.5").unwrap(), "'1.5'");
+        // String values use the same Cypher escaping as query parameters — quotes, backslashes, and
+        // control characters such as newlines.
+        assert_eq!(format_index_option_value("a'b\\c").unwrap(), "'a\\'b\\\\c'");
+        assert_eq!(format_index_option_value("a\nb").unwrap(), "'a\\nb'");
+        // A NUL byte cannot be encoded, mirroring `to_cypher_param`.
+        assert!(format_index_option_value("a\0b").is_err());
     }
 
     #[test]
@@ -263,7 +278,8 @@ mod tests {
             "Person",
             &["firstName", "lastName"],
             None,
-        );
+        )
+        .unwrap();
         assert!(query.contains("l.firstName"));
         assert!(query.contains("l.lastName"));
     }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-use crate::{EntityType, FalkorResult, GraphSchema, IndexType};
+use crate::{EntityType, FalkorDBError, FalkorResult, GraphSchema, IndexType};
 use std::{collections::HashMap, fmt::Display};
 
 pub(crate) mod blocking;
@@ -63,7 +63,18 @@ pub(crate) fn generate_create_index_query<P: Display>(
         Some(hashmap) => {
             let mut entries = hashmap
                 .iter()
-                .map(|(key, val)| Ok(format!("{key}: {}", format_index_option_value(val)?)))
+                .map(|(key, val)| {
+                    // Keys are interpolated unquoted, so they must be Cypher identifiers; reject
+                    // anything else rather than emit invalid (or injectable) Cypher.
+                    if !crate::value::param::is_bare_identifier(key) {
+                        return Err(FalkorDBError::InvalidIndexOption {
+                            key: key.clone(),
+                            message: "must be a Cypher identifier ([A-Za-z_][A-Za-z0-9_]*)"
+                                .to_string(),
+                        });
+                    }
+                    Ok(format!("{key}: {}", format_index_option_value(val)?))
+                })
                 .collect::<FalkorResult<Vec<_>>>()?;
             // Sort for deterministic output regardless of HashMap iteration order.
             entries.sort();
@@ -80,13 +91,12 @@ pub(crate) fn generate_create_index_query<P: Display>(
 
 /// Formats a single index `OPTIONS` value as a Cypher map value.
 ///
-/// FalkorDB's `OPTIONS` map uses unquoted identifier keys and rejects quoted ones, and it expects
-/// numeric options (e.g. a vector index `dimension`) to be bare numbers rather than quoted strings.
-/// Integer-looking values are therefore emitted verbatim, while everything else is encoded as a
-/// single-quoted Cypher string literal via the same escaping as query parameters (see
-/// [`encode_str`](crate::value::param::encode_str)), so option values stay consistent with
-/// `to_cypher_param`. The only options FalkorDB accepts today are an integer `dimension` and a
-/// string `similarityFunction`, both handled correctly here.
+/// FalkorDB's `OPTIONS` map expects numeric options (e.g. a vector index `dimension`) to be bare
+/// numbers rather than quoted strings. Integer-looking values are therefore emitted verbatim, while
+/// everything else is encoded as a single-quoted Cypher string literal using the same escaping as
+/// query parameters (see [`encode_str`](crate::value::param::encode_str)), so option values stay
+/// consistent with `to_cypher_param` and a NUL byte is rejected. The only options FalkorDB accepts
+/// today are an integer `dimension` and a string `similarityFunction`, both handled correctly here.
 fn format_index_option_value(value: &str) -> FalkorResult<String> {
     if value.parse::<i64>().is_ok() {
         Ok(value.to_string())
@@ -268,14 +278,36 @@ mod tests {
         // A NUL byte in an option value cannot be encoded, so query generation fails rather than
         // emitting invalid Cypher — mirroring `to_cypher_param`.
         let options = HashMap::from([("similarityFunction".to_string(), "a\0b".to_string())]);
-        assert!(generate_create_index_query(
+        let err = generate_create_index_query(
             IndexType::Vector,
             EntityType::Node,
             "Item",
             &["embedding"],
             Some(&options),
         )
-        .is_err());
+        .unwrap_err();
+        assert!(matches!(err, FalkorDBError::ParamEncoding { .. }));
+        assert!(err.to_string().contains("NUL byte"));
+    }
+
+    #[test]
+    fn test_generate_create_index_query_rejects_non_identifier_key() {
+        // An option key that is not a Cypher identifier is rejected rather than interpolated raw.
+        let options = HashMap::from([("bad-key".to_string(), "4".to_string())]);
+        let err = generate_create_index_query(
+            IndexType::Vector,
+            EntityType::Node,
+            "Item",
+            &["embedding"],
+            Some(&options),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            FalkorDBError::InvalidIndexOption { ref key, .. } if key == "bad-key"
+        ));
+        // The key is surfaced in the error message.
+        assert!(err.to_string().contains("'bad-key'"));
     }
 
     #[test]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -264,6 +264,21 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_create_index_query_rejects_unencodable_option() {
+        // A NUL byte in an option value cannot be encoded, so query generation fails rather than
+        // emitting invalid Cypher — mirroring `to_cypher_param`.
+        let options = HashMap::from([("similarityFunction".to_string(), "a\0b".to_string())]);
+        assert!(generate_create_index_query(
+            IndexType::Vector,
+            EntityType::Node,
+            "Item",
+            &["embedding"],
+            Some(&options),
+        )
+        .is_err());
+    }
+
+    #[test]
     fn test_vector_similarity_display() {
         assert_eq!(VectorSimilarity::Euclidean.to_string(), "euclidean");
         assert_eq!(VectorSimilarity::Cosine.to_string(), "cosine");

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -20,6 +20,21 @@ pub trait HasGraphSchema {
     fn get_graph_schema_mut(&mut self) -> &mut GraphSchema;
 }
 
+/// The similarity function a vector index uses when comparing vectors.
+///
+/// Passed to [`SyncGraph::create_node_vector_index`](crate::SyncGraph::create_node_vector_index)
+/// and the matching edge/async helpers. [`VectorSimilarity::Euclidean`] is the FalkorDB default.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+#[non_exhaustive]
+pub enum VectorSimilarity {
+    /// Euclidean (L2) distance — the FalkorDB default.
+    #[default]
+    Euclidean,
+    /// Cosine similarity.
+    Cosine,
+}
+
 pub(crate) fn generate_create_index_query<P: Display>(
     index_field_type: IndexType,
     entity_type: EntityType,
@@ -46,11 +61,13 @@ pub(crate) fn generate_create_index_query<P: Display>(
 
     let options_string = options
         .map(|hashmap| {
-            hashmap
+            let mut entries = hashmap
                 .iter()
-                .map(|(key, val)| format!("'{key}':'{val}'"))
-                .collect::<Vec<_>>()
-                .join(",")
+                .map(|(key, val)| format!("{key}: {}", format_index_option_value(val)))
+                .collect::<Vec<_>>();
+            // Sort for deterministic output regardless of HashMap iteration order.
+            entries.sort();
+            entries.join(", ")
         })
         .map(|options_string| format!(" OPTIONS {{ {} }}", options_string))
         .unwrap_or_default();
@@ -59,6 +76,37 @@ pub(crate) fn generate_create_index_query<P: Display>(
         "CREATE {idx_type}INDEX FOR {pattern} ON ({}){}",
         properties_string, options_string
     )
+}
+
+/// Formats a single index `OPTIONS` value as a Cypher map value.
+///
+/// FalkorDB's `OPTIONS` map uses unquoted identifier keys and rejects quoted ones, and it expects
+/// numeric options (e.g. a vector index `dimension`) to be bare numbers rather than quoted strings.
+/// Integer-looking values are therefore emitted verbatim, while everything else is single-quoted
+/// with embedded backslashes and single quotes escaped (e.g. `'euclidean'`). The only options
+/// FalkorDB accepts today are an integer `dimension` and a string `similarityFunction`, both handled
+/// correctly here.
+fn format_index_option_value(value: &str) -> String {
+    if value.parse::<i64>().is_ok() {
+        value.to_string()
+    } else {
+        let escaped = value.replace('\\', "\\\\").replace('\'', "\\'");
+        format!("'{escaped}'")
+    }
+}
+
+/// Builds the `OPTIONS` map for a vector index from its `dimension` and similarity function.
+pub(crate) fn vector_index_options(
+    dimension: u32,
+    similarity_function: VectorSimilarity,
+) -> HashMap<String, String> {
+    HashMap::from([
+        ("dimension".to_string(), dimension.to_string()),
+        (
+            "similarityFunction".to_string(),
+            similarity_function.to_string(),
+        ),
+    ])
 }
 
 pub(crate) fn generate_drop_index_query<P: Display>(
@@ -166,6 +214,45 @@ mod tests {
         assert!(query.contains("OPTIONS"));
         assert!(query.contains("option1"));
         assert!(query.contains("value1"));
+    }
+
+    #[test]
+    fn test_vector_index_options_are_valid_cypher() {
+        let options = vector_index_options(128, VectorSimilarity::Euclidean);
+        let query = generate_create_index_query(
+            IndexType::Vector,
+            EntityType::Node,
+            "Item",
+            &["embedding"],
+            Some(&options),
+        );
+        assert!(query.contains("CREATE VECTOR INDEX"));
+        // Keys are unquoted, the numeric dimension is bare, and the function name is single-quoted —
+        // the form FalkorDB accepts. Sorting makes the option order deterministic.
+        assert!(
+            query.contains("OPTIONS { dimension: 128, similarityFunction: 'euclidean' }"),
+            "{query}"
+        );
+        // The previous, server-rejected quoted-key form must never be produced.
+        assert!(!query.contains("'dimension'"));
+    }
+
+    #[test]
+    fn test_format_index_option_value() {
+        assert_eq!(format_index_option_value("128"), "128");
+        assert_eq!(format_index_option_value("-3"), "-3");
+        assert_eq!(format_index_option_value("euclidean"), "'euclidean'");
+        // Non-integer numerics are treated as strings (quoted), keeping the emitter simple and safe.
+        assert_eq!(format_index_option_value("1.5"), "'1.5'");
+        // Embedded single quotes and backslashes are escaped.
+        assert_eq!(format_index_option_value("a'b\\c"), "'a\\'b\\\\c'");
+    }
+
+    #[test]
+    fn test_vector_similarity_display() {
+        assert_eq!(VectorSimilarity::Euclidean.to_string(), "euclidean");
+        assert_eq!(VectorSimilarity::Cosine.to_string(), "cosine");
+        assert_eq!(VectorSimilarity::default(), VectorSimilarity::Euclidean);
     }
 
     #[test]

--- a/src/graph/ops/async_ops.rs
+++ b/src/graph/ops/async_ops.rs
@@ -9,9 +9,10 @@ use super::{
     classify_copy_result, owned_properties, poll_async, property_refs, ConstraintOp, IndexOp, Step,
     Wait, WaitOperation, WaitOptions,
 };
+use crate::graph::vector_index_options;
 use crate::{
     AsyncGraph, ConstraintType, EntityType, FalkorAsyncClient, FalkorResult, IndexType,
-    QueryResult, RowStream,
+    QueryResult, RowStream, VectorSimilarity,
 };
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -284,6 +285,52 @@ impl AsyncGraph {
                 label: label.to_string(),
                 properties: owned_properties(properties),
                 options: options.cloned(),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a **vector** index on a node label, supporting `.execute()`
+    /// (non-blocking) and `.wait()` (await until the index is operational). The typed counterpart of
+    /// [`create_index_op`](Self::create_index_op) for vectors; mirrors
+    /// [`AsyncGraph::create_node_vector_index`].
+    pub fn create_node_vector_index_op<P: Display>(
+        &mut self,
+        label: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> AsyncIndexOpBuilder<'_> {
+        AsyncIndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: IndexType::Vector,
+                entity_type: EntityType::Node,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+                options: Some(vector_index_options(dimension, similarity_function)),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a **vector** index on a relationship type, supporting
+    /// `.execute()` (non-blocking) and `.wait()` (await until operational). The typed counterpart of
+    /// [`create_index_op`](Self::create_index_op) for vectors; mirrors
+    /// [`AsyncGraph::create_edge_vector_index`].
+    pub fn create_edge_vector_index_op<P: Display>(
+        &mut self,
+        relation: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> AsyncIndexOpBuilder<'_> {
+        AsyncIndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: IndexType::Vector,
+                entity_type: EntityType::Edge,
+                label: relation.to_string(),
+                properties: owned_properties(properties),
+                options: Some(vector_index_options(dimension, similarity_function)),
             },
         )
     }

--- a/src/graph/ops/blocking_ops.rs
+++ b/src/graph/ops/blocking_ops.rs
@@ -9,9 +9,10 @@ use super::{
     classify_copy_result, owned_properties, poll_sync, property_refs, ConstraintOp, IndexOp, Wait,
     WaitOperation, WaitOptions,
 };
+use crate::graph::vector_index_options;
 use crate::{
     ConstraintType, EntityType, FalkorResult, FalkorSyncClient, IndexType, LazyResultSet,
-    QueryResult, SyncGraph,
+    QueryResult, SyncGraph, VectorSimilarity,
 };
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -242,6 +243,52 @@ impl SyncGraph {
                 label: label.to_string(),
                 properties: owned_properties(properties),
                 options: options.cloned(),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a **vector** index on a node label, supporting `.execute()`
+    /// (non-blocking) and `.wait()` (block until the index is operational). The typed counterpart of
+    /// [`create_index_op`](Self::create_index_op) for vectors; mirrors
+    /// [`SyncGraph::create_node_vector_index`].
+    pub fn create_node_vector_index_op<P: Display>(
+        &mut self,
+        label: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> IndexOpBuilder<'_> {
+        IndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: IndexType::Vector,
+                entity_type: EntityType::Node,
+                label: label.to_string(),
+                properties: owned_properties(properties),
+                options: Some(vector_index_options(dimension, similarity_function)),
+            },
+        )
+    }
+
+    /// Returns a builder for creating a **vector** index on a relationship type, supporting
+    /// `.execute()` (non-blocking) and `.wait()` (block until operational). The typed counterpart of
+    /// [`create_index_op`](Self::create_index_op) for vectors; mirrors
+    /// [`SyncGraph::create_edge_vector_index`].
+    pub fn create_edge_vector_index_op<P: Display>(
+        &mut self,
+        relation: &str,
+        properties: &[P],
+        dimension: u32,
+        similarity_function: VectorSimilarity,
+    ) -> IndexOpBuilder<'_> {
+        IndexOpBuilder::new(
+            self,
+            IndexOp::Create {
+                index_type: IndexType::Vector,
+                entity_type: EntityType::Edge,
+                label: relation.to_string(),
+                properties: owned_properties(properties),
+                options: Some(vector_index_options(dimension, similarity_function)),
             },
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use value::{
     graph_entities::{Edge, EntityType, Node},
     path::Path,
     point::Point,
-    temporal::{Date, DateTime, Duration, Time},
+    temporal::{Date, DateTime, Duration, Seconds, Time},
     to_cypher_param, FalkorParams, FalkorValue, FromFalkorValue, IntoFalkorParam, IntoFalkorParams,
     RawParam,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use graph::{
     blocking::SyncGraph,
     ops::{ConstraintOpBuilder, CopyGraphBuilder, IndexOpBuilder, WaitOperation, WaitOptions},
     query_builder::{ProcedureQueryBuilder, QueryBuilder},
+    VectorSimilarity,
 };
 pub use graph_schema::{GraphSchema, SchemaType};
 pub use response::{
@@ -54,6 +55,7 @@ pub use value::{
     graph_entities::{Edge, EntityType, Node},
     path::Path,
     point::Point,
+    temporal::{Date, DateTime, Duration, Time},
     to_cypher_param, FalkorParams, FalkorValue, FromFalkorValue, IntoFalkorParam, IntoFalkorParams,
     RawParam,
 };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,8 +4,8 @@
  */
 
 use crate::{
-    value::vec32::Vec32, ConfigValue, Edge, FalkorDBError, FalkorResult, FalkorValue, GraphSchema,
-    Node, Path, Point,
+    value::{temporal, vec32::Vec32},
+    ConfigValue, Edge, FalkorDBError, FalkorResult, FalkorValue, GraphSchema, Node, Path, Point,
 };
 use std::collections::HashMap;
 
@@ -24,6 +24,10 @@ pub(crate) enum ParserTypeMarker {
     Map = 10,
     Point = 11,
     Vec32 = 12,
+    DateTime = 13,
+    Date = 14,
+    Time = 15,
+    Duration = 16,
 }
 
 impl TryFrom<i64> for ParserTypeMarker {
@@ -43,6 +47,10 @@ impl TryFrom<i64> for ParserTypeMarker {
             10 => Self::Map,
             11 => Self::Point,
             12 => Self::Vec32,
+            13 => Self::DateTime,
+            14 => Self::Date,
+            15 => Self::Time,
+            16 => Self::Duration,
             _ => Err(FalkorDBError::ParsingUnknownType)?,
         })
     }
@@ -320,6 +328,10 @@ pub(crate) fn parse_type(
         ParserTypeMarker::Map => FalkorValue::Map(parse_regular_falkor_map(val, graph_schema)?),
         ParserTypeMarker::Point => FalkorValue::Point(Point::parse(val)?),
         ParserTypeMarker::Vec32 => FalkorValue::Vec32(Vec32::parse(val)?),
+        ParserTypeMarker::DateTime => FalkorValue::DateTime(temporal::DateTime::parse(val)?),
+        ParserTypeMarker::Date => FalkorValue::Date(temporal::Date::parse(val)?),
+        ParserTypeMarker::Time => FalkorValue::Time(temporal::Time::parse(val)?),
+        ParserTypeMarker::Duration => FalkorValue::Duration(temporal::Duration::parse(val)?),
     };
 
     Ok(res)
@@ -728,5 +740,80 @@ mod tests {
 
         assert_eq!(res.get("IntKey"), Some(FalkorValue::I64(1)).as_ref());
         assert_eq!(res.get("BoolKey"), Some(FalkorValue::Bool(true)).as_ref());
+    }
+
+    #[test]
+    fn test_try_from_temporal_markers() {
+        assert_eq!(
+            ParserTypeMarker::try_from(13).unwrap(),
+            ParserTypeMarker::DateTime
+        );
+        assert_eq!(
+            ParserTypeMarker::try_from(14).unwrap(),
+            ParserTypeMarker::Date
+        );
+        assert_eq!(
+            ParserTypeMarker::try_from(15).unwrap(),
+            ParserTypeMarker::Time
+        );
+        assert_eq!(
+            ParserTypeMarker::try_from(16).unwrap(),
+            ParserTypeMarker::Duration
+        );
+        // The first marker beyond the temporal range is still unknown.
+        assert_eq!(
+            ParserTypeMarker::try_from(17),
+            Err(FalkorDBError::ParsingUnknownType)
+        );
+    }
+
+    #[test]
+    fn test_parse_type_temporal_values() {
+        let mut graph_schema = GraphSchema::new("test_graph", create_empty_inner_sync_client());
+
+        assert_eq!(
+            parse_type(
+                ParserTypeMarker::DateTime,
+                redis::Value::Int(1700),
+                &mut graph_schema
+            )
+            .unwrap(),
+            FalkorValue::DateTime(temporal::DateTime::new(1700))
+        );
+        assert_eq!(
+            parse_type(
+                ParserTypeMarker::Date,
+                redis::Value::Int(-697_161_600),
+                &mut graph_schema
+            )
+            .unwrap(),
+            FalkorValue::Date(temporal::Date::new(-697_161_600))
+        );
+        assert_eq!(
+            parse_type(
+                ParserTypeMarker::Time,
+                redis::Value::Int(3600),
+                &mut graph_schema
+            )
+            .unwrap(),
+            FalkorValue::Time(temporal::Time::new(3600))
+        );
+        assert_eq!(
+            parse_type(
+                ParserTypeMarker::Duration,
+                redis::Value::Int(259_200),
+                &mut graph_schema
+            )
+            .unwrap(),
+            FalkorValue::Duration(temporal::Duration::new(259_200))
+        );
+
+        // A temporal marker over a non-integer payload surfaces a parse error.
+        assert!(parse_type(
+            ParserTypeMarker::Duration,
+            redis::Value::SimpleString("nope".to_string()),
+            &mut graph_schema
+        )
+        .is_err());
     }
 }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -31,6 +31,7 @@ use serde::forward_to_deserialize_any;
 /// | `Map`                      | a map / struct keyed by string                      |
 /// | `Node` / `Edge`            | a map / struct built from the entity's `properties` |
 /// | `Point`                    | a map / struct with `latitude` and `longitude`      |
+/// | `DateTime`/`Date`/`Time`/`Duration` | the raw temporal scalar as an [`i64`]      |
 /// | `Path` / `Unparseable`     | an error                                            |
 ///
 /// # Errors
@@ -162,6 +163,10 @@ impl<'de> Deserializer<'de> for FalkorValueDeserializer {
                 .into_iter(),
             )
             .deserialize_any(visitor),
+            FalkorValue::DateTime(datetime) => visitor.visit_i64(datetime.raw()),
+            FalkorValue::Date(date) => visitor.visit_i64(date.raw()),
+            FalkorValue::Time(time) => visitor.visit_i64(time.raw()),
+            FalkorValue::Duration(duration) => visitor.visit_i64(duration.raw()),
             FalkorValue::Path(_) => Err(FalkorDBError::SerdeError(
                 "deserializing a Path into a user type is not supported".to_string(),
             )),
@@ -510,6 +515,35 @@ mod tests {
         let value = FalkorValue::Unparseable("boom".to_string());
         let err = value.deserialize_into::<i64>().unwrap_err();
         assert!(matches!(err, FalkorDBError::SerdeError(_)));
+    }
+
+    #[test]
+    fn test_deserialize_temporal_as_i64() {
+        use crate::value::temporal::{Date, DateTime, Duration, Time};
+        assert_eq!(
+            FalkorValue::DateTime(DateTime::new(1_700_000_000))
+                .deserialize_into::<i64>()
+                .unwrap(),
+            1_700_000_000
+        );
+        assert_eq!(
+            FalkorValue::Date(Date::new(-697_161_600))
+                .deserialize_into::<i64>()
+                .unwrap(),
+            -697_161_600
+        );
+        assert_eq!(
+            FalkorValue::Time(Time::new(3600))
+                .deserialize_into::<i64>()
+                .unwrap(),
+            3600
+        );
+        assert_eq!(
+            FalkorValue::Duration(Duration::new(259_200))
+                .deserialize_into::<i64>()
+                .unwrap(),
+            259_200
+        );
     }
 
     #[test]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -163,10 +163,10 @@ impl<'de> Deserializer<'de> for FalkorValueDeserializer {
                 .into_iter(),
             )
             .deserialize_any(visitor),
-            FalkorValue::DateTime(datetime) => visitor.visit_i64(datetime.raw()),
-            FalkorValue::Date(date) => visitor.visit_i64(date.raw()),
-            FalkorValue::Time(time) => visitor.visit_i64(time.raw()),
-            FalkorValue::Duration(duration) => visitor.visit_i64(duration.raw()),
+            FalkorValue::DateTime(datetime) => visitor.visit_i64(datetime.seconds().get()),
+            FalkorValue::Date(date) => visitor.visit_i64(date.seconds().get()),
+            FalkorValue::Time(time) => visitor.visit_i64(time.seconds().get()),
+            FalkorValue::Duration(duration) => visitor.visit_i64(duration.seconds().get()),
             FalkorValue::Path(_) => Err(FalkorDBError::SerdeError(
                 "deserializing a Path into a user type is not supported".to_string(),
             )),

--- a/src/value/from_value.rs
+++ b/src/value/from_value.rs
@@ -11,6 +11,7 @@
 use crate::value::graph_entities::{Edge, Node};
 use crate::value::path::Path;
 use crate::value::point::Point;
+use crate::value::temporal::{Date, DateTime, Duration, Time};
 use crate::value::vec32::Vec32;
 use crate::{FalkorDBError, FalkorResult, FalkorValue};
 use std::collections::HashMap;
@@ -53,6 +54,10 @@ pub(crate) fn variant_name(value: &FalkorValue) -> &'static str {
         FalkorValue::F64(_) => "F64",
         FalkorValue::Point(_) => "Point",
         FalkorValue::Path(_) => "Path",
+        FalkorValue::DateTime(_) => "DateTime",
+        FalkorValue::Date(_) => "Date",
+        FalkorValue::Time(_) => "Time",
+        FalkorValue::Duration(_) => "Duration",
         FalkorValue::None => "None",
         FalkorValue::Unparseable(_) => "Unparseable",
     }
@@ -152,6 +157,10 @@ impl_entity_from_value!(
     Point => Point => "Point",
     Path => Path => "Path",
     Vec32 => Vec32 => "Vec32",
+    DateTime => DateTime => "DateTime",
+    Date => Date => "Date",
+    Time => Time => "Time",
+    Duration => Duration => "Duration",
 );
 
 impl<T: FromFalkorValue> FromFalkorValue for Option<T> {
@@ -284,6 +293,35 @@ mod tests {
     }
 
     #[test]
+    fn test_temporal_conversions() {
+        assert_eq!(
+            convert::<DateTime>(FalkorValue::DateTime(DateTime::new(5))).unwrap(),
+            DateTime::new(5)
+        );
+        assert_eq!(
+            convert::<Date>(FalkorValue::Date(Date::new(-1))).unwrap(),
+            Date::new(-1)
+        );
+        assert_eq!(
+            convert::<Time>(FalkorValue::Time(Time::new(7))).unwrap(),
+            Time::new(7)
+        );
+        assert_eq!(
+            convert::<Duration>(FalkorValue::Duration(Duration::new(9))).unwrap(),
+            Duration::new(9)
+        );
+
+        // Strict: a non-temporal value (or the wrong temporal type) is a type error.
+        assert_eq!(
+            convert::<Duration>(FalkorValue::I64(9)),
+            Err(FalkorDBError::TypeError {
+                expected: "Duration",
+                got: "I64"
+            })
+        );
+    }
+
+    #[test]
     fn test_type_error_reports_variant() {
         assert_eq!(
             convert::<i64>(FalkorValue::Bool(true)),
@@ -299,9 +337,10 @@ mod tests {
         use crate::value::graph_entities::{Edge, Node};
         use crate::value::path::Path;
         use crate::value::point::Point;
+        use crate::value::temporal::{Date, DateTime, Duration, Time};
         use crate::value::vec32::Vec32;
 
-        let cases: [(FalkorValue, &str); 13] = [
+        let cases: [(FalkorValue, &str); 17] = [
             (FalkorValue::Node(Node::default()), "Node"),
             (FalkorValue::Edge(Edge::default()), "Edge"),
             (FalkorValue::Array(vec![]), "Array"),
@@ -313,6 +352,10 @@ mod tests {
             (FalkorValue::F64(0.0), "F64"),
             (FalkorValue::Point(Point::default()), "Point"),
             (FalkorValue::Path(Path::default()), "Path"),
+            (FalkorValue::DateTime(DateTime::default()), "DateTime"),
+            (FalkorValue::Date(Date::default()), "Date"),
+            (FalkorValue::Time(Time::default()), "Time"),
+            (FalkorValue::Duration(Duration::default()), "Duration"),
             (FalkorValue::None, "None"),
             (FalkorValue::Unparseable(String::new()), "Unparseable"),
         ];

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -8,6 +8,7 @@ use graph_entities::{Edge, Node};
 use path::Path;
 use point::Point;
 use std::{collections::HashMap, fmt::Debug};
+use temporal::{Date, DateTime, Duration, Time};
 use vec32::Vec32;
 
 pub(crate) mod config;
@@ -16,6 +17,7 @@ pub(crate) mod graph_entities;
 pub(crate) mod param;
 pub(crate) mod path;
 pub(crate) mod point;
+pub(crate) mod temporal;
 pub(crate) mod vec32;
 
 #[cfg(feature = "serde")]
@@ -36,6 +38,7 @@ pub use de::{from_falkor_row, from_falkor_value, FalkorValueDeserializer};
 
 /// An enum of all the supported Falkor types
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum FalkorValue {
     /// See [`Node`]
     Node(Node),
@@ -59,6 +62,14 @@ pub enum FalkorValue {
     Point(Point),
     /// See [`Path`]
     Path(Path),
+    /// A FalkorDB `datetime` value, see [`DateTime`]
+    DateTime(DateTime),
+    /// A FalkorDB `date` value, see [`Date`]
+    Date(Date),
+    /// A FalkorDB `time`/`localtime` value, see [`Time`]
+    Time(Time),
+    /// A FalkorDB `duration` value, see [`Duration`]
+    Duration(Duration),
     /// A NULL type
     None,
     /// Failed parsing this value
@@ -168,6 +179,50 @@ impl FalkorValue {
     pub fn as_point(&self) -> Option<&Point> {
         match self {
             FalkorValue::Point(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    /// Returns a copy of the inner [`DateTime`] if this is a `DateTime` variant.
+    ///
+    /// # Returns
+    /// A copy of the inner [`DateTime`]
+    pub fn as_datetime(&self) -> Option<DateTime> {
+        match self {
+            FalkorValue::DateTime(val) => Some(*val),
+            _ => None,
+        }
+    }
+
+    /// Returns a copy of the inner [`Date`] if this is a `Date` variant.
+    ///
+    /// # Returns
+    /// A copy of the inner [`Date`]
+    pub fn as_date(&self) -> Option<Date> {
+        match self {
+            FalkorValue::Date(val) => Some(*val),
+            _ => None,
+        }
+    }
+
+    /// Returns a copy of the inner [`Time`] if this is a `Time` variant.
+    ///
+    /// # Returns
+    /// A copy of the inner [`Time`]
+    pub fn as_time(&self) -> Option<Time> {
+        match self {
+            FalkorValue::Time(val) => Some(*val),
+            _ => None,
+        }
+    }
+
+    /// Returns a copy of the inner [`Duration`] if this is a `Duration` variant.
+    ///
+    /// # Returns
+    /// A copy of the inner [`Duration`]
+    pub fn as_duration(&self) -> Option<Duration> {
+        match self {
+            FalkorValue::Duration(val) => Some(*val),
             _ => None,
         }
     }
@@ -315,6 +370,25 @@ mod tests {
 
         let non_point_val = FalkorValue::I64(42);
         assert!(non_point_val.as_point().is_none());
+    }
+
+    #[test]
+    fn test_temporal_accessors() {
+        let datetime = FalkorValue::DateTime(DateTime::new(1_700_000_000));
+        assert_eq!(datetime.as_datetime(), Some(DateTime::new(1_700_000_000)));
+        assert!(datetime.as_date().is_none());
+
+        let date = FalkorValue::Date(Date::new(-697_161_600));
+        assert_eq!(date.as_date(), Some(Date::new(-697_161_600)));
+        assert!(date.as_time().is_none());
+
+        let time = FalkorValue::Time(Time::new(3600));
+        assert_eq!(time.as_time(), Some(Time::new(3600)));
+        assert!(time.as_duration().is_none());
+
+        let duration = FalkorValue::Duration(Duration::new(259_200));
+        assert_eq!(duration.as_duration(), Some(Duration::new(259_200)));
+        assert!(duration.as_datetime().is_none());
     }
 
     #[test]

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -511,6 +511,18 @@ impl IntoFalkorParam for FalkorValue {
             FalkorValue::Node(_) => Err(param_err("a Node cannot be used as a query parameter")),
             FalkorValue::Edge(_) => Err(param_err("an Edge cannot be used as a query parameter")),
             FalkorValue::Path(_) => Err(param_err("a Path cannot be used as a query parameter")),
+            FalkorValue::DateTime(_) => Err(param_err(
+                "a DateTime cannot be used as a query parameter; build it in Cypher instead, e.g. `datetime($s)`",
+            )),
+            FalkorValue::Date(_) => Err(param_err(
+                "a Date cannot be used as a query parameter; build it in Cypher instead, e.g. `date($s)`",
+            )),
+            FalkorValue::Time(_) => Err(param_err(
+                "a Time cannot be used as a query parameter; build it in Cypher instead, e.g. `localtime($s)`",
+            )),
+            FalkorValue::Duration(_) => Err(param_err(
+                "a Duration cannot be used as a query parameter; build it in Cypher instead, e.g. `duration($s)`",
+            )),
             FalkorValue::Unparseable(_) => Err(param_err(
                 "an unparseable value cannot be used as a query parameter",
             )),
@@ -954,6 +966,15 @@ mod tests {
         use crate::value::graph_entities::Edge;
         assert!(to_cypher_param(&FalkorValue::Edge(Edge::default())).is_err());
         assert!(to_cypher_param(&FalkorValue::Unparseable("boom".to_string())).is_err());
+    }
+
+    #[test]
+    fn test_encode_temporal_values_are_rejected() {
+        use crate::value::temporal::{Date, DateTime, Duration, Time};
+        assert!(to_cypher_param(&FalkorValue::DateTime(DateTime::new(1))).is_err());
+        assert!(to_cypher_param(&FalkorValue::Date(Date::new(1))).is_err());
+        assert!(to_cypher_param(&FalkorValue::Time(Time::new(1))).is_err());
+        assert!(to_cypher_param(&FalkorValue::Duration(Duration::new(1))).is_err());
     }
 
     fn preamble_of(params: FalkorParams) -> String {

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -123,7 +123,7 @@ pub(crate) fn validate_param_name(name: &str) -> FalkorResult<()> {
 /// Verified against FalkorDB: only `\\ \' \n \r \t \b \f` are interpreted as escapes, `\uXXXX`
 /// is *not*, and a NUL byte is rejected. Every other code point (including non-ASCII) is emitted
 /// raw as UTF-8.
-fn encode_str(
+pub(crate) fn encode_str(
     s: &str,
     out: &mut String,
 ) -> FalkorResult<()> {

--- a/src/value/param.rs
+++ b/src/value/param.rs
@@ -149,7 +149,7 @@ pub(crate) fn encode_str(
     Ok(())
 }
 
-fn is_bare_identifier(key: &str) -> bool {
+pub(crate) fn is_bare_identifier(key: &str) -> bool {
     let mut chars = key.chars();
     matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
         && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')

--- a/src/value/temporal.rs
+++ b/src/value/temporal.rs
@@ -1,0 +1,169 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! FalkorDB temporal scalar values.
+//!
+//! FalkorDB encodes `datetime`, `date`, `time` and `duration` values in the compact protocol as a
+//! single signed-integer scalar (type markers 13–16). These newtypes preserve that raw scalar
+//! verbatim — the client performs no lossy calendar conversion — so callers keep full fidelity and
+//! can interpret the value with whatever date/time library they prefer.
+//!
+//! As observed from the server: `date` is seconds since the Unix epoch at UTC midnight (negative
+//! before 1970), `time`/`localtime` is a number of seconds, and `duration` is a span in seconds.
+
+use crate::{parser::redis_value_as_int, FalkorResult};
+use std::fmt;
+
+macro_rules! temporal_scalar {
+    ($(#[$meta:meta])* $name:ident, $kind:literal, $marker:literal) => {
+        $(#[$meta])*
+        #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name {
+            raw: i64,
+        }
+
+        impl $name {
+            #[doc = concat!(
+                "Wraps the raw FalkorDB scalar (compact type marker ", $marker, ") of a `", $kind,
+                "` value."
+            )]
+            pub fn new(raw: i64) -> Self {
+                Self { raw }
+            }
+
+            #[doc = concat!(
+                "Returns the raw integer scalar FalkorDB sent for this `", $kind, "` value."
+            )]
+            pub fn raw(&self) -> i64 {
+                self.raw
+            }
+
+            pub(crate) fn parse(value: redis::Value) -> FalkorResult<Self> {
+                redis_value_as_int(value).map(Self::new)
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(
+                &self,
+                f: &mut fmt::Formatter<'_>,
+            ) -> fmt::Result {
+                write!(f, "{}", self.raw)
+            }
+        }
+    };
+}
+
+temporal_scalar!(
+    /// A FalkorDB `datetime` value (compact type marker 13).
+    ///
+    /// Stores the raw signed-integer scalar FalkorDB sends; the client does not reinterpret it.
+    DateTime,
+    "datetime",
+    "13"
+);
+
+temporal_scalar!(
+    /// A FalkorDB `date` value (compact type marker 14).
+    ///
+    /// FalkorDB sends this as seconds since the Unix epoch at UTC midnight; it is negative for
+    /// dates before 1970.
+    Date,
+    "date",
+    "14"
+);
+
+temporal_scalar!(
+    /// A FalkorDB `time` / `localtime` value (compact type marker 15), expressed in seconds.
+    Time,
+    "time",
+    "15"
+);
+
+temporal_scalar!(
+    /// A FalkorDB `duration` value (compact type marker 16): a span expressed in seconds.
+    Duration,
+    "duration",
+    "16"
+);
+
+impl Duration {
+    /// Returns this duration as a number of seconds (an alias for [`Duration::raw`]).
+    pub fn as_seconds(&self) -> i64 {
+        self.raw
+    }
+
+    /// Returns this duration as a [`std::time::Duration`], or `None` if it is negative — a
+    /// [`std::time::Duration`] cannot represent a negative span.
+    pub fn as_std_duration(&self) -> Option<std::time::Duration> {
+        u64::try_from(self.raw)
+            .ok()
+            .map(std::time::Duration::from_secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FalkorDBError;
+
+    #[test]
+    fn test_new_raw_and_display() {
+        let dt = DateTime::new(1_700_000_000);
+        assert_eq!(dt.raw(), 1_700_000_000);
+        assert_eq!(dt.to_string(), "1700000000");
+
+        let date = Date::new(-697_161_600);
+        assert_eq!(date.raw(), -697_161_600);
+        assert_eq!(date.to_string(), "-697161600");
+
+        let time = Time::new(3600);
+        assert_eq!(time.raw(), 3600);
+        assert_eq!(time.to_string(), "3600");
+    }
+
+    #[test]
+    fn test_parse_reads_int() {
+        assert_eq!(
+            DateTime::parse(redis::Value::Int(42)).unwrap(),
+            DateTime::new(42)
+        );
+        assert_eq!(Date::parse(redis::Value::Int(-1)).unwrap(), Date::new(-1));
+        assert_eq!(Time::parse(redis::Value::Int(7)).unwrap(), Time::new(7));
+        assert_eq!(
+            Duration::parse(redis::Value::Int(259_200)).unwrap(),
+            Duration::new(259_200)
+        );
+    }
+
+    #[test]
+    fn test_parse_rejects_non_int() {
+        let err = Duration::parse(redis::Value::SimpleString("nope".to_string())).unwrap_err();
+        assert_eq!(err, FalkorDBError::ParsingI64);
+    }
+
+    #[test]
+    fn test_duration_helpers() {
+        let three_days = Duration::new(259_200);
+        assert_eq!(three_days.raw(), 259_200);
+        assert_eq!(three_days.to_string(), "259200");
+        assert_eq!(three_days.as_seconds(), 259_200);
+        assert_eq!(
+            three_days.as_std_duration(),
+            Some(std::time::Duration::from_secs(259_200))
+        );
+
+        // A negative span has no std::time::Duration representation.
+        let negative = Duration::new(-1);
+        assert_eq!(negative.as_seconds(), -1);
+        assert_eq!(negative.as_std_duration(), None);
+    }
+
+    #[test]
+    fn test_ordering_and_default() {
+        assert_eq!(Date::default(), Date::new(0));
+        assert!(Time::new(1) < Time::new(2));
+    }
+}

--- a/src/value/temporal.rs
+++ b/src/value/temporal.rs
@@ -6,38 +6,134 @@
 //! FalkorDB temporal scalar values.
 //!
 //! FalkorDB encodes `datetime`, `date`, `time` and `duration` values in the compact protocol as a
-//! single signed-integer scalar (type markers 13–16). These newtypes preserve that raw scalar
-//! verbatim — the client performs no lossy calendar conversion — so callers keep full fidelity and
-//! can interpret the value with whatever date/time library they prefer.
+//! single signed-integer scalar (type markers 13–16). These newtypes preserve that scalar verbatim
+//! — the client performs no lossy calendar conversion — so callers keep full fidelity and can
+//! interpret the value with whatever date/time library they prefer.
+//!
+//! Each value exposes its scalar as a typed [`Seconds`] (rather than a bare `i64`), and the instant
+//! types support a small, type-safe algebra: subtracting two [`DateTime`]s yields a [`Duration`],
+//! and a [`DateTime`] can be shifted by a [`Duration`]. Nonsensical combinations (e.g. adding two
+//! instants) simply have no impl and fail to compile.
 //!
 //! As observed from the server: `date` is seconds since the Unix epoch at UTC midnight (negative
 //! before 1970), `time`/`localtime` is a number of seconds, and `duration` is a span in seconds.
 
 use crate::{parser::redis_value_as_int, FalkorResult};
 use std::fmt;
+use std::ops::{Add, Neg, Sub};
+
+/// A signed number of seconds — the scalar carried by every FalkorDB temporal value.
+///
+/// This newtype keeps a temporal scalar from being silently mixed with an arbitrary integer; call
+/// [`Seconds::get`] (or use the [`From`] conversions) for the underlying `i64`. The plain `+`/`-`
+/// operators follow `i64` semantics (they panic on overflow in debug builds); the `checked_*`
+/// methods return [`None`] on overflow instead.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Seconds(i64);
+
+impl Seconds {
+    /// Wraps a raw number of seconds.
+    pub const fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying number of seconds.
+    pub const fn get(self) -> i64 {
+        self.0
+    }
+
+    /// Adds two second counts, returning [`None`] on `i64` overflow.
+    pub fn checked_add(
+        self,
+        rhs: Seconds,
+    ) -> Option<Seconds> {
+        self.0.checked_add(rhs.0).map(Seconds)
+    }
+
+    /// Subtracts two second counts, returning [`None`] on `i64` overflow.
+    pub fn checked_sub(
+        self,
+        rhs: Seconds,
+    ) -> Option<Seconds> {
+        self.0.checked_sub(rhs.0).map(Seconds)
+    }
+
+    /// Negates this second count, returning [`None`] on `i64` overflow (i.e. `i64::MIN`).
+    pub fn checked_neg(self) -> Option<Seconds> {
+        self.0.checked_neg().map(Seconds)
+    }
+}
+
+impl fmt::Display for Seconds {
+    fn fmt(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<i64> for Seconds {
+    fn from(value: i64) -> Self {
+        Seconds(value)
+    }
+}
+
+impl From<Seconds> for i64 {
+    fn from(value: Seconds) -> Self {
+        value.0
+    }
+}
+
+impl Add for Seconds {
+    type Output = Seconds;
+    fn add(
+        self,
+        rhs: Seconds,
+    ) -> Seconds {
+        Seconds(self.0 + rhs.0)
+    }
+}
+
+impl Sub for Seconds {
+    type Output = Seconds;
+    fn sub(
+        self,
+        rhs: Seconds,
+    ) -> Seconds {
+        Seconds(self.0 - rhs.0)
+    }
+}
+
+impl Neg for Seconds {
+    type Output = Seconds;
+    fn neg(self) -> Seconds {
+        Seconds(-self.0)
+    }
+}
 
 macro_rules! temporal_scalar {
     ($(#[$meta:meta])* $name:ident, $kind:literal, $marker:literal) => {
         $(#[$meta])*
         #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
         pub struct $name {
-            raw: i64,
+            secs: i64,
         }
 
         impl $name {
             #[doc = concat!(
                 "Wraps the raw FalkorDB scalar (compact type marker ", $marker, ") of a `", $kind,
-                "` value."
+                "` value, in seconds."
             )]
-            pub fn new(raw: i64) -> Self {
-                Self { raw }
+            pub const fn new(seconds: i64) -> Self {
+                Self { secs: seconds }
             }
 
             #[doc = concat!(
-                "Returns the raw integer scalar FalkorDB sent for this `", $kind, "` value."
+                "Returns this `", $kind, "` value's scalar as a typed [`Seconds`]."
             )]
-            pub fn raw(&self) -> i64 {
-                self.raw
+            pub const fn seconds(self) -> Seconds {
+                Seconds::new(self.secs)
             }
 
             pub(crate) fn parse(value: redis::Value) -> FalkorResult<Self> {
@@ -50,16 +146,17 @@ macro_rules! temporal_scalar {
                 &self,
                 f: &mut fmt::Formatter<'_>,
             ) -> fmt::Result {
-                write!(f, "{}", self.raw)
+                write!(f, "{}", self.secs)
             }
         }
     };
 }
 
 temporal_scalar!(
-    /// A FalkorDB `datetime` value (compact type marker 13).
+    /// A FalkorDB `datetime` value (compact type marker 13): seconds since the Unix epoch (UTC).
     ///
-    /// Stores the raw signed-integer scalar FalkorDB sends; the client does not reinterpret it.
+    /// Supports type-safe arithmetic: subtract two `DateTime`s for a [`Duration`], or add/subtract a
+    /// [`Duration`] to shift the instant.
     DateTime,
     "datetime",
     "13"
@@ -84,23 +181,139 @@ temporal_scalar!(
 
 temporal_scalar!(
     /// A FalkorDB `duration` value (compact type marker 16): a span expressed in seconds.
+    ///
+    /// Supports type-safe arithmetic: add or subtract `Duration`s, negate one, or shift a
+    /// [`DateTime`] by it.
     Duration,
     "duration",
     "16"
 );
 
-impl Duration {
-    /// Returns this duration as a number of seconds (an alias for [`Duration::raw`]).
-    pub fn as_seconds(&self) -> i64 {
-        self.raw
+impl DateTime {
+    /// Returns the [`Duration`] elapsed from `earlier` until `self`, or [`None`] on `i64` overflow.
+    pub fn checked_duration_since(
+        self,
+        earlier: DateTime,
+    ) -> Option<Duration> {
+        self.secs.checked_sub(earlier.secs).map(Duration::new)
     }
 
-    /// Returns this duration as a [`std::time::Duration`], or `None` if it is negative — a
+    /// Shifts this instant forward by `rhs`, returning [`None`] on `i64` overflow.
+    pub fn checked_add(
+        self,
+        rhs: Duration,
+    ) -> Option<DateTime> {
+        self.secs.checked_add(rhs.secs).map(DateTime::new)
+    }
+
+    /// Shifts this instant backward by `rhs`, returning [`None`] on `i64` overflow.
+    pub fn checked_sub(
+        self,
+        rhs: Duration,
+    ) -> Option<DateTime> {
+        self.secs.checked_sub(rhs.secs).map(DateTime::new)
+    }
+}
+
+/// `DateTime - DateTime` yields the [`Duration`] between the two instants.
+impl Sub<DateTime> for DateTime {
+    type Output = Duration;
+    fn sub(
+        self,
+        rhs: DateTime,
+    ) -> Duration {
+        Duration::new(self.secs - rhs.secs)
+    }
+}
+
+/// `DateTime + Duration` shifts the instant forward.
+impl Add<Duration> for DateTime {
+    type Output = DateTime;
+    fn add(
+        self,
+        rhs: Duration,
+    ) -> DateTime {
+        DateTime::new(self.secs + rhs.secs)
+    }
+}
+
+/// `DateTime - Duration` shifts the instant backward.
+impl Sub<Duration> for DateTime {
+    type Output = DateTime;
+    fn sub(
+        self,
+        rhs: Duration,
+    ) -> DateTime {
+        DateTime::new(self.secs - rhs.secs)
+    }
+}
+
+/// `Duration + DateTime` shifts the instant forward (commutative with `DateTime + Duration`).
+impl Add<DateTime> for Duration {
+    type Output = DateTime;
+    fn add(
+        self,
+        rhs: DateTime,
+    ) -> DateTime {
+        DateTime::new(self.secs + rhs.secs)
+    }
+}
+
+impl Duration {
+    /// Returns this duration as a [`std::time::Duration`], or [`None`] if it is negative — a
     /// [`std::time::Duration`] cannot represent a negative span.
-    pub fn as_std_duration(&self) -> Option<std::time::Duration> {
-        u64::try_from(self.raw)
+    pub fn as_std_duration(self) -> Option<std::time::Duration> {
+        u64::try_from(self.secs)
             .ok()
             .map(std::time::Duration::from_secs)
+    }
+
+    /// Adds another [`Duration`], returning [`None`] on `i64` overflow.
+    pub fn checked_add(
+        self,
+        rhs: Duration,
+    ) -> Option<Duration> {
+        self.secs.checked_add(rhs.secs).map(Duration::new)
+    }
+
+    /// Subtracts another [`Duration`], returning [`None`] on `i64` overflow.
+    pub fn checked_sub(
+        self,
+        rhs: Duration,
+    ) -> Option<Duration> {
+        self.secs.checked_sub(rhs.secs).map(Duration::new)
+    }
+
+    /// Negates this duration, returning [`None`] on `i64` overflow (i.e. `i64::MIN`).
+    pub fn checked_neg(self) -> Option<Duration> {
+        self.secs.checked_neg().map(Duration::new)
+    }
+}
+
+impl Add for Duration {
+    type Output = Duration;
+    fn add(
+        self,
+        rhs: Duration,
+    ) -> Duration {
+        Duration::new(self.secs + rhs.secs)
+    }
+}
+
+impl Sub for Duration {
+    type Output = Duration;
+    fn sub(
+        self,
+        rhs: Duration,
+    ) -> Duration {
+        Duration::new(self.secs - rhs.secs)
+    }
+}
+
+impl Neg for Duration {
+    type Output = Duration;
+    fn neg(self) -> Duration {
+        Duration::new(-self.secs)
     }
 }
 
@@ -110,18 +323,22 @@ mod tests {
     use crate::FalkorDBError;
 
     #[test]
-    fn test_new_raw_and_display() {
+    fn test_new_seconds_and_display() {
         let dt = DateTime::new(1_700_000_000);
-        assert_eq!(dt.raw(), 1_700_000_000);
+        assert_eq!(dt.seconds(), Seconds::new(1_700_000_000));
         assert_eq!(dt.to_string(), "1700000000");
 
         let date = Date::new(-697_161_600);
-        assert_eq!(date.raw(), -697_161_600);
+        assert_eq!(date.seconds().get(), -697_161_600);
         assert_eq!(date.to_string(), "-697161600");
 
         let time = Time::new(3600);
-        assert_eq!(time.raw(), 3600);
+        assert_eq!(time.seconds(), Seconds::new(3600));
         assert_eq!(time.to_string(), "3600");
+
+        let dur = Duration::new(259_200);
+        assert_eq!(dur.seconds(), Seconds::new(259_200));
+        assert_eq!(dur.to_string(), "259200");
     }
 
     #[test]
@@ -145,25 +362,99 @@ mod tests {
     }
 
     #[test]
-    fn test_duration_helpers() {
+    fn test_ordering_and_default() {
+        assert_eq!(Date::default(), Date::new(0));
+        assert!(Time::new(1) < Time::new(2));
+    }
+
+    #[test]
+    fn test_seconds_scalar() {
+        let s = Seconds::new(10);
+        assert_eq!(s.get(), 10);
+        assert_eq!(s.to_string(), "10");
+        assert_eq!(Seconds::from(5), Seconds::new(5));
+        assert_eq!(i64::from(Seconds::new(8)), 8);
+        assert_eq!(Seconds::default(), Seconds::new(0));
+
+        // Operators.
+        assert_eq!(Seconds::new(3) + Seconds::new(4), Seconds::new(7));
+        assert_eq!(Seconds::new(7) - Seconds::new(4), Seconds::new(3));
+        assert_eq!(-Seconds::new(3), Seconds::new(-3));
+
+        // Checked arithmetic.
+        assert_eq!(
+            Seconds::new(10).checked_add(Seconds::new(5)),
+            Some(Seconds::new(15))
+        );
+        assert_eq!(Seconds::new(i64::MAX).checked_add(Seconds::new(1)), None);
+        assert_eq!(
+            Seconds::new(10).checked_sub(Seconds::new(4)),
+            Some(Seconds::new(6))
+        );
+        assert_eq!(Seconds::new(i64::MIN).checked_sub(Seconds::new(1)), None);
+        assert_eq!(Seconds::new(3).checked_neg(), Some(Seconds::new(-3)));
+        assert_eq!(Seconds::new(i64::MIN).checked_neg(), None);
+    }
+
+    #[test]
+    fn test_datetime_duration_algebra() {
+        // instant - instant = span
+        assert_eq!(DateTime::new(100) - DateTime::new(40), Duration::new(60));
+        // instant ± span = instant
+        assert_eq!(DateTime::new(100) + Duration::new(5), DateTime::new(105));
+        assert_eq!(DateTime::new(100) - Duration::new(5), DateTime::new(95));
+        // span + instant = instant (commutative)
+        assert_eq!(Duration::new(5) + DateTime::new(100), DateTime::new(105));
+        // span arithmetic
+        assert_eq!(Duration::new(3) + Duration::new(4), Duration::new(7));
+        assert_eq!(Duration::new(7) - Duration::new(4), Duration::new(3));
+        assert_eq!(-Duration::new(3), Duration::new(-3));
+    }
+
+    #[test]
+    fn test_datetime_checked_arithmetic() {
+        assert_eq!(
+            DateTime::new(10).checked_duration_since(DateTime::new(4)),
+            Some(Duration::new(6))
+        );
+        assert_eq!(
+            DateTime::new(i64::MIN).checked_duration_since(DateTime::new(1)),
+            None
+        );
+        assert_eq!(
+            DateTime::new(10).checked_add(Duration::new(5)),
+            Some(DateTime::new(15))
+        );
+        assert_eq!(DateTime::new(i64::MAX).checked_add(Duration::new(1)), None);
+        assert_eq!(
+            DateTime::new(10).checked_sub(Duration::new(3)),
+            Some(DateTime::new(7))
+        );
+        assert_eq!(DateTime::new(i64::MIN).checked_sub(Duration::new(1)), None);
+    }
+
+    #[test]
+    fn test_duration_helpers_and_checked() {
         let three_days = Duration::new(259_200);
-        assert_eq!(three_days.raw(), 259_200);
-        assert_eq!(three_days.to_string(), "259200");
-        assert_eq!(three_days.as_seconds(), 259_200);
+        assert_eq!(three_days.seconds().get(), 259_200);
         assert_eq!(
             three_days.as_std_duration(),
             Some(std::time::Duration::from_secs(259_200))
         );
-
         // A negative span has no std::time::Duration representation.
-        let negative = Duration::new(-1);
-        assert_eq!(negative.as_seconds(), -1);
-        assert_eq!(negative.as_std_duration(), None);
-    }
+        assert_eq!(Duration::new(-1).as_std_duration(), None);
 
-    #[test]
-    fn test_ordering_and_default() {
-        assert_eq!(Date::default(), Date::new(0));
-        assert!(Time::new(1) < Time::new(2));
+        assert_eq!(
+            Duration::new(3).checked_add(Duration::new(4)),
+            Some(Duration::new(7))
+        );
+        assert_eq!(Duration::new(i64::MAX).checked_add(Duration::new(1)), None);
+        assert_eq!(
+            Duration::new(7).checked_sub(Duration::new(4)),
+            Some(Duration::new(3))
+        );
+        assert_eq!(Duration::new(i64::MIN).checked_sub(Duration::new(1)), None);
+        assert_eq!(Duration::new(3).checked_neg(), Some(Duration::new(-3)));
+        assert_eq!(Duration::new(i64::MIN).checked_neg(), None);
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1567,7 +1567,7 @@ mod async_batch_pipelining {
 
 mod temporal_values {
     use super::{get_test_connection_info, skip_if_no_server};
-    use falkordb::{Date, Duration, FalkorClientBuilder, Time};
+    use falkordb::{Date, DateTime, Duration, FalkorClientBuilder, Time};
 
     fn graph_for(name: &str) -> Option<falkordb::SyncGraph> {
         if skip_if_no_server() {
@@ -1602,20 +1602,26 @@ mod temporal_values {
 
         // `date('1947-11-29')` is seconds since the Unix epoch at UTC midnight (negative, pre-1970).
         let d: Date = row.try_get("d").expect("date column");
-        assert_eq!(d.raw(), -697_161_600);
+        assert_eq!(d.seconds().get(), -697_161_600);
 
         // `localtime()` is a `Time`; its exact value is dynamic, so just assert it decoded into the
         // typed value (rather than `Unparseable`). Temporal scalars are non-negative.
         let t: Time = row.try_get("t").expect("time column");
-        assert!(t.raw() >= 0);
+        assert!(t.seconds().get() >= 0);
 
         // `duration({days: 3})` is 3 * 86400 seconds.
         let dur: Duration = row.try_get("dur").expect("duration column");
-        assert_eq!(dur.as_seconds(), 259_200);
+        assert_eq!(dur.seconds().get(), 259_200);
         assert_eq!(
             dur.as_std_duration(),
             Some(std::time::Duration::from_secs(259_200))
         );
+
+        // The typed instant/span algebra composes as expected: shifting an instant by a duration
+        // and back is a no-op.
+        let instant = DateTime::new(d.seconds().get());
+        assert_eq!(instant + dur - dur, instant);
+        assert_eq!((instant - instant), Duration::new(0));
 
         let _ = graph.delete();
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1583,15 +1583,18 @@ mod temporal_values {
         Some(graph)
     }
 
-    /// End-to-end: FalkorDB temporal scalars (markers 14/15/16) decode into the typed
-    /// `Date` / `Time` / `Duration` values rather than surfacing as `Unparseable`.
+    /// End-to-end: FalkorDB temporal scalars (markers 13/14/15/16) decode into the typed
+    /// `DateTime` / `Date` / `Time` / `Duration` values rather than surfacing as `Unparseable`.
     #[test]
     fn test_temporal_values_round_trip() {
         let Some(mut graph) = graph_for("test_temporal_round_trip") else {
             return;
         };
         let mut result = graph
-            .query("RETURN date('1947-11-29') AS d, localtime() AS t, duration({days: 3}) AS dur")
+            .query(
+                "RETURN date('1947-11-29') AS d, localdatetime('1947-11-29T00:00:00') AS dt, \
+                 localtime() AS t, duration({days: 3}) AS dur",
+            )
             .execute()
             .expect("temporal query should succeed");
         let row = result
@@ -1603,6 +1606,10 @@ mod temporal_values {
         // `date('1947-11-29')` is seconds since the Unix epoch at UTC midnight (negative, pre-1970).
         let d: Date = row.try_get("d").expect("date column");
         assert_eq!(d.seconds().get(), -697_161_600);
+
+        // `localdatetime('1947-11-29T00:00:00')` is the same instant decoded as a `DateTime` (marker 13).
+        let dt: DateTime = row.try_get("dt").expect("datetime column");
+        assert_eq!(dt.seconds().get(), -697_161_600);
 
         // `localtime()` is a `Time`; its exact value is dynamic, so just assert it decoded into the
         // typed value (rather than `Unparseable`). A `localtime`/`time` scalar is non-negative —

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1605,7 +1605,8 @@ mod temporal_values {
         assert_eq!(d.seconds().get(), -697_161_600);
 
         // `localtime()` is a `Time`; its exact value is dynamic, so just assert it decoded into the
-        // typed value (rather than `Unparseable`). Temporal scalars are non-negative.
+        // typed value (rather than `Unparseable`). A `localtime`/`time` scalar is non-negative —
+        // unlike `date`/`datetime`, which are negative before 1970 (see `d` above).
         let t: Time = row.try_get("t").expect("time column");
         assert!(t.seconds().get() >= 0);
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1564,3 +1564,59 @@ mod async_batch_pipelining {
         graph.delete().await.expect("delete");
     }
 }
+
+mod temporal_values {
+    use super::{get_test_connection_info, skip_if_no_server};
+    use falkordb::{Date, Duration, FalkorClientBuilder, Time};
+
+    fn graph_for(name: &str) -> Option<falkordb::SyncGraph> {
+        if skip_if_no_server() {
+            return None;
+        }
+        let conn_info = get_test_connection_info().ok()?;
+        let client = FalkorClientBuilder::new()
+            .with_connection_info(conn_info)
+            .build()
+            .ok()?;
+        let mut graph = client.select_graph(name);
+        let _ = graph.delete();
+        Some(graph)
+    }
+
+    /// End-to-end: FalkorDB temporal scalars (markers 14/15/16) decode into the typed
+    /// `Date` / `Time` / `Duration` values rather than surfacing as `Unparseable`.
+    #[test]
+    fn test_temporal_values_round_trip() {
+        let Some(mut graph) = graph_for("test_temporal_round_trip") else {
+            return;
+        };
+        let mut result = graph
+            .query("RETURN date('1947-11-29') AS d, localtime() AS t, duration({days: 3}) AS dur")
+            .execute()
+            .expect("temporal query should succeed");
+        let row = result
+            .data
+            .next()
+            .expect("expected a row")
+            .expect("row should parse");
+
+        // `date('1947-11-29')` is seconds since the Unix epoch at UTC midnight (negative, pre-1970).
+        let d: Date = row.try_get("d").expect("date column");
+        assert_eq!(d.raw(), -697_161_600);
+
+        // `localtime()` is a `Time`; its exact value is dynamic, so just assert it decoded into the
+        // typed value (rather than `Unparseable`). Temporal scalars are non-negative.
+        let t: Time = row.try_get("t").expect("time column");
+        assert!(t.raw() >= 0);
+
+        // `duration({days: 3})` is 3 * 86400 seconds.
+        let dur: Duration = row.try_get("dur").expect("duration column");
+        assert_eq!(dur.as_seconds(), 259_200);
+        assert_eq!(
+            dur.as_std_duration(),
+            Some(std::time::Duration::from_secs(259_200))
+        );
+
+        let _ = graph.delete();
+    }
+}


### PR DESCRIPTION
## What & why

Closes gaps found by comparing the Rust client against the Python client (`falkordb-py`). Most of the original comparison items were **already implemented** on `main` (typed injection-proof params, serde row mapping, the `call_procedure().with_args()` fix). The genuinely-remaining, verifiable gaps are addressed here.

### 1. Temporal value types
FalkorDB encodes `datetime`/`date`/`time`/`duration` in the compact protocol as `[marker, i64]` (markers **13–16**). The client only knew markers 1–12, so temporal values silently fell through to `FalkorValue::Unparseable`. They now decode into typed `DateTime` / `Date` / `Time` / `Duration` values, each preserving the raw FalkorDB scalar (`.raw()`); `Duration` also exposes `.as_seconds()` / `.as_std_duration()`. Wired through the parser, `FromFalkorValue`, the `serde` deserializer, and `FalkorValue::as_*` accessors. Verified end-to-end against a live server.

Temporal values **cannot be bound as query parameters** (there is no safe Cypher literal); attempting it returns a clear error, consistent with `Node`/`Edge`/`Path`.

### 2. Vector index creation was broken — fixed
`create_index` with `IndexType::Vector` generated `OPTIONS { 'dimension':'4', ... }` (quoted keys), which FalkorDB **rejects** with a parse error. Options now use unquoted identifier keys and emit numeric values (e.g. a vector `dimension`) unquoted, producing `OPTIONS { dimension: 4, similarityFunction: 'euclidean' }`. Added typed helpers **`create_node_vector_index` / `create_edge_vector_index`** (sync + async) and a **`VectorSimilarity`** enum (`Euclidean` / `Cosine`). Verified the generated Cypher is accepted by a live server for node + edge indexes.

## ⚠️ Breaking change
`FalkorValue` is now `#[non_exhaustive]` and has four new variants. Exhaustive `match` expressions over a `FalkorValue` must add a wildcard (`_ => …`) arm. Documented in `CHANGELOG.md`.

## Out of scope (deliberately deferred)
- **Redis Cluster auto-detection** (Python has it): large, and cannot reach the 100%-coverage bar on a single-node test server. Better as its own PR.
- **`flushdb`** (Python has it): `FLUSHDB` is a *global, destructive* op — it wipes every graph (including the shared `imdb` test fixture), and FalkorDB graphs are **not** isolated by logical DB. There is no `None`-backed async executor to cover it safely, so it can't be added without an isolated/embedded CI harness. Deferred rather than ship a half-covered destructive command.

## Testing
- New unit tests cover every new branch (parser markers, value accessors, `FromFalkorValue`, serde, param rejection, the `OPTIONS` encoder, `VectorSimilarity`).
- New server-backed tests: temporal round-trip and sync+async vector-index helpers.
- **All new code is 100% covered** (`temporal.rs` and `graph/mod.rs` are 100%; remaining file-level gaps are pre-existing).
- Full local gate green: `just done` and `just test` (657 passed).
- `llms.txt` regenerated for the new public API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Typed decoding into `DateTime`, `Date`, `Time`, and `Duration`, with `seconds()` access, plus safe checked temporal arithmetic.
  * Added `VectorSimilarity` and new typed vector-index helpers (dimension + similarity), including async and operation-builder variants.
* **Bug Fixes**
  * Vector index `OPTIONS` now generate valid Cypher (unquoted identifier keys and correctly formatted values).
* **Breaking Changes**
  * `FalkorValue` is now `#[non_exhaustive]` and includes new temporal variants (wildcard matches required).
* **Documentation**
  * Updated README, changelog, and added `temporal` and `vector_index` examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->