### PR TITLE
docs: link the Dev Log blog prominently from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 [![Try Free](https://img.shields.io/badge/Try%20Free-FalkorDB%20Cloud-FF8101?labelColor=FDE900&style=for-the-badge&link=https://app.falkordb.cloud)](https://app.falkordb.cloud)
 
+> 📖 **New — the [FalkorDB-rs Dev Log](https://falkordb.github.io/falkordb-rs/):** field notes on the design behind this client, from type-safe parameters and async streaming to the embedded server and replica routing.
+
 <!-- cargo-rdme start -->
 
 The official Rust client for [FalkorDB](https://www.falkordb.com/) — a fast, low-latency


### PR DESCRIPTION
Adds a prominent callout under the README title linking to the **[FalkorDB-rs Dev Log](https://falkordb.github.io/falkordb-rs/)**:

> 📖 **New — the FalkorDB-rs Dev Log:** field notes on the design behind this client…

There's already a small "Dev Log" badge in the badge row, but it's easy to miss among the others — this is a clearer, in-content link. It edits only the hand-written header above the `cargo-rdme` marker, so the generated body and `check-readme` are unaffected.

⚠️ **Release note:** this is a `docs:` change, and the README is the crates.io / docs.rs landing page, so on merge release-plz will open a release PR (a patch bump) to publish the updated README — that's intended for discoverability. If you'd rather it ride along with the next feature release instead, rename this PR to `chore: …` before merging.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new announcement near the top of the README highlighting the FalkorDB-rs Dev Log with a link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->