### PR TITLE
feat!: make replica routing for read-only queries opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in replica routing for read-only queries via a new `ReadPreference` enum (`Primary`, the
+  default, and `PreferReplica`). Set a client-wide default with
+  `FalkorClientBuilder::with_read_preference`, or override per request with the `with_read_preference`
+  method (and `prefer_replica()` / `primary_only()` shortcuts) on `QueryBuilder`,
+  `ProcedureQueryBuilder` and `BatchBuilder`. Adds `FalkorSyncClient`/`FalkorAsyncClient` accessors
+  `replica_reads_available()` (whether replica connections exist) and `read_preference()` (the
+  client default) ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+
+### Changed
+
+- **Breaking (behavior):** read-only queries (`ro_query` / `call_procedure_ro`) and all-read batches
+  now run on the **primary by default** instead of being routed to a replica automatically. Replicas
+  apply writes only after the primary, so replica reads can be stale; routing them is now opt-in for
+  accuracy. **To restore the previous replica offload, build the client with
+  `.with_read_preference(ReadPreference::PreferReplica)`** (or opt in per request with
+  `prefer_replica()`). Requesting a replica for a writable query, procedure or batch now fails with
+  the new `FalkorDBError::ReadPreferenceNotReadOnly`. See the
+  [0.10 migration guide](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.10.md)
+  ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+- **Deprecated:** `FalkorSyncClient::reads_from_replicas` and `FalkorAsyncClient::reads_from_replicas`
+  in favor of `replica_reads_available()` (replica capability) plus `read_preference()` (the routing
+  policy), since a replica pool can now exist without reads being routed to it
+  ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+
 ### Other
 
 - The `README.md` is now generated from the crate-level `//!` documentation in `src/lib.rs` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   method (and `prefer_replica()` / `primary_only()` shortcuts) on `QueryBuilder`,
   `ProcedureQueryBuilder` and `BatchBuilder`. Adds `FalkorSyncClient`/`FalkorAsyncClient` accessors
   `replica_reads_available()` (whether replica connections exist) and `read_preference()` (the
-  client default) ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+  client default) ([#277](https://github.com/FalkorDB/falkordb-rs/pull/277))
 
 ### Changed
 
@@ -26,11 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `prefer_replica()`). Requesting a replica for a writable query, procedure or batch now fails with
   the new `FalkorDBError::ReadPreferenceNotReadOnly`. See the
   [0.10 migration guide](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.10.md)
-  ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+  ([#277](https://github.com/FalkorDB/falkordb-rs/pull/277))
 - **Deprecated:** `FalkorSyncClient::reads_from_replicas` and `FalkorAsyncClient::reads_from_replicas`
   in favor of `replica_reads_available()` (replica capability) plus `read_preference()` (the routing
   policy), since a replica pool can now exist without reads being routed to it
-  ([#PRNUM](https://github.com/FalkorDB/falkordb-rs/pull/PRNUM))
+  ([#277](https://github.com/FalkorDB/falkordb-rs/pull/277))
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ OpenTelemetry-aligned tracing and metrics.
 - **Async streaming** — result sets are `Stream`s that compose with the full `futures` toolbox.
 - **Resilient** — opt-in `RetryPolicy` with bounded backoff for transient failures; writes are never retried.
 - **Observable** — OpenTelemetry-aligned `tracing` spans and `metrics` counters/histograms, privacy-safe by default.
-- **Replica-aware** — routes read-only queries to replicas behind Redis Sentinel.
+- **Replica-aware** — opt in to routing read-only queries to replicas behind Redis Sentinel.
 - **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping.
 
 ## Table of contents
@@ -606,44 +606,63 @@ let client = FalkorClientBuilder::new()
 
 #### Read-only queries and replica routing
 
-Read-only queries (`ro_query` and `call_procedure_ro`) can be served from
-replica nodes, taking read load off the primary. When the client connects to a
-Redis Sentinel deployment that exposes readable replicas, it automatically
-builds a dedicated read-only connection pool that routes those queries to a
-replica. Writes always go to the primary.
+Read-only queries (`ro_query` and `call_procedure_ro`) send `GRAPH.RO_QUERY`, which the server
+refuses to let write. *Where* such a query runs is a separate, **opt-in** choice expressed with
+`ReadPreference`. Because a FalkorDB replica applies writes only **after** the primary, a read
+served from a replica can be slightly **stale**, so the default (`ReadPreference::Primary`)
+keeps every read on the primary — you never observe replication lag unless you ask for it.
+
+Opt into replicas either per client or per query:
+
+- **Per client** — `with_read_preference` sets the
+  default for every read-only query.
+- **Per query** — `prefer_replica` opts a single query in, and
+  `primary_only` forces one back onto the primary (read-your-writes).
+  The per-query choice overrides the client default.
+
+Replica routing requires a Redis Sentinel deployment that exposes readable replicas; when none is
+available (for example a single node), `ReadPreference::PreferReplica` transparently falls back
+to the primary, so the same code runs everywhere. Writes always go to the primary — asking for a
+replica on a writable `query`/`call_procedure`/batch fails with
+`FalkorDBError::ReadPreferenceNotReadOnly`.
 
 > **Connection pool sizing:** When readable replicas are present the client opens
 > a second pool of up to `num_connections` additional connections (one per slot)
-> alongside the primary pool. Size your pool limits and file-descriptor limits
-> accordingly.
+> alongside the primary pool, regardless of the read preference. Size your pool limits and
+> file-descriptor limits accordingly.
 
 ```rust
-use falkordb::FalkorClientBuilder;
+use falkordb::{FalkorClientBuilder, ReadPreference};
 
 let client = FalkorClientBuilder::new()
     // A Sentinel endpoint, e.g. falkor://127.0.0.1:26379
     .with_connection_info("falkor://127.0.0.1:26379".try_into().expect("Invalid connection info"))
+    // Prefer replicas for this client's read-only queries (accepts slightly stale reads).
+    .with_read_preference(ReadPreference::PreferReplica)
     .build()
     .expect("Failed to build client");
 
-// `true` only when readable replicas are available.
-if client.reads_from_replicas() {
-    println!("Read-only queries are routed to replicas");
+// Capability (a replica pool exists) vs policy (the default routing).
+if client.replica_reads_available() {
+    println!("Replica connections are available");
 }
+println!("Default read preference: {:?}", client.read_preference());
 
 let mut graph = client.select_graph("imdb");
 
 // Writes go to the primary.
 graph.query("CREATE (:Actor {name: 'Tom Hanks'})").execute().expect("Failed to write");
 
-// Read-only queries are served from a replica when one is available.
+// Follows the client default (a replica when available, else the primary).
 let mut nodes = graph.ro_query("MATCH (a:Actor) RETURN a.name").execute().expect("Failed to read");
+
+// Force the freshest data from the primary for a single read, overriding the default.
+let mut fresh = graph.ro_query("MATCH (a:Actor) RETURN a.name").primary_only().execute().expect("Failed to read");
 ```
 
-This behavior is fully backward compatible: against a single node (or any
-deployment without readable replicas), `ro_query` / `call_procedure_ro`
-transparently fall back to the primary connection, and `reads_from_replicas()`
-returns `false`. See [`examples/readonly_replica.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/readonly_replica.rs)
+Against a single node (or any deployment without readable replicas),
+`replica_reads_available` returns `false` and reads
+use the primary. See [`examples/readonly_replica.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/readonly_replica.rs)
 for a complete working example.
 
 ### Resilience and observability
@@ -913,6 +932,7 @@ The complete API reference is published on [docs.rs](https://docs.rs/falkordb/la
 
 - [Migrating to 0.7](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.7.md)
 - [Migrating to 0.8](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.8.md)
+- [Migrating to 0.10](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.10.md)
 
 ## Contributing
 

--- a/docs/llms.template.md
+++ b/docs/llms.template.md
@@ -22,7 +22,8 @@
 - Iterate the fallible result rows by column alias:
   `for row in result.data { let n: Node = row?.try_get("n")?; }`
   (`data` is the result set; `Row::try_get::<T>("alias")` / `try_get_at::<T>(index)`).
-- Read-only queries route to replicas: `graph.ro_query("MATCH …")`.
+- Read-only queries (`graph.ro_query("MATCH …")`) run on the primary by default; opt into replicas
+  per client (`with_read_preference(ReadPreference::PreferReplica)`) or per query (`.prefer_replica()`).
 - Map a result straight into your own type with `serde`:
   `graph.query("…").query_as::<MyRow>().execute()?` (or `FalkorValue::deserialize_into::<T>()`).
 - Async (`tokio` feature): build with `FalkorClientBuilder::new_async().build().await?` →

--- a/docs/migrating-to-0.10.md
+++ b/docs/migrating-to-0.10.md
@@ -1,0 +1,102 @@
+# Migrating to 0.10
+
+Version 0.10 makes **replica routing opt-in**. Read-only queries (`ro_query` /
+`call_procedure_ro`) and all-read batches now run on the **primary by default** instead of being
+sent to a replica automatically. Nothing else changes — the query methods, results and the
+synchronous/async split are untouched.
+
+> **Read this if you connect to a Redis Sentinel deployment with readable replicas.** On a single
+> node (or any deployment without readable replicas) behavior is unchanged: reads already used the
+> primary, and they still do.
+
+## Why it changed
+
+A FalkorDB replica applies writes only **after** the primary has committed them, so a read served
+from a replica can return slightly **stale** data. Previously `ro_query` / `call_procedure_ro` were
+routed to a replica *automatically* whenever one was available, with no way to opt out per query and
+no warning about staleness. That conflated two separate ideas:
+
+- the **read-only command** (`GRAPH.RO_QUERY`) — whether the server allows the query to write, and
+- **replica routing** — which node answers, which is a consistency/accuracy choice.
+
+0.10 separates them. The command stays the same; *where* a read runs is now an explicit
+[`ReadPreference`], defaulting to the primary so you never observe replication lag unless you ask
+for it.
+
+## At a glance
+
+| Before (≤ 0.9) | After (0.10) |
+| --- | --- |
+| `ro_query` auto-used a replica when one existed | `ro_query` uses the **primary** unless you opt in |
+| no way to keep a specific read on the primary | `ro_query(..).primary_only()` |
+| no per-query replica opt-in | `ro_query(..).prefer_replica()` |
+| `client.reads_from_replicas()` | `client.replica_reads_available()` + `client.read_preference()` |
+
+## 1. Restore the old replica offload (one line)
+
+If you relied on read-only queries being served from replicas, set the client default to
+`PreferReplica`:
+
+```rust
+use falkordb::{FalkorClientBuilder, ReadPreference};
+
+let client = FalkorClientBuilder::new()
+    .with_connection_info("falkor://127.0.0.1:26379".try_into()?)
+    .with_read_preference(ReadPreference::PreferReplica) // restore pre-0.10 behavior
+    .build()?;
+```
+
+Every `ro_query` / `call_procedure_ro` from this client now prefers a replica again, transparently
+falling back to the primary when none is available.
+
+## 2. Or opt in per query
+
+Leave the client on the default (`Primary`) and opt individual reads into replicas:
+
+```rust
+// Offload this analytics read to a replica (stale data is acceptable here).
+let mut rows = graph
+    .ro_query("MATCH (a:Actor) RETURN count(a)")
+    .prefer_replica()
+    .execute()?;
+```
+
+With a `PreferReplica` client default, do the opposite for read-your-writes paths that must see the
+freshest data:
+
+```rust
+// Force the primary for this read, overriding the client default.
+let mut rows = graph
+    .ro_query("MATCH (a:Actor {name: $name}) RETURN a")
+    .primary_only()
+    .execute()?;
+```
+
+Batches take the same methods (`graph.batch().prefer_replica()`); routing applies to the whole
+pipeline, which must be all-read.
+
+## 3. Replica preference on a write is now an error
+
+A write can never run on a replica, so requesting one on a writable `query`, `call_procedure`, or a
+batch that contains a write fails fast with `FalkorDBError::ReadPreferenceNotReadOnly` (before any
+round-trip) instead of being silently ignored:
+
+```rust
+let err = graph
+    .query("CREATE (:Actor {name: 'Tom Hanks'})")
+    .prefer_replica()
+    .execute()
+    .unwrap_err(); // FalkorDBError::ReadPreferenceNotReadOnly
+```
+
+## 4. `reads_from_replicas()` is deprecated
+
+It conflated capability with policy. Replace it with whichever you actually need:
+
+| Before | After |
+| --- | --- |
+| `client.reads_from_replicas()` (a replica pool exists) | `client.replica_reads_available()` |
+| (no equivalent) — the active routing policy | `client.read_preference()` |
+
+`reads_from_replicas()` still works for now but emits a deprecation warning; it will be removed in a
+future release.

--- a/examples/readonly_replica.rs
+++ b/examples/readonly_replica.rs
@@ -3,35 +3,46 @@
  * Licensed under the MIT License.
  */
 
-//! Demonstrates routing read-only queries to replica nodes.
+//! Demonstrates opt-in routing of read-only queries to replica nodes.
 //!
-//! When the client is pointed at a Redis Sentinel deployment that exposes
-//! readable replicas, `ro_query` / `call_procedure_ro` are automatically served
-//! from a replica, taking read load off the primary. Against a single-node
-//! deployment there are no replicas, so read-only queries transparently fall
-//! back to the primary and behave exactly as before.
+//! Routing reads to replicas is **opt-in**, because a FalkorDB replica applies writes only after
+//! the primary has committed them — a read served from a replica can be slightly **stale**. By
+//! default every read goes to the primary, so you never observe replication lag unless you ask for
+//! it. Opt in either:
+//!
+//! * **per client** — `FalkorClientBuilder::with_read_preference(ReadPreference::PreferReplica)`
+//!   makes every read-only query prefer a replica, or
+//! * **per query** — `ro_query(..).prefer_replica()` opts a single query in (and
+//!   `.primary_only()` forces a single query back onto the primary for read-your-writes paths).
+//!
+//! `PreferReplica` transparently falls back to the primary when no replica is available (for
+//! example a single-node deployment), so the same code runs everywhere.
 //!
 //! Set `FALKORDB_CONNECTION` to a Sentinel endpoint (for example
 //! `falkor://127.0.0.1:26379`) to see reads routed to replicas; otherwise it
 //! defaults to a local single node.
 
-use falkordb::{FalkorClientBuilder, FalkorResult};
+use falkordb::{FalkorClientBuilder, FalkorResult, ReadPreference};
 
 fn main() -> FalkorResult<()> {
     let connection_info = std::env::var("FALKORDB_CONNECTION")
         .unwrap_or_else(|_| "falkor://127.0.0.1:6379".to_string());
 
+    // Opt this client into replica reads by default. Drop `with_read_preference` (or pass
+    // `ReadPreference::Primary`) to keep every read on the primary.
     let client = FalkorClientBuilder::new()
         .with_connection_info(connection_info.as_str().try_into()?)
+        .with_read_preference(ReadPreference::PreferReplica)
         .build()?;
 
-    // Reports whether read-only queries are routed to replica nodes. This is
-    // `true` only for Sentinel deployments that expose readable replicas.
-    if client.reads_from_replicas() {
-        println!("Read-only queries are routed to replica nodes.");
+    // `replica_reads_available()` reports capability (a replica pool exists), while
+    // `read_preference()` reports the client's default policy.
+    if client.replica_reads_available() {
+        println!("Replica connections are available; read-only queries may be served from them.");
     } else {
         println!("No readable replicas detected; read-only queries use the primary.");
     }
+    println!("Default read preference: {:?}", client.read_preference());
 
     let mut graph = client.select_graph("readonly_example");
 
@@ -40,13 +51,22 @@ fn main() -> FalkorResult<()> {
         .query("CREATE (:Greeting {text: 'hello'})")
         .execute()?;
 
-    // Read-only queries are served from a replica when one is available.
+    // This read-only query follows the client default (PreferReplica) — served from a replica when
+    // one is available, otherwise transparently from the primary.
     let mut greetings = graph
         .ro_query("MATCH (g:Greeting) RETURN g.text")
         .execute()?;
-
     for row in greetings.data.by_ref() {
-        println!("read-only result: {row:?}");
+        println!("replica-preferring read: {row:?}");
+    }
+
+    // A read-your-writes path can force the primary for a single query, ignoring the client default.
+    let mut fresh = graph
+        .ro_query("MATCH (g:Greeting) RETURN g.text")
+        .primary_only()
+        .execute()?;
+    for row in fresh.data.by_ref() {
+        println!("primary (fresh) read: {row:?}");
     }
 
     graph.delete()?;

--- a/llms.txt
+++ b/llms.txt
@@ -22,7 +22,8 @@
 - Iterate the fallible result rows by column alias:
   `for row in result.data { let n: Node = row?.try_get("n")?; }`
   (`data` is the result set; `Row::try_get::<T>("alias")` / `try_get_at::<T>(index)`).
-- Read-only queries route to replicas: `graph.ro_query("MATCH …")`.
+- Read-only queries (`graph.ro_query("MATCH …")`) run on the primary by default; opt into replicas
+  per client (`with_read_preference(ReadPreference::PreferReplica)`) or per query (`.prefer_replica()`).
 - Map a result straight into your own type with `serde`:
   `graph.query("…").query_as::<MyRow>().execute()?` (or `FalkorValue::deserialize_into::<T>()`).
 - Async (`tokio` feature): build with `FalkorClientBuilder::new_async().build().await?` →
@@ -104,6 +105,7 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `QueryBuilder`
 - `QueryResult`
 - `RawParam`
+- `ReadPreference`
 - `RetryPolicy`
 - `RetryScope`
 - `Row`

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -883,7 +883,7 @@ mod tests {
             "A single-node deployment must not have replica connections available"
         );
 
-        let mut graph = client.select_graph("test_reads_from_replicas_single_node_async");
+        let mut graph = client.select_graph("test_replica_reads_available_single_node_async");
         graph
             .query("CREATE (n:Person {name: 'Jane Doe', age: 25})")
             .execute()

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::{
-    client::{ConnectionStrategy, FalkorClientProvider, ProvidesSyncConnections},
+    client::{ConnectionStrategy, FalkorClientProvider, ProvidesSyncConnections, ReadPreference},
     connection::{
         asynchronous::{BorrowedAsyncConnection, FalkorAsyncConnection},
         blocking::FalkorSyncConnection,
@@ -74,6 +74,8 @@ pub struct FalkorAsyncClientInner {
     /// When set, the raw query text is recorded as a span field (opt-in via `with_query_logging`).
     #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     query_logging: bool,
+    /// Client-wide default read preference for read-only queries (overridable per query).
+    read_preference: ReadPreference,
 }
 
 impl FalkorAsyncClientInner {
@@ -81,6 +83,11 @@ impl FalkorAsyncClientInner {
     /// [`disabled`](RetryPolicy::disabled)).
     pub(crate) fn retry_policy(&self) -> RetryPolicy {
         self.retry_policy
+    }
+
+    /// The client-wide default [`ReadPreference`] for read-only queries.
+    pub(crate) fn read_preference(&self) -> ReadPreference {
+        self.read_preference
     }
 
     /// The active connection strategy (used for observability span fields and metric labels).
@@ -258,6 +265,7 @@ impl FalkorAsyncClient {
         max_inflight: Option<NonZeroUsize>,
         retry_policy: RetryPolicy,
         query_logging: bool,
+        read_preference: ReadPreference,
     ) -> FalkorResult<Self> {
         // A multiplexed ConnectionManager built from a Sentinel-resolved client pins to a
         // single node and reconnects to the same address rather than re-resolving the
@@ -300,6 +308,7 @@ impl FalkorAsyncClient {
                 readonly,
                 retry_policy,
                 query_logging,
+                read_preference,
             }),
             _connection_info: connection_info,
         })
@@ -381,9 +390,32 @@ impl FalkorAsyncClient {
         self.inner.strategy
     }
 
+    /// Whether replica connections are available for routing read-only queries — `true` only for
+    /// Redis Sentinel deployments that expose readable replicas.
+    ///
+    /// This reports **capability**, not policy: a query is served from a replica only when this is
+    /// `true` **and** the effective [`ReadPreference`] is
+    /// [`PreferReplica`](ReadPreference::PreferReplica). Use [`read_preference`](Self::read_preference)
+    /// to inspect the client's default policy.
+    pub fn replica_reads_available(&self) -> bool {
+        self.inner.has_readonly_pool()
+    }
+
+    /// The client-wide default [`ReadPreference`] applied to read-only queries (set via
+    /// [`FalkorClientBuilder::with_read_preference`](crate::FalkorClientBuilder::with_read_preference);
+    /// defaults to [`ReadPreference::Primary`]). Individual queries can override it.
+    pub fn read_preference(&self) -> ReadPreference {
+        self.inner.read_preference()
+    }
+
     /// Whether read-only queries (`ro_query` / `call_procedure_ro`) are routed to
     /// replica nodes. This is `true` only for Redis Sentinel deployments that expose
     /// readable replicas; otherwise read-only queries are served by the primary.
+    #[deprecated(
+        since = "0.10.0",
+        note = "renamed to `replica_reads_available` (reports replica capability). Since replica \
+                routing is now opt-in, use `read_preference` to inspect the routing policy."
+    )]
     pub fn reads_from_replicas(&self) -> bool {
         self.inner.has_readonly_pool()
     }
@@ -841,14 +873,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_reads_from_replicas_single_node() {
+    async fn test_replica_reads_available_single_node() {
         // On a single-node (non-Sentinel) deployment there are no readable
         // replicas, so read-only queries transparently fall back to the primary
-        // pool and `reads_from_replicas` reports false.
+        // pool and `replica_reads_available` reports false.
         let client = create_async_test_client().await;
         assert!(
-            !client.reads_from_replicas(),
-            "A single-node deployment must not route reads to replicas"
+            !client.replica_reads_available(),
+            "A single-node deployment must not have replica connections available"
         );
 
         let mut graph = client.select_graph("test_reads_from_replicas_single_node_async");
@@ -973,6 +1005,7 @@ mod tests {
             readonly: Some(readonly),
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
+            read_preference: ReadPreference::Primary,
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -609,7 +609,7 @@ mod tests {
             "A single-node deployment must not have replica connections available"
         );
 
-        let mut graph = client.select_graph("test_reads_from_replicas_single_node");
+        let mut graph = client.select_graph("test_replica_reads_available_single_node");
         graph
             .query("CREATE (n:Person {name: 'Jane Doe', age: 25})")
             .execute()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::{
-    client::{FalkorClientProvider, ProvidesSyncConnections},
+    client::{FalkorClientProvider, ProvidesSyncConnections, ReadPreference},
     connection::blocking::{BorrowedSyncConnection, FalkorSyncConnection},
     parser::{parse_config_hashmap, redis_value_as_untyped_string_vec},
     ConfigValue, FalkorConnectionInfo, FalkorDBError, FalkorResult, RetryPolicy, SyncGraph,
@@ -42,6 +42,8 @@ pub(crate) struct FalkorSyncClientInner {
     /// When set, the raw query text is recorded as a span field (opt-in via `with_query_logging`).
     #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     query_logging: bool,
+    /// Client-wide default read preference for read-only queries (overridable per query).
+    read_preference: ReadPreference,
 }
 
 impl FalkorSyncClientInner {
@@ -49,6 +51,11 @@ impl FalkorSyncClientInner {
     /// [`disabled`](RetryPolicy::disabled)).
     pub(crate) fn retry_policy(&self) -> RetryPolicy {
         self.retry_policy
+    }
+
+    /// The client-wide default [`ReadPreference`] for read-only queries.
+    pub(crate) fn read_preference(&self) -> ReadPreference {
+        self.read_preference
     }
 
     /// Whether raw query text may be recorded on spans (opt-in; `false` by default).
@@ -174,6 +181,7 @@ impl FalkorSyncClient {
         num_connections: u8,
         retry_policy: RetryPolicy,
         query_logging: bool,
+        read_preference: ReadPreference,
     ) -> FalkorResult<Self> {
         let (connection_pool_tx, connection_pool_rx) = mpsc::sync_channel(num_connections as usize);
 
@@ -199,6 +207,7 @@ impl FalkorSyncClient {
                 readonly_pool,
                 retry_policy,
                 query_logging,
+                read_preference,
             }),
             _connection_info: connection_info,
         })
@@ -244,9 +253,32 @@ impl FalkorSyncClient {
         self.inner.connection_pool_size
     }
 
+    /// Whether replica connections are available for routing read-only queries — `true` only for
+    /// Redis Sentinel deployments that expose readable replicas.
+    ///
+    /// This reports **capability**, not policy: a query is served from a replica only when this is
+    /// `true` **and** the effective [`ReadPreference`] is
+    /// [`PreferReplica`](ReadPreference::PreferReplica). Use [`read_preference`](Self::read_preference)
+    /// to inspect the client's default policy.
+    pub fn replica_reads_available(&self) -> bool {
+        self.inner.has_readonly_pool()
+    }
+
+    /// The client-wide default [`ReadPreference`] applied to read-only queries (set via
+    /// [`FalkorClientBuilder::with_read_preference`](crate::FalkorClientBuilder::with_read_preference);
+    /// defaults to [`ReadPreference::Primary`]). Individual queries can override it.
+    pub fn read_preference(&self) -> ReadPreference {
+        self.inner.read_preference()
+    }
+
     /// Whether read-only queries (`ro_query` / `call_procedure_ro`) are routed to
     /// replica nodes. This is `true` only for Redis Sentinel deployments that expose
     /// readable replicas; otherwise read-only queries are served by the primary.
+    #[deprecated(
+        since = "0.10.0",
+        note = "renamed to `replica_reads_available` (reports replica capability). Since replica \
+                routing is now opt-in, use `read_preference` to inspect the routing policy."
+    )]
     pub fn reads_from_replicas(&self) -> bool {
         self.inner.has_readonly_pool()
     }
@@ -479,6 +511,7 @@ pub(crate) fn create_empty_inner_sync_client() -> Arc<FalkorSyncClientInner> {
         readonly_pool: None,
         retry_policy: RetryPolicy::disabled(),
         query_logging: false,
+        read_preference: ReadPreference::Primary,
     })
 }
 
@@ -566,14 +599,14 @@ mod tests {
     }
 
     #[test]
-    fn test_reads_from_replicas_single_node() {
+    fn test_replica_reads_available_single_node() {
         // On a single-node (non-Sentinel) deployment there are no readable
         // replicas, so read-only queries transparently fall back to the primary
-        // pool and `reads_from_replicas` reports false.
+        // pool and `replica_reads_available` reports false.
         let client = create_test_client();
         assert!(
-            !client.reads_from_replicas(),
-            "A single-node deployment must not route reads to replicas"
+            !client.replica_reads_available(),
+            "A single-node deployment must not have replica connections available"
         );
 
         let mut graph = client.select_graph("test_reads_from_replicas_single_node");
@@ -667,6 +700,7 @@ mod tests {
             readonly_pool: Some(pool),
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
+            read_preference: ReadPreference::Primary,
         });
 
         assert!(inner.has_readonly_pool());

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::{
-    client::{ConnectionStrategy, FalkorClientProvider},
+    client::{ConnectionStrategy, FalkorClientProvider, ReadPreference},
     FalkorConnectionInfo, FalkorDBError, FalkorResult, FalkorSyncClient, RetryPolicy,
 };
 use std::num::{NonZeroU8, NonZeroUsize};
@@ -22,6 +22,7 @@ pub struct FalkorClientBuilder<const R: char> {
     tcp_settings: Option<redis::io::tcp::TcpSettings>,
     retry_policy: RetryPolicy,
     query_logging: bool,
+    read_preference: ReadPreference,
 }
 
 impl<const R: char> FalkorClientBuilder<R> {
@@ -108,6 +109,33 @@ impl<const R: char> FalkorClientBuilder<R> {
     ) -> Self {
         Self {
             query_logging: enabled,
+            ..self
+        }
+    }
+
+    /// Set the default [`ReadPreference`] for read-only queries from this client.
+    ///
+    /// Defaults to [`ReadPreference::Primary`], so reads are served from the primary and never see
+    /// replication lag. Set [`ReadPreference::PreferReplica`] to offload reads to a replica when one
+    /// is available (Redis Sentinel deployments), accepting that those reads may be slightly stale.
+    ///
+    /// This is the client-wide default; individual read-only queries can override it with
+    /// [`QueryBuilder::with_read_preference`](crate::QueryBuilder::with_read_preference) (or the
+    /// [`prefer_replica`](crate::QueryBuilder::prefer_replica) /
+    /// [`primary_only`](crate::QueryBuilder::primary_only) shortcuts). It only affects read-only
+    /// commands (`ro_query` / `call_procedure_ro`); writes always go to the primary.
+    ///
+    /// # Arguments
+    /// * `read_preference`: the default [`ReadPreference`] to apply.
+    ///
+    /// # Returns
+    /// The consumed and modified self.
+    pub fn with_read_preference(
+        self,
+        read_preference: ReadPreference,
+    ) -> Self {
+        Self {
+            read_preference,
             ..self
         }
     }
@@ -248,6 +276,7 @@ impl FalkorClientBuilder<'S'> {
             tcp_settings: None,
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
+            read_preference: ReadPreference::Primary,
         }
     }
 
@@ -278,6 +307,7 @@ impl FalkorClientBuilder<'S'> {
             self.strategy.connection_count().get(),
             self.retry_policy,
             self.query_logging,
+            self.read_preference,
         )
     }
 }
@@ -298,6 +328,7 @@ impl FalkorClientBuilder<'A'> {
             tcp_settings: None,
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
+            read_preference: ReadPreference::Primary,
         }
     }
 
@@ -395,6 +426,7 @@ impl FalkorClientBuilder<'A'> {
             self.max_inflight,
             self.retry_policy,
             self.query_logging,
+            self.read_preference,
         )
         .await
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -86,6 +86,42 @@ impl ConnectionStrategy {
     }
 }
 
+/// Controls which node a read-only query may be served from.
+///
+/// A FalkorDB replica applies writes only **after** the primary has committed them, so a read
+/// served from a replica can return slightly **stale** data. Routing reads to replicas is therefore
+/// opt-in: the default ([`ReadPreference::Primary`]) keeps every read on the primary, so you never
+/// observe replication lag unless you ask for it.
+///
+/// This is orthogonal to the read-only *command* (`GRAPH.RO_QUERY`, issued by
+/// [`ro_query`](crate::SyncGraph::ro_query) / [`call_procedure_ro`](crate::SyncGraph::call_procedure_ro)):
+/// the command decides whether the server allows writes, while `ReadPreference` decides which node
+/// answers. A read preference only takes effect for read-only commands.
+///
+/// Set a client-wide default with
+/// [`FalkorClientBuilder::with_read_preference`](crate::FalkorClientBuilder::with_read_preference),
+/// and override it per query with
+/// [`QueryBuilder::with_read_preference`](crate::QueryBuilder::with_read_preference) (or the
+/// [`prefer_replica`](crate::QueryBuilder::prefer_replica) /
+/// [`primary_only`](crate::QueryBuilder::primary_only) shortcuts).
+///
+/// # Example
+/// ```no_run
+/// use falkordb::ReadPreference;
+///
+/// assert_eq!(ReadPreference::default(), ReadPreference::Primary);
+/// ```
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReadPreference {
+    /// Serve reads from the primary only — never subject to replica lag. **Default.**
+    #[default]
+    Primary,
+    /// Prefer a replica when one is available, falling back to the primary otherwise. Accepts that
+    /// reads may be slightly stale in exchange for offloading the primary.
+    PreferReplica,
+}
+
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum FalkorClientProvider {
     #[cfg(test)]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -203,6 +203,15 @@ pub enum FalkorDBError {
         /// The [`crate::FalkorValue`] variant that was found.
         got: &'static str,
     },
+    /// A replica read preference ([`ReadPreference::PreferReplica`](crate::ReadPreference::PreferReplica))
+    /// was set on a query or batch that can write. Writes must go to the primary, so they cannot be
+    /// routed to a replica; use `query`/`call_procedure` without a replica preference, or make the
+    /// request read-only.
+    #[error("replica read preference cannot be applied to a writable {context}; only read-only queries may be routed to a replica")]
+    ReadPreferenceNotReadOnly {
+        /// What the preference was set on — `"query"` or `"batch"`.
+        context: &'static str,
+    },
 }
 
 impl FalkorDBError {

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -495,6 +495,40 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_call_procedure_ro_read_preference() {
+        // A read-only procedure call may opt into a replica (transparently falling back to the
+        // primary on single-node) or be forced onto the primary.
+        let client = create_async_test_client().await;
+        #[allow(deprecated)]
+        let legacy = client.reads_from_replicas();
+        assert_eq!(legacy, client.replica_reads_available());
+
+        let mut graph = client.select_graph("imdb");
+        assert!(graph
+            .call_procedure_ro::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+            .prefer_replica()
+            .execute()
+            .await
+            .is_ok());
+        assert!(graph
+            .call_procedure_ro::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+            .primary_only()
+            .execute()
+            .await
+            .is_ok());
+
+        // A replica preference on a writable procedure call is rejected before any round-trip.
+        assert!(matches!(
+            graph
+                .call_procedure::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+                .prefer_replica()
+                .execute()
+                .await,
+            Err(FalkorDBError::ReadPreferenceNotReadOnly { context: "query" })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_create_drop_index() {
         let mut graph = open_empty_async_test_graph("test_create_drop_index_async").await;
 

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -502,6 +502,7 @@ mod tests {
         #[allow(deprecated)]
         let legacy = client.reads_from_replicas();
         assert_eq!(legacy, client.replica_reads_available());
+        assert_eq!(client.read_preference(), crate::ReadPreference::Primary);
 
         let mut graph = client.select_graph("imdb");
         assert!(graph

--- a/src/graph/batch.rs
+++ b/src/graph/batch.rs
@@ -7,12 +7,13 @@
 //! in one round-trip, with per-query results in submission order.
 
 use crate::graph::query_builder::{
-    build_vec_rows, construct_query, dispatch_query_response, unwrap_query_response,
+    build_vec_rows, construct_query, dispatch_query_response, resolve_use_replica,
+    unwrap_query_response,
 };
 use crate::graph::HasGraphSchema;
 use crate::{
     FalkorDBError, FalkorParams, FalkorResult, GraphSchema, IntoFalkorParam, IntoFalkorParams,
-    QueryResult, Row, SyncGraph,
+    QueryResult, ReadPreference, Row, SyncGraph,
 };
 
 /// The result of one query in a batch: `Ok` with its [`QueryResult`] (rows eagerly parsed into a
@@ -152,6 +153,7 @@ impl BatchQuery {
 pub struct BatchBuilder<'a, G> {
     graph: &'a mut G,
     queries: Vec<BatchQuery>,
+    read_preference: Option<ReadPreference>,
 }
 
 impl<'a, G> BatchBuilder<'a, G> {
@@ -159,6 +161,7 @@ impl<'a, G> BatchBuilder<'a, G> {
         Self {
             graph,
             queries: Vec::new(),
+            read_preference: None,
         }
     }
 
@@ -197,6 +200,37 @@ impl<'a, G> BatchBuilder<'a, G> {
     /// Whether no queries have been queued.
     pub fn is_empty(&self) -> bool {
         self.queries.is_empty()
+    }
+
+    /// Override the [`ReadPreference`] for this batch, ignoring the client-wide default.
+    ///
+    /// Routing applies to the **whole** batch (one pipelined round-trip on one connection). A batch
+    /// is eligible for a replica only when **every** queued query is read-only; setting
+    /// [`ReadPreference::PreferReplica`] on a batch that contains a write makes `execute()` fail with
+    /// [`FalkorDBError::ReadPreferenceNotReadOnly`](crate::FalkorDBError::ReadPreferenceNotReadOnly).
+    ///
+    /// # Arguments
+    /// * `read_preference`: the [`ReadPreference`] to apply to this batch.
+    pub fn with_read_preference(
+        mut self,
+        read_preference: ReadPreference,
+    ) -> Self {
+        self.read_preference = Some(read_preference);
+        self
+    }
+
+    /// Route this all-read batch to a replica when available, else the primary. Shortcut for
+    /// [`with_read_preference(ReadPreference::PreferReplica)`](Self::with_read_preference). Replicas
+    /// can be slightly stale; fails at `execute()` if the batch contains a write.
+    pub fn prefer_replica(self) -> Self {
+        self.with_read_preference(ReadPreference::PreferReplica)
+    }
+
+    /// Serve this batch from the primary, overriding a client default of
+    /// [`ReadPreference::PreferReplica`]. Shortcut for
+    /// [`with_read_preference(ReadPreference::Primary)`](Self::with_read_preference).
+    pub fn primary_only(self) -> Self {
+        self.with_read_preference(ReadPreference::Primary)
     }
 }
 
@@ -272,6 +306,14 @@ impl BatchBuilder<'_, SyncGraph> {
         tracing::instrument(name = "Execute Batch", skip_all, level = "info")
     )]
     pub fn execute(self) -> BatchResult {
+        let client = self.graph.get_client().clone();
+        let use_replica = resolve_use_replica(
+            !has_write(&self.queries),
+            self.read_preference,
+            client.read_preference(),
+            "batch",
+        )?;
+
         let (pipe, submitted, slots) = prepare(self.graph.graph_name(), &self.queries);
         if submitted.is_empty() {
             return Ok(slots
@@ -280,11 +322,10 @@ impl BatchBuilder<'_, SyncGraph> {
                 .collect());
         }
 
-        let client = self.graph.get_client().clone();
-        let conn = if has_write(&self.queries) {
-            client.borrow_connection(client.clone())
-        } else {
+        let conn = if use_replica {
             client.borrow_readonly_connection(client.clone())
+        } else {
+            client.borrow_connection(client.clone())
         };
         let replies = conn?.execute_pipeline(&pipe)?;
 
@@ -303,6 +344,14 @@ impl BatchBuilder<'_, crate::AsyncGraph> {
         tracing::instrument(name = "Execute Batch", skip_all, level = "info")
     )]
     pub async fn execute(self) -> BatchResult {
+        let client = self.graph.get_client().clone();
+        let use_replica = resolve_use_replica(
+            !has_write(&self.queries),
+            self.read_preference,
+            client.read_preference(),
+            "batch",
+        )?;
+
         let (pipe, submitted, slots) = prepare(self.graph.graph_name(), &self.queries);
         if submitted.is_empty() {
             return Ok(slots
@@ -311,11 +360,10 @@ impl BatchBuilder<'_, crate::AsyncGraph> {
                 .collect());
         }
 
-        let client = self.graph.get_client().clone();
-        let conn = if has_write(&self.queries) {
-            client.borrow_connection(client.clone()).await
-        } else {
+        let conn = if use_replica {
             client.borrow_readonly_connection(client.clone()).await
+        } else {
+            client.borrow_connection(client.clone()).await
         };
         let replies = conn?.execute_pipeline(&pipe).await?;
 

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -481,6 +481,38 @@ mod tests {
     }
 
     #[test]
+    fn test_call_procedure_ro_read_preference() {
+        // A read-only procedure call may opt into a replica (transparently falling back to the
+        // primary on single-node) or be forced onto the primary.
+        let client = create_test_client();
+        // The deprecated alias still reports replica capability (kept for one release).
+        #[allow(deprecated)]
+        let legacy = client.reads_from_replicas();
+        assert_eq!(legacy, client.replica_reads_available());
+
+        let mut graph = client.select_graph("imdb");
+        assert!(graph
+            .call_procedure_ro::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+            .prefer_replica()
+            .execute()
+            .is_ok());
+        assert!(graph
+            .call_procedure_ro::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+            .primary_only()
+            .execute()
+            .is_ok());
+
+        // A replica preference on a writable procedure call is rejected before any round-trip.
+        assert!(matches!(
+            graph
+                .call_procedure::<QueryResult<Vec<FalkorIndex>>>("DB.INDEXES")
+                .prefer_replica()
+                .execute(),
+            Err(FalkorDBError::ReadPreferenceNotReadOnly { context: "query" })
+        ));
+    }
+
+    #[test]
     fn test_create_drop_index() {
         let mut graph = open_empty_test_graph("test_create_drop_index");
 

--- a/src/graph/query_builder.rs
+++ b/src/graph/query_builder.rs
@@ -8,7 +8,7 @@ use crate::{
     parser::{parse_header, redis_value_as_vec, SchemaParsable},
     retry::{op_kind_for_command, run_with_retry_blocking, OpKind},
     Constraint, ExecutionPlan, FalkorDBError, FalkorIndex, FalkorParams, FalkorResult, GraphSchema,
-    IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, SyncGraph,
+    IntoFalkorParam, IntoFalkorParams, LazyResultSet, QueryResult, ReadPreference, SyncGraph,
 };
 use std::sync::Arc;
 use std::{
@@ -136,6 +136,30 @@ pub(crate) fn construct_query<Q: Display>(
     Ok(query)
 }
 
+/// Resolve whether a read-only-capable command should be served from a replica connection.
+///
+/// `requested` is the per-request override (`None` means "inherit the client default"). The three
+/// concepts are kept separate: `is_ro_command` is the command's read-only semantics, the resolved
+/// [`ReadPreference`] is the requested policy, and the returned `bool` is the actual route. A
+/// replica route is only taken for a read-only command whose effective preference is
+/// [`ReadPreference::PreferReplica`]; the borrow path still falls back to the primary when no
+/// replica connection exists.
+///
+/// Returns [`FalkorDBError::ReadPreferenceNotReadOnly`] when a replica preference was explicitly
+/// requested for a command that can write — a write can never be routed to a replica.
+pub(crate) fn resolve_use_replica(
+    is_ro_command: bool,
+    requested: Option<ReadPreference>,
+    client_default: ReadPreference,
+    context: &'static str,
+) -> FalkorResult<bool> {
+    if requested == Some(ReadPreference::PreferReplica) && !is_ro_command {
+        return Err(FalkorDBError::ReadPreferenceNotReadOnly { context });
+    }
+    let effective = requested.unwrap_or(client_default);
+    Ok(is_ro_command && effective == ReadPreference::PreferReplica)
+}
+
 /// A Builder-pattern struct that allows creating and executing queries on a graph
 pub struct QueryBuilder<'a, Output, T: Display, G> {
     _unused: PhantomData<Output>,
@@ -144,6 +168,7 @@ pub struct QueryBuilder<'a, Output, T: Display, G> {
     query_string: T,
     params: FalkorParams,
     timeout: Option<i64>,
+    read_preference: Option<ReadPreference>,
 }
 
 impl<'a, Output, T: Display, G> QueryBuilder<'a, Output, T, G> {
@@ -159,6 +184,7 @@ impl<'a, Output, T: Display, G> QueryBuilder<'a, Output, T, G> {
             query_string,
             params: FalkorParams::new(),
             timeout: None,
+            read_preference: None,
         }
     }
 
@@ -235,6 +261,43 @@ impl<'a, Output, T: Display, G> QueryBuilder<'a, Output, T, G> {
             ..self
         }
     }
+
+    /// Override the [`ReadPreference`] for this single query, ignoring the client-wide default.
+    ///
+    /// Only read-only queries (`ro_query`) can be routed to a replica. Setting
+    /// [`ReadPreference::PreferReplica`] on a writable `query` makes `execute()` fail with
+    /// [`FalkorDBError::ReadPreferenceNotReadOnly`](crate::FalkorDBError::ReadPreferenceNotReadOnly),
+    /// since a write can never run on a replica. See [`prefer_replica`](Self::prefer_replica) and
+    /// [`primary_only`](Self::primary_only) for the common shortcuts.
+    ///
+    /// # Arguments
+    /// * `read_preference`: the [`ReadPreference`] to apply to this query.
+    pub fn with_read_preference(
+        self,
+        read_preference: ReadPreference,
+    ) -> Self {
+        Self {
+            read_preference: Some(read_preference),
+            ..self
+        }
+    }
+
+    /// Route this read-only query to a replica when one is available, falling back to the primary
+    /// otherwise. Shortcut for [`with_read_preference(ReadPreference::PreferReplica)`](Self::with_read_preference).
+    ///
+    /// Replicas can be slightly stale, so only use this when a marginally out-of-date read is
+    /// acceptable. Has effect only on `ro_query`; on a writable `query` it makes `execute()` fail.
+    pub fn prefer_replica(self) -> Self {
+        self.with_read_preference(ReadPreference::PreferReplica)
+    }
+
+    /// Serve this query from the primary, overriding a client default of
+    /// [`ReadPreference::PreferReplica`]. Shortcut for
+    /// [`with_read_preference(ReadPreference::Primary)`](Self::with_read_preference). Use this for
+    /// read-your-writes paths that must not observe replication lag.
+    pub fn primary_only(self) -> Self {
+        self.with_read_preference(ReadPreference::Primary)
+    }
 }
 
 impl<'a, Output, T: Display, G: HasGraphSchema> QueryBuilder<'a, Output, T, G> {
@@ -294,14 +357,19 @@ impl<Out, T: Display> QueryBuilder<'_, Out, T, SyncGraph> {
         );
 
         let graph_name = self.graph.graph_name();
-        let readonly_conn = command == "GRAPH.RO_QUERY";
+        let use_replica = resolve_use_replica(
+            command == "GRAPH.RO_QUERY",
+            self.read_preference,
+            client.read_preference(),
+            "query",
+        )?;
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
         #[cfg(feature = "metrics")]
         let metrics_start = std::time::Instant::now();
         let result = run_with_retry_blocking(&policy, op_kind, || {
-            let conn = if readonly_conn {
+            let conn = if use_replica {
                 client.borrow_readonly_connection(client.clone())
             } else {
                 client.borrow_connection(client.clone())
@@ -372,14 +440,19 @@ impl<'a, Out, T: Display> QueryBuilder<'a, Out, T, AsyncGraph> {
         );
 
         let graph_name = self.graph.graph_name();
-        let readonly_conn = command == "GRAPH.RO_QUERY";
+        let use_replica = resolve_use_replica(
+            command == "GRAPH.RO_QUERY",
+            self.read_preference,
+            client.read_preference(),
+            "query",
+        )?;
         let params_ref = params.as_slice();
         let policy = client.retry_policy();
 
         #[cfg(feature = "metrics")]
         let metrics_start = std::time::Instant::now();
         let result = run_with_retry_async(&policy, op_kind, || async move {
-            let conn = if readonly_conn {
+            let conn = if use_replica {
                 client.borrow_readonly_connection(client.clone()).await
             } else {
                 client.borrow_connection(client.clone()).await
@@ -510,6 +583,7 @@ impl<'a, T: Display, G: HasGraphSchema> QueryBuilder<'a, QueryResult<LazyResultS
             query_string: self.query_string,
             params: self.params,
             timeout: self.timeout,
+            read_preference: self.read_preference,
         }
     }
 }
@@ -563,6 +637,7 @@ impl<'a, T: Display> QueryBuilder<'a, QueryResult<RowStream>, T, AsyncGraph> {
             query_string: self.query_string,
             params: self.params,
             timeout: self.timeout,
+            read_preference: self.read_preference,
         }
     }
 }
@@ -657,6 +732,7 @@ pub struct ProcedureQueryBuilder<'a, Output, G> {
     procedure_name: &'a str,
     args: Option<&'a [&'a str]>,
     yields: Option<&'a [&'a str]>,
+    read_preference: Option<ReadPreference>,
 }
 
 impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
@@ -673,6 +749,7 @@ impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
             procedure_name,
             args: None,
             yields: None,
+            read_preference: None,
         }
     }
 
@@ -688,6 +765,7 @@ impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
             procedure_name,
             args: None,
             yields: None,
+            read_preference: None,
         }
     }
 
@@ -725,6 +803,38 @@ impl<'a, Out, G> ProcedureQueryBuilder<'a, Out, G> {
             yields: Some(yields),
             ..self
         }
+    }
+
+    /// Override the [`ReadPreference`] for this single procedure call, ignoring the client default.
+    ///
+    /// Only read-only procedure calls (`call_procedure_ro`) can be routed to a replica. Setting
+    /// [`ReadPreference::PreferReplica`] on a writable `call_procedure` makes `execute()` fail with
+    /// [`FalkorDBError::ReadPreferenceNotReadOnly`](crate::FalkorDBError::ReadPreferenceNotReadOnly).
+    ///
+    /// # Arguments
+    /// * `read_preference`: the [`ReadPreference`] to apply to this call.
+    pub fn with_read_preference(
+        self,
+        read_preference: ReadPreference,
+    ) -> Self {
+        Self {
+            read_preference: Some(read_preference),
+            ..self
+        }
+    }
+
+    /// Route this read-only procedure call to a replica when available, else the primary. Shortcut
+    /// for [`with_read_preference(ReadPreference::PreferReplica)`](Self::with_read_preference).
+    /// Replicas can be slightly stale. Has effect only on `call_procedure_ro`.
+    pub fn prefer_replica(self) -> Self {
+        self.with_read_preference(ReadPreference::PreferReplica)
+    }
+
+    /// Serve this procedure call from the primary, overriding a client default of
+    /// [`ReadPreference::PreferReplica`]. Shortcut for
+    /// [`with_read_preference(ReadPreference::Primary)`](Self::with_read_preference).
+    pub fn primary_only(self) -> Self {
+        self.with_read_preference(ReadPreference::Primary)
     }
 }
 
@@ -802,7 +912,12 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
 
         let client = self.graph.get_client();
         let graph_name = self.graph.graph_name();
-        let readonly_conn = self.readonly;
+        let use_replica = resolve_use_replica(
+            self.readonly,
+            self.read_preference,
+            client.read_preference(),
+            "query",
+        )?;
         let op_kind = self.op_kind;
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
@@ -810,7 +925,7 @@ impl<Out> ProcedureQueryBuilder<'_, Out, SyncGraph> {
         #[cfg(feature = "metrics")]
         let metrics_start = std::time::Instant::now();
         let result = run_with_retry_blocking(&policy, op_kind, || {
-            let conn = if readonly_conn {
+            let conn = if use_replica {
                 client.borrow_readonly_connection(client.clone())
             } else {
                 client.borrow_connection(client.clone())
@@ -880,7 +995,12 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         let query = construct_query(query_string, &params)?;
 
         let graph_name = self.graph.graph_name();
-        let readonly_conn = self.readonly;
+        let use_replica = resolve_use_replica(
+            self.readonly,
+            self.read_preference,
+            client.read_preference(),
+            "query",
+        )?;
         let op_kind = self.op_kind;
         let exec_params = [query.as_str(), "--compact"];
         let policy = client.retry_policy();
@@ -888,7 +1008,7 @@ impl<'a, Out> ProcedureQueryBuilder<'a, Out, AsyncGraph> {
         #[cfg(feature = "metrics")]
         let metrics_start = std::time::Instant::now();
         let result = run_with_retry_async(&policy, op_kind, || async move {
-            let conn = if readonly_conn {
+            let conn = if use_replica {
                 client.borrow_readonly_connection(client.clone()).await
             } else {
                 client.borrow_connection(client.clone()).await
@@ -1039,6 +1159,74 @@ impl<'a> ProcedureQueryBuilder<'a, QueryResult<Vec<Constraint>>, AsyncGraph> {
 mod tests {
     use super::*;
     use crate::client::blocking::create_empty_inner_sync_client;
+
+    #[test]
+    fn resolve_use_replica_defaults_to_primary() {
+        // A read-only command with no per-request override and a Primary client default stays on
+        // the primary.
+        assert!(!resolve_use_replica(true, None, ReadPreference::Primary, "query").unwrap());
+    }
+
+    #[test]
+    fn resolve_use_replica_inherits_client_prefer_replica() {
+        // A read-only command inherits a PreferReplica client default.
+        assert!(resolve_use_replica(true, None, ReadPreference::PreferReplica, "query").unwrap());
+    }
+
+    #[test]
+    fn resolve_use_replica_request_override_wins() {
+        // A per-request PreferReplica overrides a Primary client default…
+        assert!(resolve_use_replica(
+            true,
+            Some(ReadPreference::PreferReplica),
+            ReadPreference::Primary,
+            "query"
+        )
+        .unwrap());
+        // …and a per-request Primary overrides a PreferReplica client default.
+        assert!(!resolve_use_replica(
+            true,
+            Some(ReadPreference::Primary),
+            ReadPreference::PreferReplica,
+            "query"
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn resolve_use_replica_write_never_uses_replica_by_default() {
+        // A writable command never routes to a replica, even under a PreferReplica client default,
+        // and does not error as long as no replica was explicitly requested.
+        assert!(!resolve_use_replica(false, None, ReadPreference::PreferReplica, "query").unwrap());
+    }
+
+    #[test]
+    fn resolve_use_replica_explicit_replica_on_write_errors() {
+        // Explicitly requesting a replica for a writable command is rejected.
+        let err = resolve_use_replica(
+            false,
+            Some(ReadPreference::PreferReplica),
+            ReadPreference::Primary,
+            "query",
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            FalkorDBError::ReadPreferenceNotReadOnly { context: "query" }
+        ));
+    }
+
+    #[test]
+    fn resolve_use_replica_explicit_primary_on_write_is_ok() {
+        // Explicitly forcing the primary on a write is fine (it is a no-op).
+        assert!(!resolve_use_replica(
+            false,
+            Some(ReadPreference::Primary),
+            ReadPreference::PreferReplica,
+            "batch"
+        )
+        .unwrap());
+    }
 
     /// A header `redis::Value` describing a single column named `name`.
     fn header_with_one_column(name: &str) -> redis::Value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! - **Async streaming** — result sets are `Stream`s that compose with the full `futures` toolbox.
 //! - **Resilient** — opt-in `RetryPolicy` with bounded backoff for transient failures; writes are never retried.
 //! - **Observable** — OpenTelemetry-aligned `tracing` spans and `metrics` counters/histograms, privacy-safe by default.
-//! - **Replica-aware** — routes read-only queries to replicas behind Redis Sentinel.
+//! - **Replica-aware** — opt in to routing read-only queries to replicas behind Redis Sentinel.
 //! - **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping.
 //!
 //! ## Table of contents
@@ -603,44 +603,63 @@
 //!
 //! #### Read-only queries and replica routing
 //!
-//! Read-only queries (`ro_query` and `call_procedure_ro`) can be served from
-//! replica nodes, taking read load off the primary. When the client connects to a
-//! Redis Sentinel deployment that exposes readable replicas, it automatically
-//! builds a dedicated read-only connection pool that routes those queries to a
-//! replica. Writes always go to the primary.
+//! Read-only queries (`ro_query` and `call_procedure_ro`) send `GRAPH.RO_QUERY`, which the server
+//! refuses to let write. *Where* such a query runs is a separate, **opt-in** choice expressed with
+//! [`ReadPreference`]. Because a FalkorDB replica applies writes only **after** the primary, a read
+//! served from a replica can be slightly **stale**, so the default ([`ReadPreference::Primary`])
+//! keeps every read on the primary — you never observe replication lag unless you ask for it.
+//!
+//! Opt into replicas either per client or per query:
+//!
+//! - **Per client** — [`with_read_preference`](FalkorClientBuilder::with_read_preference) sets the
+//!   default for every read-only query.
+//! - **Per query** — [`prefer_replica`](QueryBuilder::prefer_replica) opts a single query in, and
+//!   [`primary_only`](QueryBuilder::primary_only) forces one back onto the primary (read-your-writes).
+//!   The per-query choice overrides the client default.
+//!
+//! Replica routing requires a Redis Sentinel deployment that exposes readable replicas; when none is
+//! available (for example a single node), [`ReadPreference::PreferReplica`] transparently falls back
+//! to the primary, so the same code runs everywhere. Writes always go to the primary — asking for a
+//! replica on a writable `query`/`call_procedure`/batch fails with
+//! [`FalkorDBError::ReadPreferenceNotReadOnly`].
 //!
 //! > **Connection pool sizing:** When readable replicas are present the client opens
 //! > a second pool of up to `num_connections` additional connections (one per slot)
-//! > alongside the primary pool. Size your pool limits and file-descriptor limits
-//! > accordingly.
+//! > alongside the primary pool, regardless of the read preference. Size your pool limits and
+//! > file-descriptor limits accordingly.
 //!
 //! ```no_run
-//! use falkordb::FalkorClientBuilder;
+//! use falkordb::{FalkorClientBuilder, ReadPreference};
 //!
 //! let client = FalkorClientBuilder::new()
 //!     // A Sentinel endpoint, e.g. falkor://127.0.0.1:26379
 //!     .with_connection_info("falkor://127.0.0.1:26379".try_into().expect("Invalid connection info"))
+//!     // Prefer replicas for this client's read-only queries (accepts slightly stale reads).
+//!     .with_read_preference(ReadPreference::PreferReplica)
 //!     .build()
 //!     .expect("Failed to build client");
 //!
-//! // `true` only when readable replicas are available.
-//! if client.reads_from_replicas() {
-//!     println!("Read-only queries are routed to replicas");
+//! // Capability (a replica pool exists) vs policy (the default routing).
+//! if client.replica_reads_available() {
+//!     println!("Replica connections are available");
 //! }
+//! println!("Default read preference: {:?}", client.read_preference());
 //!
 //! let mut graph = client.select_graph("imdb");
 //!
 //! // Writes go to the primary.
 //! graph.query("CREATE (:Actor {name: 'Tom Hanks'})").execute().expect("Failed to write");
 //!
-//! // Read-only queries are served from a replica when one is available.
+//! // Follows the client default (a replica when available, else the primary).
 //! let mut nodes = graph.ro_query("MATCH (a:Actor) RETURN a.name").execute().expect("Failed to read");
+//!
+//! // Force the freshest data from the primary for a single read, overriding the default.
+//! let mut fresh = graph.ro_query("MATCH (a:Actor) RETURN a.name").primary_only().execute().expect("Failed to read");
 //! ```
 //!
-//! This behavior is fully backward compatible: against a single node (or any
-//! deployment without readable replicas), `ro_query` / `call_procedure_ro`
-//! transparently fall back to the primary connection, and `reads_from_replicas()`
-//! returns `false`. See [`examples/readonly_replica.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/readonly_replica.rs)
+//! Against a single node (or any deployment without readable replicas),
+//! [`replica_reads_available`](FalkorSyncClient::replica_reads_available) returns `false` and reads
+//! use the primary. See [`examples/readonly_replica.rs`](https://github.com/FalkorDB/falkordb-rs/blob/main/examples/readonly_replica.rs)
 //! for a complete working example.
 //!
 //! ### Resilience and observability
@@ -918,6 +937,7 @@
 //!
 //! - [Migrating to 0.7](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.7.md)
 //! - [Migrating to 0.8](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.8.md)
+//! - [Migrating to 0.10](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.10.md)
 //!
 //! ## Contributing
 //!
@@ -950,7 +970,9 @@ mod value;
 /// A [`Result`] which only returns [`FalkorDBError`] as its E type
 pub type FalkorResult<T> = Result<T, FalkorDBError>;
 
-pub use client::{blocking::FalkorSyncClient, builder::FalkorClientBuilder, ConnectionStrategy};
+pub use client::{
+    blocking::FalkorSyncClient, builder::FalkorClientBuilder, ConnectionStrategy, ReadPreference,
+};
 pub use connection_info::FalkorConnectionInfo;
 pub use error::FalkorDBError;
 pub use graph::{

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -208,7 +208,7 @@ fn test_replica_reads_available_single_node() {
         assert!(!client.replica_reads_available());
     }
 
-    let mut graph = client.select_graph("test_reads_from_replicas_single_node");
+    let mut graph = client.select_graph("test_replica_reads_available_single_node");
     let _ = graph.query("CREATE (n:Data {value: 7})").execute();
 
     // Read-only queries must succeed regardless of whether reads are routed to a

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -300,6 +300,11 @@ fn test_read_preference_replica_on_write_batch_errors() {
     read_batch.ro_query("MATCH (n:Data) RETURN count(n)");
     assert!(read_batch.execute().is_ok());
 
+    // `primary_only()` forces the batch onto the primary, overriding any client default.
+    let mut primary_batch = graph.batch().primary_only();
+    primary_batch.ro_query("MATCH (n:Data) RETURN count(n)");
+    assert!(primary_batch.execute().is_ok());
+
     let _ = graph.delete();
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,9 @@
 //! Set FALKORDB_HOST and FALKORDB_PORT environment variables to configure.
 //! Default: localhost:6379
 
-use falkordb::{FalkorClientBuilder, FalkorConnectionInfo, FalkorResult};
+use falkordb::{
+    FalkorClientBuilder, FalkorConnectionInfo, FalkorDBError, FalkorResult, ReadPreference,
+};
 
 fn get_test_connection_info() -> FalkorResult<FalkorConnectionInfo> {
     let host = std::env::var("FALKORDB_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
@@ -174,7 +176,7 @@ fn test_read_only_query() {
 }
 
 #[test]
-fn test_reads_from_replicas_single_node() {
+fn test_replica_reads_available_single_node() {
     if skip_if_no_server() {
         return;
     }
@@ -192,24 +194,156 @@ fn test_reads_from_replicas_single_node() {
         Err(_) => return,
     };
 
+    // The default read preference keeps reads on the primary.
+    assert_eq!(client.read_preference(), ReadPreference::Primary);
+
     // The test endpoint can be pointed at a Sentinel deployment via env vars, in
-    // which case `reads_from_replicas()` may legitimately be true. Only assert the
-    // single-node expectation (no replica routing) when the endpoint is known to be
+    // which case `replica_reads_available()` may legitimately be true. Only assert the
+    // single-node expectation (no replica connections) when the endpoint is known to be
     // non-Sentinel; set FALKORDB_SENTINEL to skip that strict assertion.
     let is_sentinel = std::env::var("FALKORDB_SENTINEL")
         .map(|v| !v.is_empty() && v != "0" && v.to_lowercase() != "false")
         .unwrap_or(false);
     if !is_sentinel {
-        assert!(!client.reads_from_replicas());
+        assert!(!client.replica_reads_available());
     }
 
     let mut graph = client.select_graph("test_reads_from_replicas_single_node");
     let _ = graph.query("CREATE (n:Data {value: 7})").execute();
 
     // Read-only queries must succeed regardless of whether reads are routed to a
-    // replica (Sentinel) or served by the primary (single-node).
-    let result = graph.ro_query("MATCH (n:Data) RETURN n.value").execute();
-    assert!(result.is_ok());
+    // replica (Sentinel) or served by the primary (single-node). Opting into a replica
+    // transparently falls back to the primary when no replica exists.
+    assert!(graph
+        .ro_query("MATCH (n:Data) RETURN n.value")
+        .execute()
+        .is_ok());
+    assert!(graph
+        .ro_query("MATCH (n:Data) RETURN n.value")
+        .prefer_replica()
+        .execute()
+        .is_ok());
+
+    let _ = graph.delete();
+}
+
+#[test]
+fn test_read_preference_replica_on_write_query_errors() {
+    if skip_if_no_server() {
+        return;
+    }
+
+    let conn_info = match get_test_connection_info() {
+        Ok(info) => info,
+        Err(_) => return,
+    };
+
+    let client = match FalkorClientBuilder::new()
+        .with_connection_info(conn_info)
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let mut graph = client.select_graph("test_read_preference_write_errors");
+
+    // A replica preference on a writable query is rejected before any round-trip — a write can
+    // never be routed to a replica.
+    assert!(matches!(
+        graph
+            .query("CREATE (n:Data {value: 1})")
+            .prefer_replica()
+            .execute(),
+        Err(FalkorDBError::ReadPreferenceNotReadOnly { context: "query" })
+    ));
+
+    // The same query without the replica preference still works.
+    assert!(graph.query("CREATE (n:Data {value: 1})").execute().is_ok());
+
+    let _ = graph.delete();
+}
+
+#[test]
+fn test_read_preference_replica_on_write_batch_errors() {
+    if skip_if_no_server() {
+        return;
+    }
+
+    let conn_info = match get_test_connection_info() {
+        Ok(info) => info,
+        Err(_) => return,
+    };
+
+    let client = match FalkorClientBuilder::new()
+        .with_connection_info(conn_info)
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let mut graph = client.select_graph("test_read_preference_batch_errors");
+
+    // A batch that mixes a write with a replica preference is rejected: the whole pipeline runs on
+    // one connection, and a write cannot run on a replica.
+    let mut batch = graph.batch().prefer_replica();
+    batch.query("CREATE (n:Data {value: 1})");
+    batch.ro_query("MATCH (n:Data) RETURN count(n)");
+    assert!(matches!(
+        batch.execute(),
+        Err(FalkorDBError::ReadPreferenceNotReadOnly { context: "batch" })
+    ));
+
+    // An all-read batch may opt into a replica (and falls back to the primary on single-node).
+    let mut read_batch = graph.batch().prefer_replica();
+    read_batch.ro_query("MATCH (n:Data) RETURN count(n)");
+    assert!(read_batch.execute().is_ok());
+
+    let _ = graph.delete();
+}
+
+#[test]
+fn test_client_default_read_preference_prefer_replica() {
+    if skip_if_no_server() {
+        return;
+    }
+
+    let conn_info = match get_test_connection_info() {
+        Ok(info) => info,
+        Err(_) => return,
+    };
+
+    let client = match FalkorClientBuilder::new()
+        .with_connection_info(conn_info)
+        .with_read_preference(ReadPreference::PreferReplica)
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    assert_eq!(client.read_preference(), ReadPreference::PreferReplica);
+
+    let mut graph = client.select_graph("test_client_default_prefer_replica");
+    let _ = graph.query("CREATE (n:Data {value: 9})").execute();
+
+    // With a client-wide PreferReplica default, a read-only query is served from a replica when
+    // available and otherwise transparently from the primary — either way it succeeds.
+    assert!(graph
+        .ro_query("MATCH (n:Data) RETURN n.value")
+        .execute()
+        .is_ok());
+
+    // A read-your-writes path can still force the primary for this client.
+    assert!(graph
+        .ro_query("MATCH (n:Data) RETURN n.value")
+        .primary_only()
+        .execute()
+        .is_ok());
+
+    // Writes are unaffected by the client read preference (they always use the primary).
+    assert!(graph.query("CREATE (n:Data {value: 10})").execute().is_ok());
 
     let _ = graph.delete();
 }


### PR DESCRIPTION
## What & why

Routing read-only queries to replicas was **automatic and silent**: `ro_query` / `call_procedure_ro` (and all-read batches) were sent to a replica whenever a Sentinel deployment exposed one, with no opt-out and no warning. Because a FalkorDB replica applies writes only **after** the primary, those reads can be **stale** — an accuracy hazard the caller never agreed to.

This decouples the two concepts the old API conflated:
- the **read-only command** (`GRAPH.RO_QUERY`) — whether the server lets the query write, and
- **replica routing** — which node answers (a consistency/accuracy choice).

Routing is now **opt-in, primary by default**.

## API

```rust
use falkordb::{FalkorClientBuilder, ReadPreference};

// Client-wide default (defaults to ReadPreference::Primary)
let client = FalkorClientBuilder::new()
    .with_read_preference(ReadPreference::PreferReplica)
    .build()?;

// Per-request override (wins over the client default)
graph.ro_query("MATCH ...").prefer_replica().execute()?; // offload to a replica
graph.ro_query("MATCH ...").primary_only().execute()?;   // read-your-writes
```

- New `ReadPreference { Primary (default), PreferReplica }` (`#[non_exhaustive]`).
- `with_read_preference` / `prefer_replica()` / `primary_only()` on `QueryBuilder`, `ProcedureQueryBuilder`, `BatchBuilder`; resolution is per-request → client default → `Primary`.
- Requesting a replica for a **writable** query/procedure/batch fails with the new `FalkorDBError::ReadPreferenceNotReadOnly` (before any round-trip) instead of being silently ignored.
- New accessors `replica_reads_available()` (capability) and `read_preference()` (policy); **deprecates** `reads_from_replicas()`.
- `PreferReplica` still falls back to the primary when no replica exists, so single-node deployments are unaffected.

## Breaking change

Read-only queries now run on the **primary by default**. Restore the previous offload with `.with_read_preference(ReadPreference::PreferReplica)`. See [`docs/migrating-to-0.10.md`](https://github.com/FalkorDB/falkordb-rs/blob/main/docs/migrating-to-0.10.md).

## Validation

- `just done` — all static gates green (incl. `clippy-all`, `check-readme`, `check-llms`).
- `just test-local` — full server-backed suite: **675 passed**, 3 skipped (incl. new read-preference + error-path tests, sync & async).
- `just coverage` — **100%** patch coverage on the change.
- Design and implementation both rubber-duck reviewed — no issues.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ReadPreference` enum (`Primary` default, `PreferReplica`) for configuring read-only query routing.
  * New builder method `with_read_preference()` to set client-wide routing policy.
  * New per-query methods `.prefer_replica()` and `.primary_only()` for overriding routing on individual operations.
  * Added `replica_reads_available()` and `read_preference()` accessors.

* **Breaking Changes**
  * Read-only queries now default to primary routing; replica routing requires explicit opt-in.
  * Write operations fail when replica routing is requested (`ReadPreferenceNotReadOnly` error).

* **Deprecations**
  * Deprecated `reads_from_replicas()` in favor of `replica_reads_available()` and `read_preference()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->