### PR TITLE
feat: build-time embedded module bundle for offline runtime

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -167,3 +167,5 @@ rdme
 rustdoc
 doctest
 intra
+distro
+SSPL

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,11 @@ env:
   CARGO_NET_RETRY: "10"
   CARGO_HTTP_MULTIPLEXING: "false"
 
+# Least privilege: every job only checks out code and runs a build/test recipe,
+# so read-only access to the repository contents is all any of them needs.
+permissions:
+  contents: read
+
 # Every job runs a single `just` recipe so the exact command can be reproduced
 # locally (see the Justfile / CONTRIBUTING.md).
 jobs:
@@ -143,6 +148,24 @@ jobs:
           cache-bin: "false"
       - name: Build
         run: just build
+
+  check-embedded-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
+        with:
+          tool: just
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # Cache only dependency sources (registry/git), not target/ or ~/.cargo/bin:
+          # prevents the crates.io refetch that flaked, with no stale-artifact risk.
+          cache-targets: "false"
+          cache-bin: "false"
+      - name: Check embedded-bundle (build-time module embed, hermetic)
+        run: just check-embedded-bundle
 
   check-proptest:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Build-time embedded-module bundling via a new `embedded-bundle` feature. A `build.rs` fetches the
+  FalkorDB `falkordb.so` module for the build target at **compile time** and embeds it in the binary
+  (`include_bytes!`), so the embedded server starts with **no runtime network access** — for
+  network-isolated deployments. Build-time environment variables control the bundle:
+  `FALKORDB_EMBEDDED_MODULE_VERSION` (release tag; defaults to a pinned version),
+  `FALKORDB_EMBEDDED_MODULE_PLATFORM` (asset override for distro-specific Linux targets),
+  `FALKORDB_EMBEDDED_MODULE_PATH` (embed a local `.so` for fully offline builds) and
+  `FALKORDB_EMBEDDED_MODULE_SHA256` (required to embed a non-default downloaded version). Adds
+  `EmbeddedServer::bundled_module_version()` / `bundled_module_platform()` accessors and a new
+  `embedded-core` feature for the shared embedded logic. The embedded server now also pre-flights
+  `redis-server --version` and fails early when it is older than the required 8.0
+  ([#278](https://github.com/FalkorDB/falkordb-rs/pull/278))
 - Opt-in replica routing for read-only queries via a new `ReadPreference` enum (`Primary`, the
   default, and `PreferReplica`). Set a client-wide default with
   `FalkorClientBuilder::with_read_preference`, or override per request with the `with_read_preference`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,7 @@ reproduced with a single command:
 | `check-examples` | `just build-examples` |
 | `check-deny` | `just deny` |
 | `check-proptest` | `just proptest` |
+| `check-embedded-bundle` | `just check-embedded-bundle` |
 | `integration-tests` | `just integration` and `just integration --all-features` |
 | `integration-tests-tokio` | `just integration --features tokio` |
 | `coverage` | `just coverage` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ categories = ["database"]
 keywords = ["database", "graph-database", "database-driver", "falkordb"]
 
 [package.metadata.docs.rs]
-all-features = true
+# `embedded-bundle` is intentionally excluded: it runs a build-time download in
+# build.rs, which must not happen on docs.rs. Enable every other feature.
+features = ["tokio", "tokio-native-tls", "tokio-rustls", "native-tls", "rustls", "tracing", "metrics", "embedded", "serde"]
 
 [lib]
 
@@ -70,7 +72,18 @@ tracing = ["dep:tracing"]
 # bounded labels via the `metrics` facade, so the application can install any exporter.
 metrics = ["dep:metrics"]
 
-embedded = ["dep:which", "dep:ureq", "dep:sha2"]
+embedded-core = ["dep:which"]
+
+# Runtime self-contained mode: download the FalkorDB module on first start
+# (needs network at runtime). `embedded` is kept for backward compatibility.
+embedded = ["embedded-core", "dep:ureq", "dep:sha2"]
+
+# Build-time bundle mode (offline at runtime): a `build.rs` fetches the FalkorDB
+# module for the build target and embeds it in the binary, so the running
+# process never touches the network. The build-time download uses `curl` and a
+# small bundled SHA-256 (see `build.rs` / `provision_shared.rs`), so the runtime
+# carries no HTTP/hashing dependencies (`ureq`/`sha2` are not pulled in).
+embedded-bundle = ["embedded-core"]
 
 # Optional `serde` integration: derive `serde::Deserialize` on your own types and
 # map query results straight into them via [`FalkorValue::deserialize_into`].
@@ -96,7 +109,7 @@ required-features = ["tokio"]
 
 [[example]]
 name = "embedded_usage"
-required-features = ["embedded"]
+required-features = ["embedded-core"]
 
 [[example]]
 name = "typed_mapping"

--- a/Justfile
+++ b/Justfile
@@ -96,6 +96,23 @@ test-embedded:
     FALKORDB_HOST={{host}} FALKORDB_PORT={{port}} \
         cargo nextest run --features {{features}} --test embedded_integration
 
+# Validate the `embedded-bundle` feature (build-time module embed) hermetically:
+# build the lib, example and tests with a fixture `.so` via FALKORDB_EMBEDDED_MODULE_PATH
+# (no network, no live server) and run the bundle unit tests. This exercises build.rs,
+# the feature wiring, `include_bytes!` and runtime extraction. CI runs this same recipe.
+check-embedded-bundle:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fixture_dir="$(mktemp -d)"
+    trap 'rm -rf "$fixture_dir"' EXIT
+    fixture="$fixture_dir/falkordb-fixture.so"
+    # Deterministic placeholder bytes; the bundle path never loads it into redis.
+    printf 'falkordb-embedded-bundle-fixture-module\n' > "$fixture"
+    export FALKORDB_EMBEDDED_MODULE_PATH="$fixture"
+    cargo build --features embedded-bundle
+    cargo build --features embedded-bundle --example embedded_usage
+    cargo test --features embedded-bundle --lib embedded::bundle
+
 # Run the integration_tests binary with the given cargo args, exactly as the
 # integration CI jobs do. Examples: `just integration`,
 # `just integration --features tokio`, `just integration --all-features`.
@@ -120,10 +137,25 @@ test-local: db-up db-populate
 # === Coverage ================================================================
 
 # Generate Codecov JSON coverage (matches the `coverage` CI job).
+#
+# Two merged passes so every feature's lines are measured: (1) the full suite
+# against a live server with the dev features, and (2) the build-time
+# `embedded-bundle` path, hermetically (a fixture `.so` via
+# FALKORDB_EMBEDDED_MODULE_PATH — no server, no network). `embedded-bundle`
+# bundles `bundle.rs` and the bundle-mode resolution branch that the dev feature
+# set compiles out.
 coverage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fixture_dir="$(mktemp -d)"
+    trap 'rm -rf "$fixture_dir"' EXIT
+    printf 'falkordb-embedded-bundle-fixture-module\n' > "$fixture_dir/falkordb-fixture.so"
+    cargo llvm-cov clean --workspace
     FALKORDB_HOST={{host}} FALKORDB_PORT={{port}} \
-        cargo llvm-cov nextest --all --features {{features}} \
-        --codecov --output-path codecov.json
+        cargo llvm-cov nextest --no-report --all --features {{features}}
+    FALKORDB_EMBEDDED_MODULE_PATH="$fixture_dir/falkordb-fixture.so" \
+        cargo llvm-cov nextest --no-report --lib --features embedded-bundle
+    cargo llvm-cov report --codecov --output-path codecov.json
 
 # Generate an HTML coverage report and open it.
 coverage-html:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ OpenTelemetry-aligned tracing and metrics.
 - **Resilient** — opt-in `RetryPolicy` with bounded backoff for transient failures; writes are never retried.
 - **Observable** — OpenTelemetry-aligned `tracing` spans and `metrics` counters/histograms, privacy-safe by default.
 - **Replica-aware** — opt in to routing read-only queries to replicas behind Redis Sentinel.
-- **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping.
+- **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping, with an
+  optional build-time bundle mode that runs fully offline.
 
 ## Table of contents
 
@@ -107,7 +108,8 @@ All features are **off by default** — enable only what you need:
 | `serde` | Map query results into your own `serde::Deserialize` types. |
 | `tracing` | OpenTelemetry-aligned `tracing` spans with a privacy-safe query fingerprint. |
 | `metrics` | Counters and histograms via the `metrics` facade (install any exporter). |
-| `embedded` | Run a self-contained embedded FalkorDB server. |
+| `embedded` | Run a self-contained embedded FalkorDB server (module downloaded at runtime). |
+| `embedded-bundle` | Embed the module at build time so the embedded server runs fully offline. |
 | `rustls` / `native-tls` | TLS for the sync client, via `rustls` or `native-tls`. |
 | `tokio-rustls` / `tokio-native-tls` | TLS for the async client. |
 
@@ -826,19 +828,48 @@ To use the embedded feature, enable it:
 cargo add falkordb --features embedded
 ```
 
+#### Choosing a module-provisioning mode
+
+The `redis-server` binary is **never** downloaded — it must be installed on the host (see
+Requirements). Only the FalkorDB `falkordb.so` **module** is provisioned, and there are two
+features for that:
+
+- **`embedded`** — *runtime download*. The module is downloaded on first start (and cached), so
+  the running process **needs network access** the first time. Best for development.
+- **`embedded-bundle`** — *build-time embed, offline at runtime*. A `build.rs` fetches the module
+  for the build target at **compile time** and embeds it in your binary, so the running process
+  needs **no network at all**. Best for network-isolated deployments. Enable it instead of
+  `embedded`:
+
+  ```bash
+  cargo add falkordb --features embedded-bundle
+  ```
+
+  Control the bundled module at build time with environment variables:
+  `FALKORDB_EMBEDDED_MODULE_VERSION` (release tag; defaults to the pinned version),
+  `FALKORDB_EMBEDDED_MODULE_PLATFORM` (override the asset for distro-specific Linux targets such
+  as `rhel9-x64`), and `FALKORDB_EMBEDDED_MODULE_PATH` to embed a **local** `.so` instead of
+  downloading (fully offline builds, or unsupported platforms). A non-default version must be
+  accompanied by `FALKORDB_EMBEDDED_MODULE_SHA256` — unchecked downloaded native code is never
+  embedded. The downloading build uses the host `curl` (set `FALKORDB_EMBEDDED_MODULE_PATH` on
+  build hosts without `curl` or network access); the `embedded-bundle` runtime itself carries no
+  HTTP/hashing dependencies.
+
+  > **License:** `embedded-bundle` embeds the SSPL-licensed FalkorDB module into your binary, so
+  > you are responsible for complying with its license when you distribute that binary.
+
 #### Requirements
 
-- `redis-server` must be installed and available in PATH (or you can specify a custom path).
-  It is **not** downloaded automatically — install it from your package manager
-  (e.g. `brew install redis`, `apt-get install redis-server`).
-- The `falkordb.so` module is provisioned automatically when `auto_download` is enabled
-  (the default): it is downloaded from the official [FalkorDB](https://github.com/falkordb/falkordb)
-  releases, verified against a pinned SHA-256 checksum and cached locally. You can also point
-  `falkordb_module_path` at an existing module, or disable `auto_download` to use only
-  explicit/system-installed binaries.
+- `redis-server` (**version 8.0 or newer**) must be installed and available in PATH (or you can
+  specify a custom path). It is **not** downloaded automatically — install it from your package
+  manager (e.g. `brew install redis`, `apt-get install redis-server`).
+- The `falkordb.so` module is provisioned automatically: downloaded at runtime with `embedded`
+  (when `auto_download` is enabled, the default) or embedded at build time with
+  `embedded-bundle`. You can also point `falkordb_module_path` at an existing module, or disable
+  `auto_download` to use only explicit/system-installed binaries.
 - On macOS the module requires OpenMP: `brew install libomp`.
 
-Supported auto-download platforms: Linux x86_64/aarch64 (glibc and musl/Alpine, plus
+Supported platforms: Linux x86_64/aarch64 (glibc and musl/Alpine, plus
 RHEL 8/9 and Amazon Linux 2023 on x86_64) and macOS aarch64 (Apple Silicon).
 
 #### Self-contained vs. already-installed

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,288 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Build script for the `embedded-bundle` feature.
+//!
+//! When `embedded-bundle` is enabled, this fetches the FalkorDB module (`.so`)
+//! for the **build target** and writes it to `OUT_DIR`, so the library can
+//! `include_bytes!` it and run the embedded server with **no runtime network
+//! access**. The fetch happens here at build time precisely so the deployed
+//! binary needs no network.
+//!
+//! Inputs (all optional; env vars):
+//! * `FALKORDB_EMBEDDED_MODULE_VERSION` — release tag to fetch (default: pinned).
+//! * `FALKORDB_EMBEDDED_MODULE_PLATFORM` — override the asset platform tag
+//!   (e.g. `rhel9-x64`) when the target triple is ambiguous (distro-specific).
+//! * `FALKORDB_EMBEDDED_MODULE_PATH` — use a local `.so` instead of downloading
+//!   (fully offline builds / unsupported platforms).
+//! * `FALKORDB_EMBEDDED_MODULE_SHA256` — expected SHA-256; required to download a
+//!   non-pinned version (we never embed unchecked downloaded native code).
+//!
+//! When `embedded-bundle` is off (the default), this script does nothing beyond
+//! registering rerun triggers, and pulls in no dependencies.
+
+fn main() {
+    // Re-run when any bundle input changes (cheap; always registered).
+    for var in [
+        "FALKORDB_EMBEDDED_MODULE_VERSION",
+        "FALKORDB_EMBEDDED_MODULE_PLATFORM",
+        "FALKORDB_EMBEDDED_MODULE_PATH",
+        "FALKORDB_EMBEDDED_MODULE_SHA256",
+    ] {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/embedded/provision_shared.rs");
+
+    #[cfg(feature = "embedded-bundle")]
+    bundle::run();
+}
+
+// The pure platform/asset/checksum mapping shared with the library, so the
+// build-time asset selection can never drift from the runtime's. Declared at the
+// build-script root so its `#[path]` resolves relative to the crate root.
+#[cfg(feature = "embedded-bundle")]
+#[allow(dead_code)]
+#[path = "src/embedded/provision_shared.rs"]
+mod provision_shared;
+
+#[cfg(feature = "embedded-bundle")]
+mod bundle {
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    use super::provision_shared::{module_checksum, sha256_hex, Platform, FALKORDB_VERSION};
+
+    /// Print a build error and abort the build.
+    fn fail(msg: &str) -> ! {
+        // Cargo doesn't surface build-script panics verbatim, so emit the message
+        // as a warning for visibility, then panic to halt the build.
+        println!("cargo:warning=embedded-bundle: {msg}");
+        panic!("embedded-bundle: {msg}");
+    }
+
+    fn env(name: &str) -> Option<String> {
+        std::env::var(name).ok().filter(|v| !v.is_empty())
+    }
+
+    pub fn run() {
+        let version =
+            env("FALKORDB_EMBEDDED_MODULE_VERSION").unwrap_or_else(|| FALKORDB_VERSION.to_string());
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo"));
+        let dest = out_dir.join("falkordb_module.so");
+
+        // docs.rs must never download. Embed an empty placeholder so the crate
+        // still compiles for docs (include_bytes! + the metadata env vars) with no
+        // network. (docs.rs also excludes this feature via package metadata.)
+        if env("DOCS_RS").is_some() {
+            write_atomic(&dest, b"");
+            emit(&dest, &version, "docs-rs", &sha256_hex(b""));
+            return;
+        }
+
+        // A local module is the offline / unsupported-platform escape hatch: embed
+        // it without requiring a downloadable asset for the build target.
+        if let Some(local) = env("FALKORDB_EMBEDDED_MODULE_PATH") {
+            let sha256 = embed_local(&local, &dest);
+            let tag = env("FALKORDB_EMBEDDED_MODULE_PLATFORM")
+                .or_else(|| resolve_platform().tag_opt().map(str::to_string))
+                .unwrap_or_else(|| "local".to_string());
+            emit(&dest, &version, &tag, &sha256);
+            return;
+        }
+
+        // Download path: requires a supported target platform.
+        let platform = resolve_platform();
+        let tag = platform
+            .tag_opt()
+            .unwrap_or_else(|| fail(&unsupported_platform_message()));
+        let asset = platform
+            .asset_filename_opt()
+            .unwrap_or_else(|| fail(&unsupported_platform_message()));
+        let sha256 = download(&version, tag, asset, &dest);
+        emit(&dest, &version, tag, &sha256);
+    }
+
+    /// Expose the embedded file + metadata to the library via `env!()` /
+    /// `include_bytes!`.
+    fn emit(
+        dest: &Path,
+        version: &str,
+        tag: &str,
+        sha256: &str,
+    ) {
+        println!(
+            "cargo:rustc-env=FALKORDB_EMBEDDED_MODULE_FILE={}",
+            dest.display()
+        );
+        println!("cargo:rustc-env=FALKORDB_EMBEDDED_MODULE_VERSION={version}");
+        println!("cargo:rustc-env=FALKORDB_EMBEDDED_MODULE_PLATFORM={tag}");
+        println!("cargo:rustc-env=FALKORDB_EMBEDDED_MODULE_SHA256={sha256}");
+    }
+
+    /// Resolve the target [`Platform`] from cargo's target cfg, or an explicit
+    /// `FALKORDB_EMBEDDED_MODULE_PLATFORM` override.
+    ///
+    /// Cargo exposes arch/os/libc-flavor but not the Linux distro, so
+    /// distro-specific assets (RHEL/Amazon) need the override; otherwise a
+    /// generic glibc/musl asset is chosen.
+    fn resolve_platform() -> Platform {
+        if let Some(tag) = env("FALKORDB_EMBEDDED_MODULE_PLATFORM") {
+            return Platform::from_tag(&tag).unwrap_or_else(|| {
+                fail(&format!(
+                    "FALKORDB_EMBEDDED_MODULE_PLATFORM='{tag}' is not a known platform tag. \
+                     Known tags: linux-x64-glibc, linux-arm64-glibc, linux-x64-musl, \
+                     linux-arm64-musl, amazonlinux2023-x64, rhel8-x64, rhel9-x64, macos-arm64."
+                ))
+            });
+        }
+        let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let is_musl = std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("musl");
+        // No /etc/os-release at build time → generic glibc/musl (distro override above).
+        Platform::classify(&os, &arch, None, is_musl)
+    }
+
+    fn unsupported_platform_message() -> String {
+        let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        format!(
+            "no FalkorDB module asset for target {os}/{arch}. Set \
+             FALKORDB_EMBEDDED_MODULE_PLATFORM to a supported tag, or \
+             FALKORDB_EMBEDDED_MODULE_PATH to a local `.so` to embed."
+        )
+    }
+
+    /// Embed a user-provided local `.so`. Verifies its SHA-256 only when the
+    /// user explicitly sets `FALKORDB_EMBEDDED_MODULE_SHA256` — a local file is
+    /// the user's own artifact (possibly a custom build that legitimately differs
+    /// from the official release), so it is otherwise trusted as-is.
+    fn embed_local(
+        local: &str,
+        dest: &PathBuf,
+    ) -> String {
+        println!("cargo:rerun-if-changed={local}");
+        let bytes = std::fs::read(local).unwrap_or_else(|e| {
+            fail(&format!(
+                "cannot read FALKORDB_EMBEDDED_MODULE_PATH '{local}': {e}"
+            ))
+        });
+        let actual = sha256_hex(&bytes);
+
+        if let Some(expected) = env("FALKORDB_EMBEDDED_MODULE_SHA256") {
+            if !actual.eq_ignore_ascii_case(&expected) {
+                fail(&format!(
+                    "SHA-256 mismatch for local module '{local}': expected {expected}, got {actual}"
+                ));
+            }
+        }
+        write_atomic(dest, &bytes);
+        actual
+    }
+
+    /// Download the module from the official releases and embed it. Always
+    /// verifies a checksum: the pinned one for the default version, or an
+    /// explicit `FALKORDB_EMBEDDED_MODULE_SHA256` for any other version. We never
+    /// embed unchecked downloaded native code.
+    fn download(
+        version: &str,
+        tag: &str,
+        asset: &str,
+        dest: &PathBuf,
+    ) -> String {
+        let expected = env("FALKORDB_EMBEDDED_MODULE_SHA256")
+            .or_else(|| module_checksum(version, tag).map(str::to_string))
+            .unwrap_or_else(|| {
+                fail(&format!(
+                    "no pinned checksum for version '{version}' on platform '{tag}'. Set \
+                     FALKORDB_EMBEDDED_MODULE_SHA256 to the expected SHA-256, or \
+                     FALKORDB_EMBEDDED_MODULE_PATH to embed a local file instead."
+                ))
+            });
+
+        let url =
+            format!("https://github.com/FalkorDB/FalkorDB/releases/download/{version}/{asset}");
+        let bytes = http_get(&url);
+        let actual = sha256_hex(&bytes);
+        if !actual.eq_ignore_ascii_case(&expected) {
+            fail(&format!(
+                "SHA-256 mismatch for {url}: expected {expected}, got {actual}"
+            ));
+        }
+        write_atomic(dest, &bytes);
+        actual
+    }
+
+    /// Download `url` with the host `curl`, returning the bytes. Using `curl`
+    /// keeps `build.rs` dependency-free — declaring an HTTP client as a second
+    /// build-dependency of a runtime crate breaks `cargo-nextest`, and pulling a
+    /// TLS stack into the offline `embedded-bundle` runtime would defeat its
+    /// purpose. Hosts without `curl` (or network) use
+    /// `FALKORDB_EMBEDDED_MODULE_PATH` instead.
+    fn http_get(url: &str) -> Vec<u8> {
+        // Up to 100 MiB — the module is ~10-20 MiB.
+        const MAX_BYTES: u64 = 100 * 1024 * 1024;
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR set by cargo"));
+        let tmp = out_dir.join(format!("download.tmp.{}", std::process::id()));
+
+        let status = std::process::Command::new("curl")
+            .args([
+                "--fail",
+                "--silent",
+                "--show-error",
+                "--location",
+                "--proto",
+                "=https",
+                "--proto-redir",
+                "=https",
+                "--max-time",
+                "300",
+                "--retry",
+                "3",
+                "--max-filesize",
+            ])
+            .arg(MAX_BYTES.to_string())
+            .arg("--output")
+            .arg(&tmp)
+            .arg(url)
+            .status()
+            .unwrap_or_else(|e| {
+                fail(&format!(
+                    "failed to run `curl` to download {url}: {e}. Install curl, or set \
+                     FALKORDB_EMBEDDED_MODULE_PATH to a local module."
+                ))
+            });
+        if !status.success() {
+            let _ = std::fs::remove_file(&tmp);
+            fail(&format!("`curl` failed to download {url} (exit {status})"));
+        }
+
+        let bytes = std::fs::read(&tmp)
+            .unwrap_or_else(|e| fail(&format!("cannot read downloaded {}: {e}", tmp.display())));
+        let _ = std::fs::remove_file(&tmp);
+        if bytes.len() as u64 > MAX_BYTES {
+            fail(&format!("download from {url} exceeded {MAX_BYTES} bytes"));
+        }
+        bytes
+    }
+
+    /// Write `bytes` to `dest` via a temp file + rename, so a partial write is
+    /// never observed (and concurrent builds don't tear each other's output).
+    fn write_atomic(
+        dest: &PathBuf,
+        bytes: &[u8],
+    ) {
+        let tmp = dest.with_extension(format!("so.tmp.{}", std::process::id()));
+        let mut file = std::fs::File::create(&tmp)
+            .unwrap_or_else(|e| fail(&format!("cannot create {}: {e}", tmp.display())));
+        file.write_all(bytes)
+            .and_then(|()| file.flush())
+            .unwrap_or_else(|e| fail(&format!("cannot write {}: {e}", tmp.display())));
+        std::fs::rename(&tmp, dest).unwrap_or_else(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            fail(&format!("cannot finalize {}: {e}", dest.display()))
+        });
+    }
+}

--- a/examples/embedded_usage.rs
+++ b/examples/embedded_usage.rs
@@ -29,6 +29,17 @@
 //! `falkordb_module_path` explicitly or disable `auto_download` (common system
 //! locations are still searched). See `already_installed_config()` below.
 //!
+//! # Build-time bundle (offline at runtime)
+//!
+//! For network-isolated deployments, enable the `embedded-bundle` feature instead
+//! of `embedded`. A `build.rs` fetches the module for the build target at compile
+//! time and embeds it in the binary, so the running process needs **no network**.
+//! The same `EmbeddedConfig` / API shown here works unchanged; only the module
+//! source differs. Run it with:
+//! ```bash
+//! cargo run --example embedded_usage --features embedded-bundle
+//! ```
+//!
 //! # Platform-Specific Requirements
 //!
 //! ## macOS
@@ -37,8 +48,9 @@
 //!
 //! # License Note
 //!
-//! The downloaded FalkorDB module binary is licensed under the Server Side Public
-//! License (SSPL) v1. See https://www.falkordb.com/ for licensing details.
+//! The FalkorDB module binary (downloaded at runtime, or embedded at build time
+//! with `embedded-bundle`) is licensed under the Server Side Public License
+//! (SSPL) v1. See https://www.falkordb.com/ for licensing details.
 //!
 //! # Running this example
 //! ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -76,8 +76,8 @@ hand; if you change the public API, run `just llms` and commit the updated `llms
 - `DateTime`
 - `Duration`
 - `Edge`
-- `EmbeddedConfig` — requires `embedded`
-- `EmbeddedServer` — requires `embedded`
+- `EmbeddedConfig` — requires `embedded-core`
+- `EmbeddedServer` — requires `embedded-core`
 - `EntityType`
 - `ExecutionPlan`
 - `FalkorAsyncClient` — requires `tokio`

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -914,7 +914,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(FalkorAsyncClient::build_executor(
@@ -949,7 +949,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: Some(replica),
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(provider.has_sentinel_replica());
@@ -975,7 +975,7 @@ mod tests {
             client: redis::Client::open("redis://127.0.0.1:6379").unwrap(),
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         let readonly_conn = provider

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -637,7 +637,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(FalkorSyncClient::create_readonly_pool(&mut provider, 4).is_none());
@@ -663,7 +663,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: Some(replica),
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(provider.has_sentinel_replica());

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -205,7 +205,7 @@ impl<const R: char> FalkorClientBuilder<R> {
             .try_into()
             .map_err(|err| FalkorDBError::InvalidConnectionInfo(err.to_string()))?;
 
-        #[cfg(feature = "embedded")]
+        #[cfg(feature = "embedded-core")]
         if let FalkorConnectionInfo::Embedded(ref config) = connection_info {
             // Start the embedded server
             let embedded_server =
@@ -248,11 +248,11 @@ impl<const R: char> FalkorClientBuilder<R> {
                         client,
                         sentinel: None,
                         sentinel_replica: None,
-                        #[cfg(feature = "embedded")]
+                        #[cfg(feature = "embedded-core")]
                         embedded_server: None,
                     }
                 }
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 FalkorConnectionInfo::Embedded(_) => unreachable!("Handled above"),
             },
             connection_info,
@@ -485,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_config_creation() {
         // Test that we can create an embedded config
         let config = crate::EmbeddedConfig::default();
@@ -495,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_builder_fails_without_binaries() {
         // Test that building with embedded config fails gracefully when binaries are not found
         use std::path::PathBuf;
@@ -518,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_builder_with_custom_config() {
         use std::path::PathBuf;
 
@@ -581,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "embedded", feature = "tokio"))]
+    #[cfg(all(feature = "embedded-core", feature = "tokio"))]
     fn test_async_builder_with_embedded() {
         use std::path::PathBuf;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -139,7 +139,7 @@ pub(crate) enum FalkorClientProvider {
         /// uses replica-only connection getters (no primary fallback) so the pool is
         /// only built when a replica connection actually succeeds.
         sentinel_replica: Option<redis::sentinel::SentinelClient>,
-        #[cfg(feature = "embedded")]
+        #[cfg(feature = "embedded-core")]
         #[allow(dead_code)]
         embedded_server: Option<std::sync::Arc<crate::embedded::EmbeddedServer>>,
     },
@@ -507,7 +507,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(!provider.has_sentinel_replica());
@@ -653,7 +653,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         assert!(!provider.has_sentinel_replica());
@@ -670,7 +670,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_falkor_client_provider_with_embedded_server() {
         // Test that FalkorClientProvider::Redis can hold an embedded server
         let client = redis::Client::open("redis://127.0.0.1:6379").unwrap();
@@ -691,7 +691,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         // Just verify the structure can be created
@@ -716,7 +716,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: Some(replica),
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         // The replica connection fails and the error must surface as a replica-path
@@ -747,7 +747,7 @@ mod tests {
                 client,
                 sentinel: None,
                 sentinel_replica: Some(replica),
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 embedded_server: None,
             };
             let result = provider.get_async_replica_connection().await;
@@ -768,7 +768,7 @@ mod tests {
             client,
             sentinel: None,
             sentinel_replica: None,
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             embedded_server: None,
         };
         let result = provider.get_replica_connection();
@@ -786,7 +786,7 @@ mod tests {
                 client,
                 sentinel: None,
                 sentinel_replica: None,
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 embedded_server: None,
             };
             let result = provider.get_async_replica_connection().await;
@@ -825,7 +825,7 @@ mod tests {
                 client,
                 sentinel: Some(sentinel),
                 sentinel_replica: None,
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 embedded_server: None,
             };
             // The sentinel arm resolves the master through an unreachable sentinel, which
@@ -857,7 +857,7 @@ mod tests {
                 client,
                 sentinel: None,
                 sentinel_replica: Some(replica),
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 embedded_server: None,
             };
             let result = provider.get_async_replica_connection_manager(None).await;
@@ -879,7 +879,7 @@ mod tests {
                 client,
                 sentinel: None,
                 sentinel_replica: None,
-                #[cfg(feature = "embedded")]
+                #[cfg(feature = "embedded-core")]
                 embedded_server: None,
             };
             let result = provider.get_async_replica_connection_manager(None).await;

--- a/src/connection_info/mod.rs
+++ b/src/connection_info/mod.rs
@@ -5,7 +5,7 @@
 
 use crate::{FalkorDBError, FalkorResult};
 
-#[cfg(feature = "embedded")]
+#[cfg(feature = "embedded-core")]
 use crate::embedded::EmbeddedConfig;
 
 /// An agnostic container which allows maintaining of various connection details.
@@ -14,8 +14,9 @@ use crate::embedded::EmbeddedConfig;
 pub enum FalkorConnectionInfo {
     /// A Redis database connection
     Redis(redis::ConnectionInfo),
-    /// An embedded FalkorDB server (requires the "embedded" feature)
-    #[cfg(feature = "embedded")]
+    /// An embedded FalkorDB server (requires the "embedded-core" feature, enabled
+    /// by both "embedded" and "embedded-bundle")
+    #[cfg(feature = "embedded-core")]
     Embedded(EmbeddedConfig),
 }
 
@@ -39,7 +40,7 @@ impl FalkorConnectionInfo {
     pub fn address(&self) -> String {
         match self {
             FalkorConnectionInfo::Redis(redis_info) => redis_info.addr().to_string(),
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             FalkorConnectionInfo::Embedded(_) => "embedded".to_string(),
         }
     }
@@ -97,7 +98,7 @@ mod tests {
             FalkorConnectionInfo::Redis(redis) => {
                 assert_eq!(redis.addr().to_string(), "127.0.0.1:6379".to_string());
             }
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             _ => panic!("Expected Redis connection info"),
         }
     }
@@ -119,7 +120,7 @@ mod tests {
             FalkorConnectionInfo::Redis(conn) => {
                 assert_eq!(conn.addr(), raw_redis_conn.addr());
             }
-            #[cfg(feature = "embedded")]
+            #[cfg(feature = "embedded-core")]
             _ => panic!("Expected Redis connection info"),
         }
     }
@@ -162,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_connection_info_address() {
         use crate::EmbeddedConfig;
         let config = EmbeddedConfig::default();
@@ -171,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_connection_info_clone() {
         use crate::EmbeddedConfig;
         use std::path::PathBuf;
@@ -196,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "embedded")]
+    #[cfg(feature = "embedded-core")]
     fn test_embedded_connection_info_debug() {
         use crate::EmbeddedConfig;
         let config = EmbeddedConfig::default();

--- a/src/embedded/bundle.rs
+++ b/src/embedded/bundle.rs
@@ -1,0 +1,297 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Build-time-bundled FalkorDB module (`embedded-bundle` feature).
+//!
+//! With `embedded-bundle`, `build.rs` fetches the module for the build target
+//! and embeds it here via [`include_bytes!`]. At runtime the bytes are written
+//! once to a content-addressed cache file (keyed by the module's build-time
+//! SHA-256) and that path is handed to `redis-server --loadmodule`. This path
+//! performs **no network access**, which is the whole point of the feature.
+//!
+//! No SHA-256 is computed at runtime (the feature pulls in no hashing crate):
+//! the cache directory name is the build-time hash, and an existing extraction
+//! is reused only when its bytes are exactly the embedded module.
+
+use std::path::{Path, PathBuf};
+
+use crate::{FalkorDBError, FalkorResult};
+
+/// The FalkorDB module bytes, embedded at build time for the build target.
+pub const BUNDLED_MODULE: &[u8] = include_bytes!(env!("FALKORDB_EMBEDDED_MODULE_FILE"));
+
+/// The FalkorDB release version the bundled module was fetched from.
+pub const BUNDLED_MODULE_VERSION: &str = env!("FALKORDB_EMBEDDED_MODULE_VERSION");
+
+/// The platform tag (e.g. `linux-x64-glibc`) the bundled module targets.
+pub const BUNDLED_MODULE_PLATFORM: &str = env!("FALKORDB_EMBEDDED_MODULE_PLATFORM");
+
+/// The SHA-256 (hex) of the bundled module, computed at build time.
+pub const BUNDLED_MODULE_SHA256: &str = env!("FALKORDB_EMBEDDED_MODULE_SHA256");
+
+/// Write the embedded module to a content-addressed cache file and return its
+/// path, reusing an existing extraction when present and intact.
+///
+/// The cache directory is `cache_dir` if given, else `FALKORDB_RS_CACHE_DIR`,
+/// else the platform cache dir, else the system temp dir. The file lives at
+/// `<cache>/bundled/<sha256>/falkordb.so`, so different module versions never
+/// collide and an unchanged module is extracted only once.
+pub fn materialize_bundled_module(cache_dir: Option<&Path>) -> FalkorResult<PathBuf> {
+    let dir = cache_root(cache_dir)
+        .join("bundled")
+        .join(BUNDLED_MODULE_SHA256);
+    let dest = dir.join("falkordb.so");
+
+    // Reuse a prior extraction only when its bytes are exactly the embedded
+    // module. The directory is keyed by the build-time content hash, but a shared
+    // cache root (e.g. the world-writable temp fallback) could otherwise let
+    // another local process pre-plant a same-length `.so` that redis would
+    // dlopen — so verify the content, dependency-free, rather than trusting the
+    // length alone.
+    if extracted_matches(&dest) {
+        return Ok(dest);
+    }
+
+    create_private_dir(&dir)?;
+    write_atomic(&dir, &dest)?;
+    Ok(dest)
+}
+
+/// Whether `dest` already holds exactly [`BUNDLED_MODULE`].
+fn extracted_matches(dest: &Path) -> bool {
+    file_len(dest) == Some(BUNDLED_MODULE.len() as u64)
+        && std::fs::read(dest).is_ok_and(|bytes| bytes == BUNDLED_MODULE)
+}
+
+/// Create `dir` (and parents), then restrict it to the owner on Unix so other
+/// local users can't pre-create the content-addressed path with a hostile file.
+/// A failure to apply owner-only permissions is treated as an error: it usually
+/// means the path is pre-owned by another user, which is exactly the planted
+/// module we must not extract into / trust.
+fn create_private_dir(dir: &Path) -> FalkorResult<()> {
+    std::fs::create_dir_all(dir).map_err(|e| {
+        FalkorDBError::EmbeddedServerError(format!(
+            "Failed to create bundled-module cache dir {}: {e}",
+            dir.display()
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(|e| {
+            FalkorDBError::EmbeddedServerError(format!(
+                "Failed to secure bundled-module cache dir {} with owner-only permissions: {e}",
+                dir.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+/// Length of `path` in bytes, or `None` if it does not exist / can't be stat'd.
+fn file_len(path: &Path) -> Option<u64> {
+    std::fs::metadata(path).ok().map(|m| m.len())
+}
+
+/// Write [`BUNDLED_MODULE`] to `dest` via a uniquely-named temp file in `dir`
+/// plus an atomic rename, so a partial write is never observed and concurrent
+/// first-runs don't tear each other's output.
+fn write_atomic(
+    dir: &Path,
+    dest: &Path,
+) -> FalkorResult<()> {
+    use std::io::Write;
+
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = dir.join(format!("falkordb.so.tmp.{}.{unique}", std::process::id()));
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = std::fs::File::create(&tmp)?;
+        file.write_all(BUNDLED_MODULE)?;
+        file.flush()?;
+        // World-readable, owner-writable; redis only needs to read+dlopen it.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o644))?;
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(FalkorDBError::EmbeddedServerError(format!(
+            "Failed to extract bundled FalkorDB module to {}: {e}",
+            tmp.display()
+        )));
+    }
+
+    match std::fs::rename(&tmp, dest) {
+        Ok(()) => Ok(()),
+        Err(rename_err) => {
+            // Lost a race with another process (or the dest already exists and is
+            // intact): clean up our temp file and accept the existing extraction
+            // only if its content is exactly the bundled module.
+            let _ = std::fs::remove_file(&tmp);
+            if extracted_matches(dest) {
+                Ok(())
+            } else {
+                Err(FalkorDBError::EmbeddedServerError(format!(
+                    "Failed to finalize bundled FalkorDB module at {}: {rename_err}",
+                    dest.display()
+                )))
+            }
+        }
+    }
+}
+
+/// Resolve the cache root: explicit `cache_dir`, else `FALKORDB_RS_CACHE_DIR`,
+/// else the platform cache dir, else the system temp dir.
+fn cache_root(cache_dir: Option<&Path>) -> PathBuf {
+    if let Some(dir) = cache_dir {
+        return dir.to_path_buf();
+    }
+    if let Some(dir) = std::env::var_os("FALKORDB_RS_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        #[cfg(target_os = "macos")]
+        let base = home.join("Library").join("Caches");
+        #[cfg(not(target_os = "macos"))]
+        let base = std::env::var_os("XDG_CACHE_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".cache"));
+        return base.join("falkordb-rs");
+    }
+    std::env::temp_dir().join("falkordb-rs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bundled_metadata_is_present() {
+        // The build script always sets these; they must be non-empty and the
+        // SHA-256 must be 64 hex chars.
+        assert!(!BUNDLED_MODULE.is_empty());
+        assert!(BUNDLED_MODULE_VERSION.starts_with('v'));
+        assert!(!BUNDLED_MODULE_PLATFORM.is_empty());
+        assert_eq!(BUNDLED_MODULE_SHA256.len(), 64);
+        assert!(BUNDLED_MODULE_SHA256.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_materialize_extracts_and_reuses() {
+        let tmp = std::env::temp_dir().join(format!("falkordb-bundle-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let first = materialize_bundled_module(Some(&tmp)).expect("extract");
+        assert!(first.exists());
+        assert_eq!(
+            std::fs::metadata(&first).unwrap().len(),
+            BUNDLED_MODULE.len() as u64
+        );
+        assert_eq!(std::fs::read(&first).unwrap(), BUNDLED_MODULE);
+
+        // Second call reuses the same path without rewriting.
+        let second = materialize_bundled_module(Some(&tmp)).expect("reuse");
+        assert_eq!(first, second);
+
+        // A truncated cache file is repaired on the next call.
+        std::fs::write(&first, b"corrupt").unwrap();
+        let third = materialize_bundled_module(Some(&tmp)).expect("repair");
+        assert_eq!(third, first);
+        assert_eq!(std::fs::read(&third).unwrap(), BUNDLED_MODULE);
+
+        // A same-length but different file is NOT trusted: it is re-extracted, so
+        // a planted module at the content-addressed path can't be loaded.
+        std::fs::write(&first, vec![0u8; BUNDLED_MODULE.len()]).unwrap();
+        let repaired = materialize_bundled_module(Some(&tmp)).expect("re-extract on tamper");
+        assert_eq!(std::fs::read(&repaired).unwrap(), BUNDLED_MODULE);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_cache_root_prefers_explicit() {
+        let explicit = PathBuf::from("/tmp/explicit-cache");
+        assert_eq!(cache_root(Some(&explicit)), explicit);
+    }
+
+    // Serializes env-mutating tests so they don't race the parallel runner.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Snapshots an env var and restores it on drop, even if the test panics.
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn capture(key: &'static str) -> Self {
+            Self {
+                key,
+                original: std::env::var_os(key),
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    fn test_cache_root_env_and_home_fallbacks() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Guards restore the originals on drop, even on panic.
+        let _cache = EnvVarGuard::capture("FALKORDB_RS_CACHE_DIR");
+        let _home = EnvVarGuard::capture("HOME");
+        let _xdg = EnvVarGuard::capture("XDG_CACHE_HOME");
+
+        // `FALKORDB_RS_CACHE_DIR` is used when no explicit dir is given.
+        std::env::set_var("FALKORDB_RS_CACHE_DIR", "/custom/cache");
+        assert_eq!(cache_root(None), PathBuf::from("/custom/cache"));
+
+        // Otherwise fall back to the platform cache directory under `HOME`.
+        std::env::remove_var("FALKORDB_RS_CACHE_DIR");
+        std::env::remove_var("XDG_CACHE_HOME");
+        std::env::set_var("HOME", "/test/home");
+        let path = cache_root(None);
+        assert!(
+            path.to_string_lossy().contains("falkordb-rs"),
+            "got {path:?}"
+        );
+        assert!(path.starts_with("/test/home"), "got {path:?}");
+
+        // With neither variable nor HOME set, fall back to the system temp dir.
+        std::env::remove_var("HOME");
+        let path = cache_root(None);
+        assert!(path.ends_with("falkordb-rs"), "got {path:?}");
+    }
+
+    #[test]
+    fn test_materialize_errors_when_cache_path_is_a_file() {
+        // A regular file where a directory is expected makes the cache-dir
+        // creation fail, surfacing an actionable error.
+        let file =
+            std::env::temp_dir().join(format!("falkordb-bundle-file-{}", std::process::id()));
+        std::fs::write(&file, b"not a dir").unwrap();
+        let err = materialize_bundled_module(Some(&file))
+            .expect_err("materialize should fail when the cache path is a file");
+        assert!(
+            err.to_string().contains("cache dir") || err.to_string().contains("Failed"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_file(&file);
+    }
+}

--- a/src/embedded/mod.rs
+++ b/src/embedded/mod.rs
@@ -25,13 +25,18 @@ use std::{fs, thread};
 
 use crate::{FalkorDBError, FalkorResult};
 
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
 pub mod download;
 pub mod provision;
+
+#[cfg(feature = "embedded-bundle")]
+pub mod bundle;
 
 // Maximum length for Unix socket paths (typically 104-108 bytes on most Unix systems)
 const MAX_SOCKET_PATH_LENGTH: usize = 104;
 
 // How long to allow a module download to run before giving up.
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
 const MODULE_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 
 // Counter for ensuring unique temp directories across multiple instances
@@ -39,33 +44,42 @@ static INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Configuration for an embedded FalkorDB server instance.
 ///
-/// # Self-Contained Mode
+/// # Module source
 ///
-/// When `auto_download` is enabled (the default), a missing FalkorDB **module**
-/// (`falkordb.so`) is automatically downloaded from the official FalkorDB
-/// GitHub releases, checksum-verified and cached locally, so the embedded
-/// server "just works" without a pre-installed module.
+/// How the FalkorDB **module** (`falkordb.so`) is located depends on the enabled
+/// cargo feature:
 ///
-/// The `redis-server` binary is **not** downloaded: it is always located on the
-/// host via `redis_server_path` or `PATH`. Install it from your package manager
-/// (e.g. `brew install redis`, `apt-get install redis-server`) or point
-/// `redis_server_path` at an existing FalkorDB/Redis install.
+/// * **`embedded`** (runtime download): with `auto_download` enabled (the
+///   default), a missing module is downloaded from the official FalkorDB GitHub
+///   releases on first start, checksum-verified and cached locally. **Needs
+///   network at runtime** unless already cached or found locally.
+/// * **`embedded-bundle`** (build-time embed): the module is fetched for the
+///   build target at compile time and embedded in the binary, so the running
+///   process performs **no network access**. `auto_download` and
+///   `falkordb_version` have no effect (the version is chosen at build time via
+///   `FALKORDB_EMBEDDED_MODULE_VERSION`); setting `falkordb_version` is rejected.
 ///
-/// To use an already-installed FalkorDB module instead of downloading, either
-/// set `falkordb_module_path` explicitly or leave it unset — common system
-/// locations are searched before any download is attempted.
+/// In both modes, an explicit `falkordb_module_path` always wins.
+///
+/// The `redis-server` binary is **never** downloaded: it is always located on
+/// the host via `redis_server_path` or `PATH`. Install it from your package
+/// manager (e.g. `brew install redis`, `apt-get install redis-server`) or point
+/// `redis_server_path` at an existing FalkorDB/Redis install. FalkorDB requires
+/// redis-server **8.0 or newer**.
 ///
 /// # License Note
 ///
-/// The downloaded FalkorDB module binary is licensed under the Server Side Public
-/// License (SSPL) v1. See https://www.falkordb.com/ for licensing details.
-/// The redis-server binary is also SSPL-licensed as of Redis 7.4+.
+/// The FalkorDB module binary is licensed under the Server Side Public License
+/// (SSPL) v1. With `embedded-bundle` it is **embedded into your binary**, so you
+/// are responsible for complying with its license when distributing. See
+/// <https://www.falkordb.com/> for licensing details.
 #[derive(Debug, Clone)]
 pub struct EmbeddedConfig {
     /// Path to the redis-server executable. If None, searches in PATH.
     pub redis_server_path: Option<PathBuf>,
     /// Path to the FalkorDB module (.so file). If None, searches common
-    /// locations and (when `auto_download` is enabled) downloads it.
+    /// locations and (when `auto_download` is enabled) downloads it; with the
+    /// `embedded-bundle` feature, the build-time-embedded module is used.
     pub falkordb_module_path: Option<PathBuf>,
     /// Directory for the database files. If None, creates a temporary directory.
     pub db_dir: Option<PathBuf>,
@@ -79,13 +93,23 @@ pub struct EmbeddedConfig {
     /// official FalkorDB releases. Defaults to `true`. When `false`, behaves
     /// like a lookup-only resolver (explicit path or system locations) and
     /// errors if the module is not found. `redis-server` is never downloaded.
+    /// **No effect with the `embedded-bundle` feature** (the module is embedded
+    /// at build time and never downloaded at runtime).
     pub auto_download: bool,
     /// Override the FalkorDB version to download. If None, uses the version this
-    /// client pins ([`provision::FALKORDB_VERSION`]). Versions other than the
+    /// client pins (`provision::FALKORDB_VERSION`). Versions other than the
     /// pinned one are downloaded without checksum verification (no pinned hash).
+    /// **Rejected with the `embedded-bundle` feature**: the bundled version is
+    /// selected at build time via `FALKORDB_EMBEDDED_MODULE_VERSION`.
     pub falkordb_version: Option<String>,
-    /// Override the cache directory for downloaded binaries.
-    /// If None, uses platform-specific defaults or `FALKORDB_RS_CACHE_DIR` env var.
+    /// Override the cache directory for downloaded (or build-time-bundled,
+    /// then extracted) binaries. If None, uses platform-specific defaults or the
+    /// `FALKORDB_RS_CACHE_DIR` env var.
+    ///
+    /// The extracted module is verified against the bundled bytes before reuse,
+    /// but on a shared multi-user host prefer a private `cache_dir` (or
+    /// `FALKORDB_RS_CACHE_DIR`): the no-`HOME` fallback under the system temp
+    /// directory is world-writable.
     pub cache_dir: Option<PathBuf>,
 }
 
@@ -121,6 +145,20 @@ pub struct EmbeddedServer {
     config_file: PathBuf,
 }
 
+/// Whether a `redis-server --version` output string reports a major version
+/// older than the 8.0 the FalkorDB module requires. Output that can't be parsed
+/// is treated as new-enough (`false`), leaving the real load attempt to surface
+/// any genuine incompatibility. Example input: `Redis server v=8.6.3 sha=…`.
+fn redis_version_too_old(version_text: &str) -> bool {
+    const MIN_MAJOR: u32 = 8;
+    version_text
+        .split("v=")
+        .nth(1)
+        .and_then(|rest| rest.split('.').next())
+        .and_then(|major| major.trim().parse::<u32>().ok())
+        .is_some_and(|major| major < MIN_MAJOR)
+}
+
 impl EmbeddedServer {
     /// Creates and starts a new embedded FalkorDB server.
     ///
@@ -145,6 +183,10 @@ impl EmbeddedServer {
         // Find redis-server executable
         let redis_server = Self::find_redis_server(&config)?;
 
+        // The FalkorDB module hard-requires redis-server >= 8.0; fail fast with a
+        // clear message rather than an opaque startup timeout.
+        Self::check_redis_version(&redis_server, config.start_timeout)?;
+
         // Find FalkorDB module
         let falkordb_module = Self::find_falkordb_module(&config)?;
 
@@ -157,6 +199,20 @@ impl EmbeddedServer {
 
         let config_file = Self::create_config_file(&db_dir, &socket_path, &config.db_filename)?;
 
+        // Capture redis-server's stderr to a log file so a failed module load
+        // (wrong arch, missing libomp, redis too old, …) surfaces a real cause
+        // instead of only a timeout. Falls back to null if the log can't open.
+        // The name is unique so a caller-provided persistent `db_dir` (or several
+        // servers sharing one) can't clobber an unrelated file.
+        let log_path = db_dir.join(format!(
+            "redis-server.{}.{}.log",
+            std::process::id(),
+            INSTANCE_COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        let stderr = fs::File::create(&log_path)
+            .map(Stdio::from)
+            .unwrap_or_else(|_| Stdio::null());
+
         // Start redis-server with FalkorDB module (no daemonize to keep process handle valid)
         let mut command = Command::new(&redis_server);
         command
@@ -164,7 +220,7 @@ impl EmbeddedServer {
             .arg("--loadmodule")
             .arg(&falkordb_module)
             .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            .stderr(stderr);
 
         let mut process = command.spawn().map_err(|e| {
             FalkorDBError::EmbeddedServerError(format!("Failed to start redis-server: {}", e))
@@ -173,17 +229,22 @@ impl EmbeddedServer {
         // Wait for the socket to be created
         let start_time = std::time::Instant::now();
         while !socket_path.exists() {
-            if start_time.elapsed() > config.start_timeout {
-                // Clean up the process before returning timeout error
+            // If redis exited early (e.g. the module failed to load), stop waiting
+            // and report its stderr instead of burning the whole timeout.
+            let exited = matches!(process.try_wait(), Ok(Some(_)));
+            if exited || start_time.elapsed() > config.start_timeout {
                 let _ = process.kill();
                 let _ = process.wait();
-                // Clean up temporary files
-                let _ = fs::remove_file(&config_file);
-                if let Some(ref temp_dir) = temp_dir {
-                    let _ = fs::remove_dir_all(temp_dir);
-                }
-                return Err(FalkorDBError::EmbeddedServerError(
-                    "Timed out waiting for server to start".to_string(),
+                let reason = if exited {
+                    "redis-server exited before the socket was ready"
+                } else {
+                    "Timed out waiting for server to start"
+                };
+                return Err(Self::start_error(
+                    reason,
+                    &log_path,
+                    &config_file,
+                    temp_dir.as_deref(),
                 ));
             }
             thread::sleep(Duration::from_millis(100));
@@ -192,11 +253,69 @@ impl EmbeddedServer {
         // Give the server a bit more time to be fully ready
         thread::sleep(Duration::from_millis(500));
 
+        // The socket exists, but make sure redis didn't create it and immediately
+        // exit (or that a stale socket wasn't observed) before declaring success.
+        if matches!(process.try_wait(), Ok(Some(_))) {
+            let _ = process.wait();
+            return Err(Self::start_error(
+                "redis-server exited immediately after the socket appeared",
+                &log_path,
+                &config_file,
+                temp_dir.as_deref(),
+            ));
+        }
+
+        // The server is up; the captured log is no longer needed.
+        let _ = fs::remove_file(&log_path);
+
         Ok(Self {
             process,
             socket_path,
             temp_dir,
             config_file,
+        })
+    }
+
+    /// Read the last few KiB of the redis-server log for inclusion in a startup
+    /// error. Returns an empty string when the log is missing or empty.
+    fn read_log_tail(log_path: &Path) -> String {
+        const MAX: usize = 4096;
+        // Decode lossily so a log with stray non-UTF-8 bytes still surfaces its
+        // content (as a diagnostic) instead of being dropped entirely.
+        let bytes = fs::read(log_path).unwrap_or_default();
+        let text = String::from_utf8_lossy(&bytes);
+        let trimmed = text.trim();
+        if trimmed.len() <= MAX {
+            return trimmed.to_string();
+        }
+        // Keep the last ~MAX bytes, snapped up to a char boundary so multibyte
+        // redis output can never panic the slice.
+        let mut start = trimmed.len() - MAX;
+        while !trimmed.is_char_boundary(start) {
+            start += 1;
+        }
+        format!("…{}", &trimmed[start..])
+    }
+
+    /// Build a startup error that includes the redis log tail, cleaning up the
+    /// config file, log file and temp dir. The caller is responsible for having
+    /// already reaped the redis process.
+    fn start_error(
+        reason: &str,
+        log_path: &Path,
+        config_file: &Path,
+        temp_dir: Option<&Path>,
+    ) -> FalkorDBError {
+        let log_tail = Self::read_log_tail(log_path);
+        let _ = fs::remove_file(config_file);
+        let _ = fs::remove_file(log_path);
+        if let Some(temp_dir) = temp_dir {
+            let _ = fs::remove_dir_all(temp_dir);
+        }
+        FalkorDBError::EmbeddedServerError(if log_tail.is_empty() {
+            reason.to_string()
+        } else {
+            format!("{reason}. redis-server output:\n{log_tail}")
         })
     }
 
@@ -208,6 +327,21 @@ impl EmbeddedServer {
     /// Returns a connection string for this embedded server.
     pub fn connection_string(&self) -> String {
         format!("unix://{}", self.socket_path.display())
+    }
+
+    /// The FalkorDB release version of the module embedded at build time (the
+    /// `embedded-bundle` feature). Set via the `FALKORDB_EMBEDDED_MODULE_VERSION`
+    /// build-time environment variable (defaults to the version this client pins).
+    #[cfg(feature = "embedded-bundle")]
+    pub fn bundled_module_version() -> &'static str {
+        bundle::BUNDLED_MODULE_VERSION
+    }
+
+    /// The platform tag (e.g. `linux-x64-glibc`) the build-time bundled module
+    /// targets (the `embedded-bundle` feature).
+    #[cfg(feature = "embedded-bundle")]
+    pub fn bundled_module_platform() -> &'static str {
+        bundle::BUNDLED_MODULE_PLATFORM
     }
 
     /// Returns an error if a Unix socket path exceeds the platform limit.
@@ -240,6 +374,71 @@ impl EmbeddedServer {
             ))
     }
 
+    /// Pre-flight the redis-server version: the FalkorDB module requires
+    /// redis-server >= 8.0 and refuses to load on anything older, so checking the
+    /// version up front turns an opaque "timed out waiting for server" into an
+    /// actionable error. A version that can't be parsed is allowed through (the
+    /// real load attempt will still surface any incompatibility).
+    fn check_redis_version(
+        redis_server: &Path,
+        start_timeout: Duration,
+    ) -> FalkorResult<()> {
+        let Some(text) = Self::redis_version_output(redis_server, start_timeout) else {
+            // Couldn't get a version in time; let the start attempt (bounded by
+            // `start_timeout`) report any real problem.
+            return Ok(());
+        };
+        if redis_version_too_old(&text) {
+            return Err(FalkorDBError::EmbeddedServerError(format!(
+                "redis-server at {} reports version {}, but FalkorDB requires redis-server \
+                 8.0 or newer. Install a newer redis-server or point \
+                 `redis_server_path`/`PATH` at one.",
+                redis_server.display(),
+                text.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Run `redis-server --version`, bounded by the caller's `start_timeout`
+    /// (capped at 10s) so a hanging or wrong binary can't block startup beyond
+    /// the budget the caller allotted. Returns its stdout, or `None` on spawn
+    /// failure / timeout.
+    fn redis_version_output(
+        redis_server: &Path,
+        start_timeout: Duration,
+    ) -> Option<String> {
+        const VERSION_TIMEOUT_CAP: Duration = Duration::from_secs(10);
+        let budget = start_timeout.min(VERSION_TIMEOUT_CAP);
+        let mut child = Command::new(redis_server)
+            .arg("--version")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+
+        let deadline = std::time::Instant::now() + budget;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) if std::time::Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                Ok(None) => thread::sleep(Duration::from_millis(50)),
+                Err(_) => return None,
+            }
+        }
+        // `--version` output is tiny, so reading after exit cannot deadlock.
+        let output = child.wait_with_output().ok()?;
+        Some(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    // `return`s are load-bearing across feature combinations (the download path
+    // below is compiled out under `embedded-bundle`), so the bundle branch's
+    // explicit return can look "needless" in the bundle-only expansion.
+    #[allow(clippy::needless_return)]
     fn find_falkordb_module(config: &EmbeddedConfig) -> FalkorResult<PathBuf> {
         // Resolution order: macOS libomp prerequisite → explicit path → cache
         // (if auto_download) → system locations → download (if auto_download) → error.
@@ -268,65 +467,106 @@ impl EmbeddedServer {
             )));
         }
 
-        let version = config
-            .falkordb_version
-            .as_deref()
-            .unwrap_or(provision::FALKORDB_VERSION);
-
-        // Step 2: Reuse a previously downloaded module from the cache (verified
-        // against the pinned checksum, so a corrupted cache is not trusted).
-        if config.auto_download {
-            let platform = provision::Platform::detect();
-            if let Ok(Some(cached_path)) =
-                download::cached_verified_module(&platform, version, config.cache_dir.as_deref())
-            {
-                #[cfg(feature = "tracing")]
-                tracing::info!("Using cached FalkorDB module at: {}", cached_path.display());
-                return Ok(cached_path);
+        // Step 2 (bundle mode): the module was fetched for this target at build
+        // time and embedded in the binary. Extract it once and use it — the
+        // runtime never touches the network. Authoritative over the download
+        // path below, so enabling both features still guarantees offline start.
+        #[cfg(feature = "embedded-bundle")]
+        {
+            if config.falkordb_version.is_some() {
+                return Err(FalkorDBError::EmbeddedServerError(
+                    "`falkordb_version` has no effect with the `embedded-bundle` feature: the \
+                     module version is selected at build time via the \
+                     FALKORDB_EMBEDDED_MODULE_VERSION environment variable. Unset \
+                     `falkordb_version`, or set `falkordb_module_path` to use a specific module."
+                        .to_string(),
+                ));
             }
-        }
-
-        // Step 3: Use an already-installed module from a common system location.
-        #[cfg(feature = "tracing")]
-        tracing::debug!("Searching for FalkorDB module in common system locations");
-        let common_paths = [
-            PathBuf::from("/usr/lib/redis/modules/falkordb.so"),
-            PathBuf::from("/usr/local/lib/redis/modules/falkordb.so"),
-            PathBuf::from("/opt/homebrew/lib/redis/modules/falkordb.so"),
-            PathBuf::from("./falkordb.so"),
-        ];
-        for path in common_paths {
-            if path.exists() {
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    "Found FalkorDB module at system location: {}",
-                    path.display()
-                );
-                return Ok(path);
-            }
-        }
-
-        // Step 4: Download from the official releases. The download error is
-        // propagated directly so callers see the actionable cause (e.g.
-        // unsupported platform, checksum mismatch, or a network failure).
-        if config.auto_download {
             #[cfg(feature = "tracing")]
-            tracing::info!("FalkorDB module not found locally, downloading version {version}");
-            let platform = provision::Platform::detect();
-            return download::download_falkordb_module(
-                &platform,
-                version,
-                config.cache_dir.as_deref(),
-                MODULE_DOWNLOAD_TIMEOUT,
+            tracing::info!(
+                "Using build-time bundled FalkorDB module (version {})",
+                bundle::BUNDLED_MODULE_VERSION
             );
+            return bundle::materialize_bundled_module(config.cache_dir.as_deref());
         }
 
-        // Step 5: Lookup-only mode and nothing was found.
-        Err(FalkorDBError::EmbeddedServerError(
-            "FalkorDB module (falkordb.so) not found. Install FalkorDB, set falkordb_module_path \
-             in EmbeddedConfig, or enable auto_download to fetch it automatically."
-                .to_string(),
-        ))
+        // Steps 3-6 (runtime-download mode only): cache → system → download →
+        // error. Compiled out under `embedded-bundle` (which returns above).
+        #[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
+        {
+            let version = config
+                .falkordb_version
+                .as_deref()
+                .unwrap_or(provision::FALKORDB_VERSION);
+
+            // Step 3: Reuse a previously downloaded module from the cache (verified
+            // against the pinned checksum, so a corrupted cache is not trusted).
+            if config.auto_download {
+                let platform = provision::Platform::detect();
+                if let Ok(Some(cached_path)) = download::cached_verified_module(
+                    &platform,
+                    version,
+                    config.cache_dir.as_deref(),
+                ) {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!("Using cached FalkorDB module at: {}", cached_path.display());
+                    return Ok(cached_path);
+                }
+            }
+
+            // Step 4: Use an already-installed module from a common system location.
+            #[cfg(feature = "tracing")]
+            tracing::debug!("Searching for FalkorDB module in common system locations");
+            let common_paths = [
+                PathBuf::from("/usr/lib/redis/modules/falkordb.so"),
+                PathBuf::from("/usr/local/lib/redis/modules/falkordb.so"),
+                PathBuf::from("/opt/homebrew/lib/redis/modules/falkordb.so"),
+                PathBuf::from("./falkordb.so"),
+            ];
+            for path in common_paths {
+                if path.exists() {
+                    #[cfg(feature = "tracing")]
+                    tracing::info!(
+                        "Found FalkorDB module at system location: {}",
+                        path.display()
+                    );
+                    return Ok(path);
+                }
+            }
+
+            // Step 5: Download from the official releases. The download error is
+            // propagated directly so callers see the actionable cause (e.g.
+            // unsupported platform, checksum mismatch, or a network failure).
+            if config.auto_download {
+                #[cfg(feature = "tracing")]
+                tracing::info!("FalkorDB module not found locally, downloading version {version}");
+                let platform = provision::Platform::detect();
+                return download::download_falkordb_module(
+                    &platform,
+                    version,
+                    config.cache_dir.as_deref(),
+                    MODULE_DOWNLOAD_TIMEOUT,
+                );
+            }
+
+            // Step 6: Lookup-only mode and nothing was found.
+            Err(FalkorDBError::EmbeddedServerError(
+                "FalkorDB module (falkordb.so) not found. Install FalkorDB, set falkordb_module_path \
+                 in EmbeddedConfig, or enable auto_download to fetch it automatically."
+                    .to_string(),
+            ))
+        }
+
+        // No module source compiled in (only `embedded-core` is enabled).
+        #[cfg(not(any(feature = "embedded", feature = "embedded-bundle")))]
+        {
+            Err(FalkorDBError::EmbeddedServerError(
+                "No embedded FalkorDB module source is available. Set `falkordb_module_path` in \
+                 EmbeddedConfig, or enable the `embedded` (runtime download) or `embedded-bundle` \
+                 (build-time embed) cargo feature."
+                    .to_string(),
+            ))
+        }
     }
 
     fn setup_db_dir(config: &EmbeddedConfig) -> FalkorResult<(PathBuf, Option<PathBuf>)> {
@@ -888,6 +1128,193 @@ mod tests {
     }
 
     #[test]
+    fn test_redis_version_too_old() {
+        // Below the required 8.0 → rejected.
+        assert!(redis_version_too_old(
+            "Redis server v=7.4.2 sha=00000000:0 malloc=libc bits=64"
+        ));
+        assert!(redis_version_too_old("Redis server v=6.2.0"));
+        // 8.0 and newer → accepted.
+        assert!(!redis_version_too_old("Redis server v=8.0.0 sha=0"));
+        assert!(!redis_version_too_old("Redis server v=8.6.3 sha=0"));
+        assert!(!redis_version_too_old("Redis server v=12.1.0"));
+        // Unparseable / missing version is treated as new-enough.
+        assert!(!redis_version_too_old("fake redis"));
+        assert!(!redis_version_too_old(""));
+        assert!(!redis_version_too_old("Redis server v=notanumber.0"));
+    }
+
+    #[test]
+    fn test_check_redis_version_allows_unrunnable_binary() {
+        // A binary that can't be spawned can't be version-checked, so the
+        // pre-flight allows it through (the start attempt then reports any issue).
+        assert!(EmbeddedServer::check_redis_version(
+            Path::new("/nonexistent/redis-server"),
+            Duration::from_secs(5)
+        )
+        .is_ok());
+    }
+
+    /// A fake `redis-server` whose `--version` reports `version`, made executable
+    /// at `<dir>/redis-server`. `server_body` runs when invoked as a server.
+    #[cfg(unix)]
+    fn write_fake_redis(
+        dir: &Path,
+        version: &str,
+        server_body: &str,
+    ) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let fake = dir.join("redis-server");
+        let script = format!(
+            "#!/bin/sh\ncase \"$1\" in --version) echo '{version}'; exit 0;; esac\n{server_body}\n"
+        );
+        fs::write(&fake, script).unwrap();
+        let mut perms = fs::metadata(&fake).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&fake, perms).unwrap();
+        fake
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_start_rejects_old_redis_version() {
+        let dir = std::env::temp_dir().join(format!("test_redis_old_{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let fake_redis = write_fake_redis(&dir, "Redis server v=7.4.2 sha=0", "exit 0");
+
+        let config = EmbeddedConfig {
+            redis_server_path: Some(fake_redis),
+            // Never reached: the version pre-flight fails first.
+            falkordb_module_path: Some(dir.join("falkordb.so")),
+            auto_download: false,
+            ..Default::default()
+        };
+        let err = EmbeddedServer::start(config)
+            .err()
+            .expect("start should fail on an old redis-server");
+        assert!(
+            err.to_string().contains("8.0 or newer"),
+            "unexpected error: {err}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_start_surfaces_redis_stderr_on_early_exit() {
+        // The macOS module load gates on libomp before the spawn; skip if it is
+        // absent (the spawn/stderr path is still exercised on Linux CI).
+        #[cfg(target_os = "macos")]
+        if provision::check_macos_libomp().is_err() {
+            return;
+        }
+
+        let dir = std::env::temp_dir().join(format!("test_redis_exit_{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let fake_redis = write_fake_redis(
+            &dir,
+            "Redis server v=8.0.0 sha=0",
+            "echo 'FATAL: fake module load failure' >&2\nexit 1",
+        );
+        // A present (but fake) module so resolution returns it without network.
+        let fake_module = dir.join("falkordb.so");
+        fs::write(&fake_module, b"\0fake module").unwrap();
+
+        let config = EmbeddedConfig {
+            redis_server_path: Some(fake_redis),
+            falkordb_module_path: Some(fake_module),
+            auto_download: false,
+            start_timeout: Duration::from_secs(10),
+            ..Default::default()
+        };
+        let err = EmbeddedServer::start(config)
+            .err()
+            .expect("start should fail when redis-server exits early");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("exited before the socket was ready"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("fake module load failure"),
+            "redis stderr not surfaced: {msg}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_start_detects_redis_dying_after_socket_appears() {
+        #[cfg(target_os = "macos")]
+        if provision::check_macos_libomp().is_err() {
+            return;
+        }
+
+        let dir = std::env::temp_dir().join(format!("test_redis_sockdie_{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        // Server mode: create the unix socket from the config, then exit — the
+        // start loop must not mistake the lingering socket for a live server.
+        let fake_redis = write_fake_redis(
+            &dir,
+            "Redis server v=8.0.0 sha=0",
+            "sock=$(awk '/^unixsocket /{print $2}' \"$1\"); [ -n \"$sock\" ] && : > \"$sock\"; exit 0",
+        );
+        let fake_module = dir.join("falkordb.so");
+        fs::write(&fake_module, b"\0fake module").unwrap();
+
+        let config = EmbeddedConfig {
+            redis_server_path: Some(fake_redis),
+            falkordb_module_path: Some(fake_module),
+            auto_download: false,
+            start_timeout: Duration::from_secs(10),
+            ..Default::default()
+        };
+        let err = EmbeddedServer::start(config)
+            .err()
+            .expect("start should fail when redis dies after creating the socket");
+        assert!(
+            err.to_string()
+                .contains("exited immediately after the socket appeared"),
+            "unexpected error: {err}"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_read_log_tail() {
+        let dir = std::env::temp_dir().join(format!("test_logtail_{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+
+        // Missing or empty log → empty string.
+        assert_eq!(EmbeddedServer::read_log_tail(&dir.join("missing.log")), "");
+
+        // A short log is returned whole; a long one is tail-truncated with a marker.
+        let log = dir.join("redis-server.log");
+        fs::write(&log, "short message").unwrap();
+        assert_eq!(EmbeddedServer::read_log_tail(&log), "short message");
+
+        fs::write(&log, "x".repeat(5000)).unwrap();
+        let tail = EmbeddedServer::read_log_tail(&log);
+        assert!(
+            tail.starts_with('…'),
+            "expected truncation marker: {tail:.16}"
+        );
+        assert!(tail.chars().filter(|&c| c == 'x').count() == 4096);
+
+        // Multibyte content whose tail boundary lands mid-char must not panic.
+        fs::write(&log, format!("a{}", "→".repeat(2000))).unwrap();
+        let tail = EmbeddedServer::read_log_tail(&log);
+        assert!(tail.starts_with('…'));
+        assert!(tail.len() <= 4096 + '…'.len_utf8());
+
+        // Non-UTF-8 bytes are decoded lossily, not dropped.
+        fs::write(&log, b"\xff\xfe redis fatal \xff").unwrap();
+        assert!(EmbeddedServer::read_log_tail(&log).contains("redis fatal"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn test_find_redis_server_in_path() {
         // Test the PATH lookup when redis_server_path is None
         let config = EmbeddedConfig {
@@ -901,6 +1328,7 @@ mod tests {
         let _ = result;
     }
 
+    #[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
     #[test]
     fn test_find_falkordb_module_common_paths() {
         // Test the common-location lookup when falkordb_module_path is None.
@@ -1136,10 +1564,13 @@ mod tests {
         }
     }
 
+    #[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
     #[test]
     fn test_find_falkordb_module_error_message_without_auto_download() {
-        // Test error message when auto_download is disabled
-        // Note: On macOS, this may fail with libomp check first, so we account for both
+        // With auto_download disabled and no module available, resolution must
+        // fail with an actionable message. The exact text depends on the host:
+        // macOS without libomp fails the OpenMP prerequisite first, otherwise the
+        // message points at the missing module / auto_download.
         let config = EmbeddedConfig {
             falkordb_module_path: None,
             auto_download: false,
@@ -1147,31 +1578,21 @@ mod tests {
             ..Default::default()
         };
 
-        let result = EmbeddedServer::find_falkordb_module(&config);
-        assert!(result.is_err());
-
-        let err_msg = format!("{}", result.unwrap_err());
-
-        // On macOS, the error will be about libomp; on other platforms it will suggest enabling auto_download
-        #[cfg(target_os = "macos")]
-        {
-            assert!(
-                err_msg.contains("OpenMP") || err_msg.contains("libomp"),
-                "Error should mention OpenMP on macOS: {}",
-                err_msg
-            );
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            assert!(
-                err_msg.contains("enable auto_download") || err_msg.contains("not found"),
-                "Error should suggest enabling auto_download or mention not found: {}",
-                err_msg
-            );
-        }
+        let err_msg = format!(
+            "{}",
+            EmbeddedServer::find_falkordb_module(&config)
+                .expect_err("resolution should fail without a module or auto_download")
+        );
+        assert!(
+            err_msg.contains("enable auto_download")
+                || err_msg.contains("not found")
+                || err_msg.contains("OpenMP")
+                || err_msg.contains("libomp"),
+            "error should be actionable: {err_msg}"
+        );
     }
 
+    #[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
     #[test]
     fn test_find_falkordb_module_auto_download_uses_cache() {
         // With auto_download enabled, a previously cached module is reused
@@ -1212,6 +1633,7 @@ mod tests {
         let _ = fs::remove_dir_all(&cache_dir);
     }
 
+    #[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
     #[test]
     fn test_find_falkordb_module_checks_common_system_locations() {
         // Test that common system locations are checked
@@ -1256,5 +1678,43 @@ mod tests {
         };
 
         assert_eq!(config.falkordb_version, Some(version));
+    }
+
+    #[test]
+    #[cfg(feature = "embedded-bundle")]
+    fn test_bundle_resolution_and_accessors() {
+        // Accessors expose the build-time bundle metadata.
+        assert!(!EmbeddedServer::bundled_module_version().is_empty());
+        assert!(!EmbeddedServer::bundled_module_platform().is_empty());
+
+        // A runtime `falkordb_version` has no meaning in bundle mode → rejected.
+        let err = EmbeddedServer::find_falkordb_module(&EmbeddedConfig {
+            falkordb_version: Some("v9.9.9".to_string()),
+            ..Default::default()
+        })
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("embedded-bundle"),
+            "unexpected error: {err}"
+        );
+
+        // The macOS module load gates on libomp before extraction; skip the
+        // extraction assertion if it is absent (covered on Linux CI).
+        #[cfg(target_os = "macos")]
+        if provision::check_macos_libomp().is_err() {
+            return;
+        }
+
+        // With no explicit path, resolution extracts the embedded bytes to the
+        // (temporary) cache — no network involved.
+        let cache = std::env::temp_dir().join(format!("test_bundle_{}", std::process::id()));
+        let path = EmbeddedServer::find_falkordb_module(&EmbeddedConfig {
+            cache_dir: Some(cache.clone()),
+            auto_download: false,
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(path.exists());
+        let _ = fs::remove_dir_all(&cache);
     }
 }

--- a/src/embedded/provision.rs
+++ b/src/embedded/provision.rs
@@ -5,101 +5,28 @@
 
 //! Binary provisioning for the embedded FalkorDB server.
 //!
-//! This module maps the current system to the matching FalkorDB module release
-//! asset (filename, cache tag and pinned SHA-256 checksum) and checks platform
+//! Maps the current system to the matching FalkorDB module release asset
+//! (filename, cache tag and pinned SHA-256 checksum) and checks platform
 //! prerequisites. The actual download/caching lives in [`super::download`].
+//!
+//! The asset/checksum/platform machinery is only needed by the **runtime
+//! download** path (`embedded` feature). The pure, dependency-free mapping lives
+//! in `provision_shared.rs` so it can be shared verbatim with `build.rs` (the
+//! `embedded-bundle` build-time fetch). The macOS libomp check is needed by both
+//! the download and bundle paths, so it is always available.
 
-use crate::{FalkorDBError, FalkorResult};
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
+use crate::FalkorDBError;
+use crate::FalkorResult;
 
-/// FalkorDB version to provision (pinned for reproducibility and security).
-pub const FALKORDB_VERSION: &str = "v4.18.10";
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
+#[path = "provision_shared.rs"]
+mod shared;
 
-/// SHA-256 checksums of each platform's FalkorDB module asset for
-/// [`FALKORDB_VERSION`], keyed by [`Platform::tag`]. Sourced from the GitHub
-/// release asset digests; used to verify downloads and prevent tampering.
-const MODULE_CHECKSUMS: &[(&str, &str)] = &[
-    (
-        "linux-x64-glibc",
-        "1326869d2b7f1669f8ff540045a38a9741f366caf522e1bf496393566c964ecd",
-    ),
-    (
-        "linux-arm64-glibc",
-        "48ca64c54b75c9223d369308482492c2559e09369a1e1594690ae40881bd5614",
-    ),
-    (
-        "linux-x64-musl",
-        "33cc3935bb4b8ed32ab5400da70202e8467aaf26f81431ab0808690b28a04400",
-    ),
-    (
-        "linux-arm64-musl",
-        "9fc919fd7b599a30ba660b9b2535f5101ec04b737a3f3185af5c34374856ba2d",
-    ),
-    (
-        "amazonlinux2023-x64",
-        "426a53de07911ca01797c8f67f5149c422a6ec093664d0416fd38d21b2138bfc",
-    ),
-    (
-        "rhel8-x64",
-        "b46828737fcc079f5ecef0fb6524259117d80ade1b997e390cb49afd5c880b40",
-    ),
-    (
-        "rhel9-x64",
-        "d1fa2b4c8c42ff0aa5db8f2ec9e1d711a41a9271e17421e411b43f588b6ddd6e",
-    ),
-    (
-        "macos-arm64",
-        "6a49901df745d599cdd3b49cdb39a34e01b15291376e32befb8b8cd4ec6fe94e",
-    ),
-];
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
+pub use shared::{module_checksum, Platform, FALKORDB_VERSION};
 
-/// Returns the pinned SHA-256 checksum for a platform `tag` at `version`.
-///
-/// Checksums are only known for the [`FALKORDB_VERSION`] this client ships
-/// against, so any other (user-overridden) version returns `None` and the
-/// download is accepted without checksum verification.
-pub fn module_checksum(
-    version: &str,
-    tag: &str,
-) -> Option<&'static str> {
-    if version != FALKORDB_VERSION {
-        return None;
-    }
-    MODULE_CHECKSUMS
-        .iter()
-        .find(|(known_tag, _)| *known_tag == tag)
-        .map(|(_, checksum)| *checksum)
-}
-
-/// Platform identifier for binary selection.
-///
-/// Some variants are only constructed on the matching OS (e.g. the Linux
-/// variants are never built on macOS), so the enum is allowed to carry
-/// per-platform "dead" variants.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[allow(dead_code)]
-pub enum Platform {
-    /// Linux x86_64 with glibc
-    LinuxX64Glibc,
-    /// Linux aarch64 with glibc
-    LinuxArm64Glibc,
-    /// Linux x86_64 with musl (Alpine)
-    LinuxX64Musl,
-    /// Linux aarch64 with musl (Alpine)
-    LinuxArm64Musl,
-    /// Amazon Linux 2023 x86_64
-    AmazonLinux2023X64,
-    /// RHEL 8 x86_64
-    Rhel8X64,
-    /// RHEL 9 x86_64
-    Rhel9X64,
-    /// macOS aarch64 (Apple Silicon)
-    MacOSArm64,
-    /// macOS x86_64 on Apple Silicon via Rosetta 2 (unsupported, use ARM64 with warning)
-    MacOSX64Unsupported,
-    /// Unsupported platform
-    Unsupported,
-}
-
+#[cfg(all(feature = "embedded", not(feature = "embedded-bundle")))]
 impl Platform {
     /// Detect the current platform.
     ///
@@ -116,159 +43,39 @@ impl Platform {
         } else {
             None
         };
-        Self::classify(os, arch, os_release.as_deref(), is_musl())
+        Self::classify(os, arch, os_release.as_deref(), cfg!(target_env = "musl"))
     }
 
-    /// Pure OS/arch → [`Platform`] mapping, split out from [`detect`] so every
-    /// branch is unit-testable on any host (not just the one running the tests).
-    fn classify(
-        os: &str,
-        arch: &str,
-        os_release: Option<&str>,
-        compile_musl: bool,
-    ) -> Self {
-        match (os, arch) {
-            ("linux", arch) => classify_linux(arch, compile_musl, os_release),
-            ("macos", "aarch64") => Platform::MacOSArm64,
-            // No native x86_64 macOS binary; would need Rosetta 2.
-            ("macos", "x86_64") => Platform::MacOSX64Unsupported,
-            _ => Platform::Unsupported,
-        }
-    }
-
-    /// Returns the asset filename for this platform (without directory).
+    /// Returns the asset filename for this platform, erroring (with actionable
+    /// guidance) on unsupported platforms.
     pub fn asset_filename(&self) -> Result<&'static str, FalkorDBError> {
-        match self {
-            Platform::LinuxX64Glibc => Ok("falkordb-x64.so"),
-            Platform::LinuxArm64Glibc => Ok("falkordb-arm64v8.so"),
-            Platform::LinuxX64Musl => Ok("falkordb-alpine-x64.so"),
-            Platform::LinuxArm64Musl => Ok("falkordb-alpine-arm64v8.so"),
-            Platform::AmazonLinux2023X64 => Ok("falkordb-amazonlinux2023-x64.so"),
-            Platform::Rhel8X64 => Ok("falkordb-rhel8-x64.so"),
-            Platform::Rhel9X64 => Ok("falkordb-rhel9-x64.so"),
-            Platform::MacOSArm64 => Ok("falkordb-macos-arm64v8.so"),
-            Platform::MacOSX64Unsupported => Err(FalkorDBError::EmbeddedServerError(
+        self.asset_filename_opt().ok_or_else(|| match self {
+            Platform::MacOSX64Unsupported => FalkorDBError::EmbeddedServerError(
                 "macOS on x86_64 is not supported for auto-provisioning: there is no x86_64 \
                  FalkorDB module. On Apple Silicon, build and run your application as aarch64 \
                  (arm64) rather than under Rosetta 2. Alternatively, set falkordb_module_path to \
                  an arm64 `falkordb.so` and use an arm64 redis-server."
                     .to_string(),
-            )),
-            Platform::Unsupported => Err(FalkorDBError::EmbeddedServerError(format!(
+            ),
+            _ => FalkorDBError::EmbeddedServerError(format!(
                 "FalkorDB embedded server is not supported on {}/{}. \
                      Supported platforms: Linux x86_64/aarch64 (glibc/musl), macOS aarch64.",
                 std::env::consts::OS,
                 std::env::consts::ARCH
-            ))),
-        }
+            )),
+        })
     }
 
-    /// Returns the platform tag used in checksums and cache paths.
+    /// Returns the platform tag used in checksums and cache paths, erroring on
+    /// unsupported platforms.
     pub fn tag(&self) -> Result<&'static str, FalkorDBError> {
-        match self {
-            Platform::LinuxX64Glibc => Ok("linux-x64-glibc"),
-            Platform::LinuxArm64Glibc => Ok("linux-arm64-glibc"),
-            Platform::LinuxX64Musl => Ok("linux-x64-musl"),
-            Platform::LinuxArm64Musl => Ok("linux-arm64-musl"),
-            Platform::AmazonLinux2023X64 => Ok("amazonlinux2023-x64"),
-            Platform::Rhel8X64 => Ok("rhel8-x64"),
-            Platform::Rhel9X64 => Ok("rhel9-x64"),
-            Platform::MacOSArm64 => Ok("macos-arm64"),
-            Platform::MacOSX64Unsupported => Err(FalkorDBError::EmbeddedServerError(
-                "macOS x86_64 is not supported.".to_string(),
-            )),
-            Platform::Unsupported => Err(FalkorDBError::EmbeddedServerError(
-                "Unsupported platform.".to_string(),
-            )),
-        }
-    }
-}
-
-/// Read a `KEY=value` field from `/etc/os-release`-style contents.
-///
-/// Values may be optionally quoted; surrounding single/double quotes are
-/// stripped. Returns `None` when the key is absent.
-fn os_release_field(
-    contents: &str,
-    key: &str,
-) -> Option<String> {
-    contents.lines().find_map(|line| {
-        let rest = line.strip_prefix(key)?.strip_prefix('=')?;
-        Some(rest.trim().trim_matches(['"', '\'']).to_string())
-    })
-}
-
-/// Map a Linux `arch` to the best-matching [`Platform`].
-///
-/// `compile_musl` is the compile-time libc of this binary; `os_release` is the
-/// contents of `/etc/os-release` when available. Alpine is also treated as musl
-/// via `os-release`. RHEL-family (incl. CentOS/Rocky/Alma) 8/9 and Amazon Linux
-/// 2023 on x86_64 map to their dedicated assets; everything else falls back to
-/// the generic glibc asset. Pure and side-effect free so it is unit-testable.
-fn classify_linux(
-    arch: &str,
-    compile_musl: bool,
-    os_release: Option<&str>,
-) -> Platform {
-    let id = os_release
-        .and_then(|c| os_release_field(c, "ID"))
-        .unwrap_or_default()
-        .to_lowercase();
-    let id_like = os_release
-        .and_then(|c| os_release_field(c, "ID_LIKE"))
-        .unwrap_or_default()
-        .to_lowercase();
-    let version_id = os_release
-        .and_then(|c| os_release_field(c, "VERSION_ID"))
-        .unwrap_or_default();
-
-    // The module must match the *host's* libc (the redis-server it loads into),
-    // so the running distro takes precedence: a known non-Alpine distro means
-    // glibc even if this client was built static-musl. `compile_musl` is only a
-    // fallback when /etc/os-release is unavailable or has no recognizable ID.
-    let alpine = id == "alpine" || id_like.split_whitespace().any(|w| w == "alpine");
-    let musl = alpine || (id.is_empty() && compile_musl);
-    if musl {
-        return match arch {
-            "x86_64" => Platform::LinuxX64Musl,
-            "aarch64" => Platform::LinuxArm64Musl,
-            _ => Platform::Unsupported,
-        };
-    }
-
-    match arch {
-        "x86_64" => {
-            let major = version_id.split('.').next().unwrap_or_default();
-            if id == "amzn" && version_id.starts_with("2023") {
-                return Platform::AmazonLinux2023X64;
+        self.tag_opt().ok_or_else(|| match self {
+            Platform::MacOSX64Unsupported => {
+                FalkorDBError::EmbeddedServerError("macOS x86_64 is not supported.".to_string())
             }
-            let rhel_family = matches!(
-                id.as_str(),
-                "rhel" | "centos" | "rocky" | "almalinux" | "ol" | "fedora"
-            ) || id_like
-                .split_whitespace()
-                .any(|w| w == "rhel" || w == "fedora" || w == "centos");
-            if rhel_family {
-                match major {
-                    "8" => return Platform::Rhel8X64,
-                    "9" => return Platform::Rhel9X64,
-                    _ => {}
-                }
-            }
-            Platform::LinuxX64Glibc
-        }
-        "aarch64" => Platform::LinuxArm64Glibc,
-        _ => Platform::Unsupported,
+            _ => FalkorDBError::EmbeddedServerError("Unsupported platform.".to_string()),
+        })
     }
-}
-
-/// Whether this binary was compiled against musl libc (vs glibc).
-///
-/// Used only as a fallback signal by [`classify_linux`] when `/etc/os-release`
-/// is unavailable; the running distro is otherwise authoritative for which
-/// module asset matches the host `redis-server`.
-fn is_musl() -> bool {
-    cfg!(target_env = "musl")
 }
 
 /// Detect if macOS has the required libomp (OpenMP) library for FalkorDB module.
@@ -291,7 +98,7 @@ pub fn check_macos_libomp() -> FalkorResult<bool> {
         }
 
         // Not found
-        Err(FalkorDBError::EmbeddedServerError(
+        Err(crate::FalkorDBError::EmbeddedServerError(
             "FalkorDB module requires OpenMP (libomp) on macOS. \
              Install it with: brew install libomp\n\
              Then try again. See https://www.falkordb.com/ for more information."
@@ -305,367 +112,51 @@ pub fn check_macos_libomp() -> FalkorResult<bool> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "embedded", not(feature = "embedded-bundle")))]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_platform_detect() {
-        // `detect()` must never panic. `Unsupported` is a valid outcome on
-        // platforms/arches without a FalkorDB asset (e.g. BSD, macOS x86_64,
-        // non-x86_64/aarch64 Linux), so it is accepted here.
+    fn test_detect_returns_a_platform() {
+        // `detect()` must classify the host into one of the known variants
+        // without panicking; the exact value is host-dependent.
         let platform = Platform::detect();
-        println!("Detected platform: {:?}", platform);
+        // Either resolves to a real asset, or the tag/asset are errors on an
+        // unsupported host. Either way the calls are total.
+        let _ = platform.asset_filename();
+        let _ = platform.tag();
     }
 
     #[test]
-    fn test_classify_all_os_arches() {
-        // Every OS/arch arm is reachable here regardless of the host running
-        // the tests.
-        assert_eq!(
-            Platform::classify("macos", "aarch64", None, false),
-            Platform::MacOSArm64
-        );
-        assert_eq!(
-            Platform::classify("macos", "x86_64", None, false),
-            Platform::MacOSX64Unsupported
-        );
-        assert_eq!(
-            Platform::classify("linux", "x86_64", None, false),
-            Platform::LinuxX64Glibc
-        );
-        assert_eq!(
-            Platform::classify("linux", "aarch64", None, false),
-            Platform::LinuxArm64Glibc
-        );
-        // Unsupported OSes and arches.
-        assert_eq!(
-            Platform::classify("freebsd", "x86_64", None, false),
-            Platform::Unsupported
-        );
-        assert_eq!(
-            Platform::classify("windows", "x86_64", None, false),
-            Platform::Unsupported
-        );
-        assert_eq!(
-            Platform::classify("linux", "riscv64", None, false),
-            Platform::Unsupported
-        );
+    fn test_asset_filename_and_tag_errors_on_unsupported() {
+        assert!(Platform::Unsupported.asset_filename().is_err());
+        assert!(Platform::Unsupported.tag().is_err());
+        assert!(Platform::MacOSX64Unsupported.asset_filename().is_err());
+        assert!(Platform::MacOSX64Unsupported.tag().is_err());
     }
 
     #[test]
-    fn test_module_checksum() {
-        // Every supported tag has a 64-char hex SHA-256 for the pinned version.
-        let tags = [
-            "linux-x64-glibc",
-            "linux-arm64-glibc",
-            "linux-x64-musl",
-            "linux-arm64-musl",
-            "amazonlinux2023-x64",
-            "rhel8-x64",
-            "rhel9-x64",
-            "macos-arm64",
-        ];
-        for tag in tags {
-            let checksum = module_checksum(FALKORDB_VERSION, tag)
-                .unwrap_or_else(|| panic!("missing checksum for {tag}"));
-            assert_eq!(checksum.len(), 64, "tag {tag} checksum not 64 hex chars");
-            assert!(checksum.chars().all(|c| c.is_ascii_hexdigit()));
-            assert_ne!(
-                checksum,
-                "0".repeat(64),
-                "tag {tag} still has a placeholder checksum"
-            );
-        }
-    }
-
-    #[test]
-    fn test_module_checksum_unknown_version_or_tag() {
-        // Unknown version → no checksum (download accepted without verification).
-        assert!(module_checksum("v9.9.9", "linux-x64-glibc").is_none());
-        // Unknown tag for the pinned version → no checksum.
-        assert!(module_checksum(FALKORDB_VERSION, "solaris-sparc").is_none());
-    }
-
-    #[test]
-    fn test_checksums_cover_every_supported_platform() {
-        // The checksum table must stay in sync with the asset matrix: every
-        // platform that yields a tag must have a pinned checksum.
-        for platform in [
-            Platform::LinuxX64Glibc,
-            Platform::LinuxArm64Glibc,
-            Platform::LinuxX64Musl,
-            Platform::LinuxArm64Musl,
-            Platform::AmazonLinux2023X64,
-            Platform::Rhel8X64,
-            Platform::Rhel9X64,
-            Platform::MacOSArm64,
-        ] {
-            let tag = platform.tag().unwrap();
-            assert!(
-                module_checksum(FALKORDB_VERSION, tag).is_some(),
-                "no checksum pinned for {platform:?} (tag {tag})"
-            );
-        }
-    }
-
-    #[test]
-    fn test_os_release_field() {
-        let contents = "NAME=\"Ubuntu\"\nID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n";
-        assert_eq!(os_release_field(contents, "ID").as_deref(), Some("ubuntu"));
-        assert_eq!(
-            os_release_field(contents, "ID_LIKE").as_deref(),
-            Some("debian")
-        );
-        assert_eq!(
-            os_release_field(contents, "VERSION_ID").as_deref(),
-            Some("22.04")
-        );
-        assert_eq!(os_release_field(contents, "MISSING"), None);
-    }
-
-    #[test]
-    fn test_classify_linux_generic_glibc() {
-        let ubuntu = "ID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n";
-        assert_eq!(
-            classify_linux("x86_64", false, Some(ubuntu)),
-            Platform::LinuxX64Glibc
-        );
-        assert_eq!(
-            classify_linux("aarch64", false, Some(ubuntu)),
-            Platform::LinuxArm64Glibc
-        );
-        // No os-release available → generic glibc.
-        assert_eq!(
-            classify_linux("x86_64", false, None),
-            Platform::LinuxX64Glibc
-        );
-    }
-
-    #[test]
-    fn test_classify_linux_musl() {
-        let alpine = "ID=alpine\nVERSION_ID=3.20\n";
-        // Detected via os-release even when compiled for glibc.
-        assert_eq!(
-            classify_linux("x86_64", false, Some(alpine)),
-            Platform::LinuxX64Musl
-        );
-        assert_eq!(
-            classify_linux("aarch64", false, Some(alpine)),
-            Platform::LinuxArm64Musl
-        );
-        // Detected via compile-time target_env when os-release is unavailable.
-        assert_eq!(classify_linux("x86_64", true, None), Platform::LinuxX64Musl);
-    }
-
-    #[test]
-    fn test_classify_linux_host_distro_overrides_compile_musl() {
-        // A static-musl client running on a glibc host must pick the glibc
-        // asset: the module is loaded by the host's glibc redis-server.
-        let ubuntu = "ID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n";
-        assert_eq!(
-            classify_linux("x86_64", true, Some(ubuntu)),
-            Platform::LinuxX64Glibc
-        );
-    }
-
-    #[test]
-    fn test_classify_linux_rhel_and_amazon() {
-        let rhel8 = "ID=rhel\nVERSION_ID=\"8.9\"\n";
-        let rocky9 = "ID=rocky\nID_LIKE=\"rhel centos fedora\"\nVERSION_ID=\"9.3\"\n";
-        let amzn = "ID=amzn\nVERSION_ID=2023\n";
-        assert_eq!(
-            classify_linux("x86_64", false, Some(rhel8)),
-            Platform::Rhel8X64
-        );
-        assert_eq!(
-            classify_linux("x86_64", false, Some(rocky9)),
-            Platform::Rhel9X64
-        );
-        assert_eq!(
-            classify_linux("x86_64", false, Some(amzn)),
-            Platform::AmazonLinux2023X64
-        );
-        // RHEL/Amazon on aarch64 have no dedicated asset → generic glibc arm64.
-        assert_eq!(
-            classify_linux("aarch64", false, Some(rhel8)),
-            Platform::LinuxArm64Glibc
-        );
-        // Amazon Linux 2 (no 2023 asset) → generic glibc.
-        let amzn2 = "ID=amzn\nVERSION_ID=2\n";
-        assert_eq!(
-            classify_linux("x86_64", false, Some(amzn2)),
-            Platform::LinuxX64Glibc
-        );
-        // RHEL-family but an unsupported major (e.g. 7) → generic glibc.
-        let rhel7 = "ID=rhel\nVERSION_ID=\"7.9\"\n";
-        assert_eq!(
-            classify_linux("x86_64", false, Some(rhel7)),
-            Platform::LinuxX64Glibc
-        );
-    }
-
-    #[test]
-    fn test_classify_linux_unsupported_arch() {
-        assert_eq!(
-            classify_linux("riscv64", false, None),
-            Platform::Unsupported
-        );
-        assert_eq!(classify_linux("ppc64le", true, None), Platform::Unsupported);
-    }
-
-    #[test]
-    fn test_platform_asset_filename() {
-        // Test a supported platform
-        let platform = Platform::LinuxX64Glibc;
-        assert_eq!(platform.asset_filename().unwrap(), "falkordb-x64.so");
-
-        let platform = Platform::MacOSArm64;
-        assert_eq!(
-            platform.asset_filename().unwrap(),
-            "falkordb-macos-arm64v8.so"
-        );
-
-        // Test unsupported
-        let platform = Platform::Unsupported;
-        assert!(platform.asset_filename().is_err());
-    }
-
-    #[test]
-    fn test_platform_tag() {
-        let platform = Platform::LinuxX64Glibc;
-        assert_eq!(platform.tag().unwrap(), "linux-x64-glibc");
-
-        let platform = Platform::MacOSArm64;
-        assert_eq!(platform.tag().unwrap(), "macos-arm64");
-    }
-
-    #[test]
-    fn test_all_platform_asset_filenames() {
-        // Test all supported platforms have asset filenames
+    fn test_asset_filename_ok_for_supported() {
         assert_eq!(
             Platform::LinuxX64Glibc.asset_filename().unwrap(),
             "falkordb-x64.so"
         );
         assert_eq!(
-            Platform::LinuxArm64Glibc.asset_filename().unwrap(),
-            "falkordb-arm64v8.so"
-        );
-        assert_eq!(
-            Platform::LinuxX64Musl.asset_filename().unwrap(),
-            "falkordb-alpine-x64.so"
-        );
-        assert_eq!(
-            Platform::LinuxArm64Musl.asset_filename().unwrap(),
-            "falkordb-alpine-arm64v8.so"
-        );
-        assert_eq!(
-            Platform::AmazonLinux2023X64.asset_filename().unwrap(),
-            "falkordb-amazonlinux2023-x64.so"
-        );
-        assert_eq!(
-            Platform::Rhel8X64.asset_filename().unwrap(),
-            "falkordb-rhel8-x64.so"
-        );
-        assert_eq!(
-            Platform::Rhel9X64.asset_filename().unwrap(),
-            "falkordb-rhel9-x64.so"
-        );
-        assert_eq!(
             Platform::MacOSArm64.asset_filename().unwrap(),
             "falkordb-macos-arm64v8.so"
         );
-
-        // Unsupported platforms return errors
-        assert!(Platform::Unsupported.asset_filename().is_err());
-        assert!(Platform::MacOSX64Unsupported.asset_filename().is_err());
-    }
-
-    #[test]
-    fn test_all_platform_tags() {
-        // Test all supported platforms have tags
-        assert_eq!(Platform::LinuxX64Glibc.tag().unwrap(), "linux-x64-glibc");
-        assert_eq!(
-            Platform::LinuxArm64Glibc.tag().unwrap(),
-            "linux-arm64-glibc"
-        );
-        assert_eq!(Platform::LinuxX64Musl.tag().unwrap(), "linux-x64-musl");
-        assert_eq!(Platform::LinuxArm64Musl.tag().unwrap(), "linux-arm64-musl");
-        assert_eq!(
-            Platform::AmazonLinux2023X64.tag().unwrap(),
-            "amazonlinux2023-x64"
-        );
         assert_eq!(Platform::Rhel8X64.tag().unwrap(), "rhel8-x64");
-        assert_eq!(Platform::Rhel9X64.tag().unwrap(), "rhel9-x64");
-        assert_eq!(Platform::MacOSArm64.tag().unwrap(), "macos-arm64");
-
-        // Unsupported platforms return errors
-        assert!(Platform::Unsupported.tag().is_err());
-        assert!(Platform::MacOSX64Unsupported.tag().is_err());
     }
+}
+
+#[cfg(test)]
+mod libomp_tests {
+    use super::*;
 
     #[test]
-    fn test_platform_equality() {
-        assert_eq!(Platform::LinuxX64Glibc, Platform::LinuxX64Glibc);
-        assert_ne!(Platform::LinuxX64Glibc, Platform::LinuxArm64Glibc);
-    }
-
-    #[test]
-    fn test_platform_debug() {
-        let platform = Platform::LinuxX64Glibc;
-        let debug_str = format!("{:?}", platform);
-        assert!(debug_str.contains("LinuxX64Glibc"));
-    }
-
-    #[test]
-    fn test_is_musl() {
-        let result = is_musl();
-        // Result depends on target environment; just verify it returns a bool
-        let _: bool = result;
-    }
-
-    #[test]
-    fn test_check_macos_libomp() {
-        let result = check_macos_libomp();
-        // On non-macOS, should return Ok(false)
-        // On macOS, returns Ok(true) if libomp found, Err otherwise
-        match result {
-            Ok(_b) => {
-                #[cfg(not(target_os = "macos"))]
-                assert!(!_b);
-            }
-            Err(_) => {
-                #[cfg(target_os = "macos")]
-                {
-                    // This is expected if libomp is not installed
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn test_unsupported_platform_error_messages() {
-        // Test error messages for unsupported platforms
-        // This ensures the error message construction code is exercised
-        let unsupported_err = Platform::Unsupported.asset_filename();
-        assert!(unsupported_err.is_err());
-        let msg = format!("{}", unsupported_err.unwrap_err());
-        assert!(msg.contains("FalkorDB embedded server is not supported"));
-
-        let unsupported_tag_err = Platform::Unsupported.tag();
-        assert!(unsupported_tag_err.is_err());
-
-        let macos_x64_err = Platform::MacOSX64Unsupported.asset_filename();
-        assert!(macos_x64_err.is_err());
-        let msg = format!("{}", macos_x64_err.unwrap_err());
-        // Mentions x86_64 and steers users to an arm64/aarch64 build (not Rosetta).
-        assert!(msg.contains("x86_64"), "got: {msg}");
-        assert!(
-            msg.contains("aarch64") || msg.contains("arm64"),
-            "got: {msg}"
-        );
-
-        let macos_x64_tag_err = Platform::MacOSX64Unsupported.tag();
-        assert!(macos_x64_tag_err.is_err());
+    fn test_check_macos_libomp_is_total() {
+        // Returns Ok(false) off macOS; on macOS it's Ok(true)/Err depending on
+        // whether libomp is installed. Must never panic.
+        let _ = check_macos_libomp();
     }
 }

--- a/src/embedded/provision_shared.rs
+++ b/src/embedded/provision_shared.rs
@@ -1,0 +1,543 @@
+/*
+ * Copyright FalkorDB Ltd. 2023 - present
+ * Licensed under the MIT License.
+ */
+
+//! Pure, dependency-free platform/asset/checksum mapping for the embedded server.
+//!
+//! This file is shared verbatim by two compilation contexts:
+//!
+//! * the library, via `#[path = "provision_shared.rs"] mod shared;` in
+//!   [`super::provision`], which wraps the pure `*_opt` helpers in the crate's
+//!   `FalkorResult` API; and
+//! * `build.rs`, via `#[path = "src/embedded/provision_shared.rs"]`, so the
+//!   build-time module fetch (`embedded-bundle`) selects the **same** asset and
+//!   checksum the runtime would, with no risk of the two drifting apart.
+//!
+//! Because `build.rs` cannot depend on the crate, everything here uses only
+//! `std`. The library adds the richer, error-typed surface in `provision.rs`.
+
+/// FalkorDB version to provision (pinned for reproducibility and security).
+pub const FALKORDB_VERSION: &str = "v4.18.10";
+
+/// SHA-256 checksums of each platform's FalkorDB module asset for
+/// [`FALKORDB_VERSION`], keyed by [`Platform::tag_opt`]. Sourced from the GitHub
+/// release asset digests; used to verify downloads and prevent tampering.
+const MODULE_CHECKSUMS: &[(&str, &str)] = &[
+    (
+        "linux-x64-glibc",
+        "1326869d2b7f1669f8ff540045a38a9741f366caf522e1bf496393566c964ecd",
+    ),
+    (
+        "linux-arm64-glibc",
+        "48ca64c54b75c9223d369308482492c2559e09369a1e1594690ae40881bd5614",
+    ),
+    (
+        "linux-x64-musl",
+        "33cc3935bb4b8ed32ab5400da70202e8467aaf26f81431ab0808690b28a04400",
+    ),
+    (
+        "linux-arm64-musl",
+        "9fc919fd7b599a30ba660b9b2535f5101ec04b737a3f3185af5c34374856ba2d",
+    ),
+    (
+        "amazonlinux2023-x64",
+        "426a53de07911ca01797c8f67f5149c422a6ec093664d0416fd38d21b2138bfc",
+    ),
+    (
+        "rhel8-x64",
+        "b46828737fcc079f5ecef0fb6524259117d80ade1b997e390cb49afd5c880b40",
+    ),
+    (
+        "rhel9-x64",
+        "d1fa2b4c8c42ff0aa5db8f2ec9e1d711a41a9271e17421e411b43f588b6ddd6e",
+    ),
+    (
+        "macos-arm64",
+        "6a49901df745d599cdd3b49cdb39a34e01b15291376e32befb8b8cd4ec6fe94e",
+    ),
+];
+
+/// Returns the pinned SHA-256 checksum for a platform `tag` at `version`.
+///
+/// Checksums are only known for the [`FALKORDB_VERSION`] this client ships
+/// against, so any other (user-overridden) version returns `None`.
+pub fn module_checksum(
+    version: &str,
+    tag: &str,
+) -> Option<&'static str> {
+    if version != FALKORDB_VERSION {
+        return None;
+    }
+    MODULE_CHECKSUMS
+        .iter()
+        .find(|(known_tag, _)| *known_tag == tag)
+        .map(|(_, checksum)| *checksum)
+}
+
+/// Lowercase-hex SHA-256 of `bytes` — a dependency-free implementation of the
+/// FIPS 180-4 algorithm.
+///
+/// This lives here, alongside the checksum table, so `build.rs` (which
+/// `#[path]`-includes this file) can verify a downloaded module without a
+/// build-dependency: declaring `sha2` under a second name as a build-dep breaks
+/// `cargo-nextest`, and pulling the real `sha2`/TLS stack into the offline
+/// `embedded-bundle` runtime would defeat its purpose. The library itself hashes
+/// via the `sha2` crate (see [`super::download`]), so this is unused there.
+#[allow(dead_code)]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    #[rustfmt::skip]
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+    ];
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    // Pad: message || 0x80 || 0x00… || 64-bit big-endian bit length.
+    let bit_len = (bytes.len() as u64).wrapping_mul(8);
+    let mut msg = bytes.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut w = [0u32; 64];
+    for block in msg.chunks_exact(64) {
+        for (word, src) in w.iter_mut().zip(block.chunks_exact(4)) {
+            *word = u32::from_be_bytes([src[0], src[1], src[2], src[3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+
+        for (slot, v) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *slot = slot.wrapping_add(v);
+        }
+    }
+
+    let mut out = String::with_capacity(64);
+    use std::fmt::Write as _;
+    for word in h {
+        let _ = write!(out, "{word:08x}");
+    }
+    out
+}
+
+/// Platform identifier for binary selection.
+///
+/// Some variants are only constructed on the matching OS (e.g. the Linux
+/// variants are never built on macOS), so the enum is allowed to carry
+/// per-platform "dead" variants.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum Platform {
+    /// Linux x86_64 with glibc
+    LinuxX64Glibc,
+    /// Linux aarch64 with glibc
+    LinuxArm64Glibc,
+    /// Linux x86_64 with musl (Alpine)
+    LinuxX64Musl,
+    /// Linux aarch64 with musl (Alpine)
+    LinuxArm64Musl,
+    /// Amazon Linux 2023 x86_64
+    AmazonLinux2023X64,
+    /// RHEL 8 x86_64
+    Rhel8X64,
+    /// RHEL 9 x86_64
+    Rhel9X64,
+    /// macOS aarch64 (Apple Silicon)
+    MacOSArm64,
+    /// macOS x86_64 on Apple Silicon via Rosetta 2 (unsupported, use ARM64 with warning)
+    MacOSX64Unsupported,
+    /// Unsupported platform
+    Unsupported,
+}
+
+impl Platform {
+    /// Pure OS/arch → [`Platform`] mapping, split out so every branch is
+    /// unit-testable on any host (not just the one running the tests).
+    pub fn classify(
+        os: &str,
+        arch: &str,
+        os_release: Option<&str>,
+        compile_musl: bool,
+    ) -> Self {
+        match (os, arch) {
+            ("linux", arch) => classify_linux(arch, compile_musl, os_release),
+            ("macos", "aarch64") => Platform::MacOSArm64,
+            // No native x86_64 macOS binary; would need Rosetta 2.
+            ("macos", "x86_64") => Platform::MacOSX64Unsupported,
+            _ => Platform::Unsupported,
+        }
+    }
+
+    /// Build a [`Platform`] from a release-asset platform tag (the inverse of
+    /// [`tag_opt`](Self::tag_opt)). Used by `build.rs` to honor an explicit
+    /// `FALKORDB_EMBEDDED_MODULE_PLATFORM` override. Returns `None` for an
+    /// unknown tag.
+    #[allow(dead_code)] // used by build.rs and tests, not the plain library build
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        Some(match tag {
+            "linux-x64-glibc" => Platform::LinuxX64Glibc,
+            "linux-arm64-glibc" => Platform::LinuxArm64Glibc,
+            "linux-x64-musl" => Platform::LinuxX64Musl,
+            "linux-arm64-musl" => Platform::LinuxArm64Musl,
+            "amazonlinux2023-x64" => Platform::AmazonLinux2023X64,
+            "rhel8-x64" => Platform::Rhel8X64,
+            "rhel9-x64" => Platform::Rhel9X64,
+            "macos-arm64" => Platform::MacOSArm64,
+            _ => return None,
+        })
+    }
+
+    /// Returns the asset filename for this platform, or `None` when the platform
+    /// has no FalkorDB module asset (unsupported).
+    pub fn asset_filename_opt(&self) -> Option<&'static str> {
+        Some(match self {
+            Platform::LinuxX64Glibc => "falkordb-x64.so",
+            Platform::LinuxArm64Glibc => "falkordb-arm64v8.so",
+            Platform::LinuxX64Musl => "falkordb-alpine-x64.so",
+            Platform::LinuxArm64Musl => "falkordb-alpine-arm64v8.so",
+            Platform::AmazonLinux2023X64 => "falkordb-amazonlinux2023-x64.so",
+            Platform::Rhel8X64 => "falkordb-rhel8-x64.so",
+            Platform::Rhel9X64 => "falkordb-rhel9-x64.so",
+            Platform::MacOSArm64 => "falkordb-macos-arm64v8.so",
+            Platform::MacOSX64Unsupported | Platform::Unsupported => return None,
+        })
+    }
+
+    /// Returns the platform tag used in checksums and cache paths, or `None` for
+    /// an unsupported platform.
+    pub fn tag_opt(&self) -> Option<&'static str> {
+        Some(match self {
+            Platform::LinuxX64Glibc => "linux-x64-glibc",
+            Platform::LinuxArm64Glibc => "linux-arm64-glibc",
+            Platform::LinuxX64Musl => "linux-x64-musl",
+            Platform::LinuxArm64Musl => "linux-arm64-musl",
+            Platform::AmazonLinux2023X64 => "amazonlinux2023-x64",
+            Platform::Rhel8X64 => "rhel8-x64",
+            Platform::Rhel9X64 => "rhel9-x64",
+            Platform::MacOSArm64 => "macos-arm64",
+            Platform::MacOSX64Unsupported | Platform::Unsupported => return None,
+        })
+    }
+}
+
+/// Read a `KEY=value` field from `/etc/os-release`-style contents.
+///
+/// Values may be optionally quoted; surrounding single/double quotes are
+/// stripped. Returns `None` when the key is absent.
+fn os_release_field(
+    contents: &str,
+    key: &str,
+) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let rest = line.strip_prefix(key)?.strip_prefix('=')?;
+        Some(rest.trim().trim_matches(['"', '\'']).to_string())
+    })
+}
+
+/// Map a Linux `arch` to the best-matching [`Platform`].
+///
+/// `compile_musl` is the musl libc signal of the *target* (the binary's
+/// `target_env` in the library, `CARGO_CFG_TARGET_ENV` in `build.rs`);
+/// `os_release` is the contents of `/etc/os-release` when available (runtime
+/// only). Alpine is also treated as musl via `os-release`. RHEL-family (incl.
+/// CentOS/Rocky/Alma) 8/9 and Amazon Linux 2023 on x86_64 map to their
+/// dedicated assets; everything else falls back to the generic glibc asset.
+/// Pure and side-effect free so it is unit-testable.
+fn classify_linux(
+    arch: &str,
+    compile_musl: bool,
+    os_release: Option<&str>,
+) -> Platform {
+    let id = os_release
+        .and_then(|c| os_release_field(c, "ID"))
+        .unwrap_or_default()
+        .to_lowercase();
+    let id_like = os_release
+        .and_then(|c| os_release_field(c, "ID_LIKE"))
+        .unwrap_or_default()
+        .to_lowercase();
+    let version_id = os_release
+        .and_then(|c| os_release_field(c, "VERSION_ID"))
+        .unwrap_or_default();
+
+    // The module must match the *host's* libc (the redis-server it loads into),
+    // so the running distro takes precedence: a known non-Alpine distro means
+    // glibc even if this client was built static-musl. `compile_musl` is only a
+    // fallback when /etc/os-release is unavailable or has no recognizable ID.
+    let alpine = id == "alpine" || id_like.split_whitespace().any(|w| w == "alpine");
+    let musl = alpine || (id.is_empty() && compile_musl);
+    if musl {
+        return match arch {
+            "x86_64" => Platform::LinuxX64Musl,
+            "aarch64" => Platform::LinuxArm64Musl,
+            _ => Platform::Unsupported,
+        };
+    }
+
+    match arch {
+        "x86_64" => {
+            let major = version_id.split('.').next().unwrap_or_default();
+            if id == "amzn" && version_id.starts_with("2023") {
+                return Platform::AmazonLinux2023X64;
+            }
+            let rhel_family = matches!(
+                id.as_str(),
+                "rhel" | "centos" | "rocky" | "almalinux" | "ol" | "fedora"
+            ) || id_like
+                .split_whitespace()
+                .any(|w| w == "rhel" || w == "fedora" || w == "centos");
+            if rhel_family {
+                match major {
+                    "8" => return Platform::Rhel8X64,
+                    "9" => return Platform::Rhel9X64,
+                    _ => {}
+                }
+            }
+            Platform::LinuxX64Glibc
+        }
+        "aarch64" => Platform::LinuxArm64Glibc,
+        _ => Platform::Unsupported,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sha256_hex_nist_vectors() {
+        // FIPS 180-4 / NIST known-answer tests.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+        // A multi-block input (1000 bytes) exercises the message-schedule loop.
+        assert_eq!(
+            sha256_hex(&[0x61u8; 1000]),
+            "41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3"
+        );
+    }
+
+    #[test]
+    fn test_classify_all_os_arches() {
+        assert_eq!(
+            Platform::classify("macos", "aarch64", None, false),
+            Platform::MacOSArm64
+        );
+        assert_eq!(
+            Platform::classify("macos", "x86_64", None, false),
+            Platform::MacOSX64Unsupported
+        );
+        assert_eq!(
+            Platform::classify("linux", "x86_64", None, false),
+            Platform::LinuxX64Glibc
+        );
+        assert_eq!(
+            Platform::classify("linux", "aarch64", None, false),
+            Platform::LinuxArm64Glibc
+        );
+        assert_eq!(
+            Platform::classify("freebsd", "x86_64", None, false),
+            Platform::Unsupported
+        );
+        assert_eq!(
+            Platform::classify("windows", "x86_64", None, false),
+            Platform::Unsupported
+        );
+        assert_eq!(
+            Platform::classify("linux", "riscv64", None, false),
+            Platform::Unsupported
+        );
+    }
+
+    #[test]
+    fn test_from_tag_roundtrips() {
+        for platform in [
+            Platform::LinuxX64Glibc,
+            Platform::LinuxArm64Glibc,
+            Platform::LinuxX64Musl,
+            Platform::LinuxArm64Musl,
+            Platform::AmazonLinux2023X64,
+            Platform::Rhel8X64,
+            Platform::Rhel9X64,
+            Platform::MacOSArm64,
+        ] {
+            let tag = platform.tag_opt().unwrap();
+            assert_eq!(Platform::from_tag(tag), Some(platform));
+        }
+        assert_eq!(Platform::from_tag("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_module_checksum() {
+        for tag in [
+            "linux-x64-glibc",
+            "linux-arm64-glibc",
+            "linux-x64-musl",
+            "linux-arm64-musl",
+            "amazonlinux2023-x64",
+            "rhel8-x64",
+            "rhel9-x64",
+            "macos-arm64",
+        ] {
+            let checksum = module_checksum(FALKORDB_VERSION, tag)
+                .unwrap_or_else(|| panic!("missing checksum for {tag}"));
+            assert_eq!(checksum.len(), 64, "sha-256 hex is 64 chars for {tag}");
+            assert!(checksum.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn test_module_checksum_unknown_version_or_tag() {
+        assert!(module_checksum("v9.9.9", "linux-x64-glibc").is_none());
+        assert!(module_checksum(FALKORDB_VERSION, "solaris-sparc").is_none());
+    }
+
+    #[test]
+    fn test_all_supported_platforms_have_checksums() {
+        for platform in [
+            Platform::LinuxX64Glibc,
+            Platform::LinuxArm64Glibc,
+            Platform::LinuxX64Musl,
+            Platform::LinuxArm64Musl,
+            Platform::AmazonLinux2023X64,
+            Platform::Rhel8X64,
+            Platform::Rhel9X64,
+            Platform::MacOSArm64,
+        ] {
+            let tag = platform.tag_opt().unwrap();
+            assert!(
+                module_checksum(FALKORDB_VERSION, tag).is_some(),
+                "missing checksum for {tag}"
+            );
+            assert!(platform.asset_filename_opt().is_some());
+        }
+        assert!(Platform::Unsupported.tag_opt().is_none());
+        assert!(Platform::Unsupported.asset_filename_opt().is_none());
+        assert!(Platform::MacOSX64Unsupported.asset_filename_opt().is_none());
+    }
+
+    #[test]
+    fn test_os_release_field() {
+        let contents = "NAME=\"Ubuntu\"\nID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n";
+        assert_eq!(os_release_field(contents, "ID").as_deref(), Some("ubuntu"));
+        assert_eq!(
+            os_release_field(contents, "ID_LIKE").as_deref(),
+            Some("debian")
+        );
+        assert_eq!(
+            os_release_field(contents, "VERSION_ID").as_deref(),
+            Some("22.04")
+        );
+        assert_eq!(os_release_field(contents, "MISSING"), None);
+    }
+
+    #[test]
+    fn test_classify_linux_generic_glibc() {
+        let ubuntu = "ID=ubuntu\nID_LIKE=debian\nVERSION_ID=\"22.04\"\n";
+        assert_eq!(
+            classify_linux("x86_64", false, Some(ubuntu)),
+            Platform::LinuxX64Glibc
+        );
+        assert_eq!(
+            classify_linux("aarch64", false, Some(ubuntu)),
+            Platform::LinuxArm64Glibc
+        );
+        assert_eq!(
+            classify_linux("x86_64", false, None),
+            Platform::LinuxX64Glibc
+        );
+    }
+
+    #[test]
+    fn test_classify_linux_musl() {
+        let alpine = "ID=alpine\nVERSION_ID=3.19\n";
+        assert_eq!(
+            classify_linux("x86_64", false, Some(alpine)),
+            Platform::LinuxX64Musl
+        );
+        assert_eq!(
+            classify_linux("aarch64", false, Some(alpine)),
+            Platform::LinuxArm64Musl
+        );
+        // No os-release but compiled musl → musl asset.
+        assert_eq!(classify_linux("x86_64", true, None), Platform::LinuxX64Musl);
+    }
+
+    #[test]
+    fn test_classify_linux_rhel_and_amazon() {
+        let rhel8 = "ID=rhel\nVERSION_ID=\"8.9\"\n";
+        let rhel9 = "ID=rhel\nVERSION_ID=\"9.3\"\n";
+        let rocky9 = "ID=rocky\nID_LIKE=\"rhel centos fedora\"\nVERSION_ID=\"9.3\"\n";
+        let amzn = "ID=amzn\nVERSION_ID=\"2023\"\n";
+        assert_eq!(
+            classify_linux("x86_64", false, Some(rhel8)),
+            Platform::Rhel8X64
+        );
+        assert_eq!(
+            classify_linux("x86_64", false, Some(rhel9)),
+            Platform::Rhel9X64
+        );
+        assert_eq!(
+            classify_linux("x86_64", false, Some(rocky9)),
+            Platform::Rhel9X64
+        );
+        assert_eq!(
+            classify_linux("x86_64", false, Some(amzn)),
+            Platform::AmazonLinux2023X64
+        );
+        // RHEL on aarch64 has no dedicated asset → generic glibc arm64.
+        assert_eq!(
+            classify_linux("aarch64", false, Some(rhel9)),
+            Platform::LinuxArm64Glibc
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@
 //! - **Resilient** — opt-in `RetryPolicy` with bounded backoff for transient failures; writes are never retried.
 //! - **Observable** — OpenTelemetry-aligned `tracing` spans and `metrics` counters/histograms, privacy-safe by default.
 //! - **Replica-aware** — opt in to routing read-only queries to replicas behind Redis Sentinel.
-//! - **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping.
+//! - **Embedded server** — spin up a self-contained FalkorDB for tests and prototyping, with an
+//!   optional build-time bundle mode that runs fully offline.
 //!
 //! ## Table of contents
 //!
@@ -102,7 +103,8 @@
 //! | `serde` | Map query results into your own `serde::Deserialize` types. |
 //! | `tracing` | OpenTelemetry-aligned `tracing` spans with a privacy-safe query fingerprint. |
 //! | `metrics` | Counters and histograms via the `metrics` facade (install any exporter). |
-//! | `embedded` | Run a self-contained embedded FalkorDB server. |
+//! | `embedded` | Run a self-contained embedded FalkorDB server (module downloaded at runtime). |
+//! | `embedded-bundle` | Embed the module at build time so the embedded server runs fully offline. |
 //! | `rustls` / `native-tls` | TLS for the sync client, via `rustls` or `native-tls`. |
 //! | `tokio-rustls` / `tokio-native-tls` | TLS for the async client. |
 //!
@@ -831,19 +833,48 @@
 //! cargo add falkordb --features embedded
 //! ```
 //!
+//! #### Choosing a module-provisioning mode
+//!
+//! The `redis-server` binary is **never** downloaded — it must be installed on the host (see
+//! Requirements). Only the FalkorDB `falkordb.so` **module** is provisioned, and there are two
+//! features for that:
+//!
+//! - **`embedded`** — *runtime download*. The module is downloaded on first start (and cached), so
+//!   the running process **needs network access** the first time. Best for development.
+//! - **`embedded-bundle`** — *build-time embed, offline at runtime*. A `build.rs` fetches the module
+//!   for the build target at **compile time** and embeds it in your binary, so the running process
+//!   needs **no network at all**. Best for network-isolated deployments. Enable it instead of
+//!   `embedded`:
+//!
+//!   ```bash
+//!   cargo add falkordb --features embedded-bundle
+//!   ```
+//!
+//!   Control the bundled module at build time with environment variables:
+//!   `FALKORDB_EMBEDDED_MODULE_VERSION` (release tag; defaults to the pinned version),
+//!   `FALKORDB_EMBEDDED_MODULE_PLATFORM` (override the asset for distro-specific Linux targets such
+//!   as `rhel9-x64`), and `FALKORDB_EMBEDDED_MODULE_PATH` to embed a **local** `.so` instead of
+//!   downloading (fully offline builds, or unsupported platforms). A non-default version must be
+//!   accompanied by `FALKORDB_EMBEDDED_MODULE_SHA256` — unchecked downloaded native code is never
+//!   embedded. The downloading build uses the host `curl` (set `FALKORDB_EMBEDDED_MODULE_PATH` on
+//!   build hosts without `curl` or network access); the `embedded-bundle` runtime itself carries no
+//!   HTTP/hashing dependencies.
+//!
+//!   > **License:** `embedded-bundle` embeds the SSPL-licensed FalkorDB module into your binary, so
+//!   > you are responsible for complying with its license when you distribute that binary.
+//!
 //! #### Requirements
 //!
-//! - `redis-server` must be installed and available in PATH (or you can specify a custom path).
-//!   It is **not** downloaded automatically — install it from your package manager
-//!   (e.g. `brew install redis`, `apt-get install redis-server`).
-//! - The `falkordb.so` module is provisioned automatically when `auto_download` is enabled
-//!   (the default): it is downloaded from the official [FalkorDB](https://github.com/falkordb/falkordb)
-//!   releases, verified against a pinned SHA-256 checksum and cached locally. You can also point
-//!   `falkordb_module_path` at an existing module, or disable `auto_download` to use only
-//!   explicit/system-installed binaries.
+//! - `redis-server` (**version 8.0 or newer**) must be installed and available in PATH (or you can
+//!   specify a custom path). It is **not** downloaded automatically — install it from your package
+//!   manager (e.g. `brew install redis`, `apt-get install redis-server`).
+//! - The `falkordb.so` module is provisioned automatically: downloaded at runtime with `embedded`
+//!   (when `auto_download` is enabled, the default) or embedded at build time with
+//!   `embedded-bundle`. You can also point `falkordb_module_path` at an existing module, or disable
+//!   `auto_download` to use only explicit/system-installed binaries.
 //! - On macOS the module requires OpenMP: `brew install libomp`.
 //!
-//! Supported auto-download platforms: Linux x86_64/aarch64 (glibc and musl/Alpine, plus
+//! Supported platforms: Linux x86_64/aarch64 (glibc and musl/Alpine, plus
 //! RHEL 8/9 and Amazon Linux 2023 on x86_64) and macOS aarch64 (Apple Silicon).
 //!
 //! #### Self-contained vs. already-installed
@@ -955,7 +986,7 @@
 mod client;
 mod connection;
 mod connection_info;
-#[cfg(feature = "embedded")]
+#[cfg(feature = "embedded-core")]
 mod embedded;
 mod error;
 mod graph;
@@ -1019,7 +1050,7 @@ pub use graph::asynchronous::AsyncGraph;
 #[cfg(feature = "tokio")]
 pub use graph::ops::{AsyncConstraintOpBuilder, AsyncCopyGraphBuilder, AsyncIndexOpBuilder};
 
-#[cfg(feature = "embedded")]
+#[cfg(feature = "embedded-core")]
 pub use embedded::{EmbeddedConfig, EmbeddedServer};
 
 #[cfg(test)]

--- a/tests/embedded_integration.rs
+++ b/tests/embedded_integration.rs
@@ -29,7 +29,7 @@
 //! When the module cannot be resolved the tests no-op (return early) so they stay green on
 //! machines that lack a compatible build (e.g. macOS hosts with a Linux-only module).
 
-#![cfg(feature = "embedded")]
+#![cfg(feature = "embedded-core")]
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -38,6 +38,7 @@ use falkordb::{
     EmbeddedConfig, EmbeddedServer, EntityType, FalkorClientBuilder, FalkorConnectionInfo,
     IndexType,
 };
+#[cfg(feature = "tokio")]
 use futures::StreamExt;
 
 /// Common locations the module may live in, mirroring the client's own search list.


### PR DESCRIPTION
## Summary

The `embedded` feature downloads the FalkorDB `.so` **module** at **runtime** on first start, which fails in network-isolated deployments. This PR adds a new **`embedded-bundle`** feature that fetches the module for the build target at **compile time** (in `build.rs`) and embeds it in the binary via `include_bytes!`, so the embedded server starts with **no runtime network access**.

`redis-server` is unchanged — it is still taken from `PATH` (or `redis_server_path`) and is never downloaded.

## What changed

- **Feature split** so the bundled runtime carries no network/hashing deps:
  - `embedded-core` — shared `EmbeddedServer`/process logic + redis-from-PATH.
  - `embedded` — today's **runtime download** behavior (unchanged).
  - `embedded-bundle` — **build-time embed**, offline at runtime (no `ureq`/`sha2`).
- **`build.rs`** resolves the target platform from `CARGO_CFG_TARGET_*`, fetches the module via the host **`curl`**, and verifies it with a small dependency-free **`sha256_hex`** (pinned checksum for the default version; explicit `FALKORDB_EMBEDDED_MODULE_SHA256` otherwise — unchecked downloaded native code is never embedded). A local `.so` can be embedded via `FALKORDB_EMBEDDED_MODULE_PATH` (fully offline builds / unsupported platforms). Skips on docs.rs. **No `[build-dependencies]`**, so `cargo-nextest`'s dependency-graph check stays happy and the runtime stays lean.
- **`provision_shared.rs`** now also holds the pure `sha256_hex`, shared by the library and `build.rs` (via `#[path]` include) so build-time and runtime hashing can never drift.
- **Runtime extraction** is content-addressed by the build-time sha256 (atomic write, race-safe reuse, **no runtime hashing**); strict no-network resolution under `embedded-bundle`.
- **redis ≥ 8.0 pre-flight**: `EmbeddedServer::start` runs `redis-server --version` and fails fast with an actionable message (the module hard-requires redis ≥ 8.0), and **captures redis stderr** so a failed module load surfaces a real cause instead of a bare timeout.
- New `EmbeddedServer::bundled_module_version()` / `bundled_module_platform()` accessors.

## Build-time controls (env vars)

| Var | Effect |
| --- | --- |
| `FALKORDB_EMBEDDED_MODULE_VERSION` | Release tag to fetch (default: pinned). |
| `FALKORDB_EMBEDDED_MODULE_PLATFORM` | Override the asset for distro-specific Linux targets (e.g. `rhel9-x64`). |
| `FALKORDB_EMBEDDED_MODULE_PATH` | Embed a local `.so` instead of downloading (offline builds). |
| `FALKORDB_EMBEDDED_MODULE_SHA256` | Expected SHA-256; required to download a non-default version. |

> **License:** `embedded-bundle` embeds the SSPL-licensed FalkorDB module into the downstream binary — documented in the crate docs and example.

## Tests & validation

- New unit tests cover the redis version pre-flight, redis-stderr surfacing on early exit, log-tail truncation, bundle resolution/extraction, cache fallbacks, and the `sha256_hex` against NIST vectors. A libomp-dependent module-resolution test was made robust.
- `just coverage` now **merges a hermetic `embedded-bundle` pass** (fixture `.so`, no server/network) so the bundled code is measured; CI already calls `just coverage`.
- New hermetic `just check-embedded-bundle` recipe + CI job (builds lib/example/tests with `embedded-bundle` via a fixture and runs the bundle unit tests).
- Green locally: `just done`, `just check-embedded-bundle`, `embedded-bundle` clippy, server-backed suite, and merged coverage.

## Docs

`README.md` (via `just readme`), crate `//!` docs, the feature table, `examples/embedded_usage.rs`, `llms.txt` (via `just llms`), `CHANGELOG.md`, and `.github/wordlist.txt` are all updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional **embedded-bundle** build-time mode for fully offline runtime operation (module embedded at build instead of downloaded at startup).
  * Added environment variables to select embedded module version/platform or provide a local `.so`.
  * Added accessors to retrieve bundled module metadata (version and platform).
  * CI now includes a dedicated `check-embedded-bundle` verification run.

* **Bug Fixes**
  * Improved `redis-server` startup validation with early minimum-version checking and clearer startup failure diagnostics.

* **Documentation**
  * Updated README, crate docs, and the `embedded_usage` example to explain module-provisioning modes and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->