### PR TITLE
build(deps): bump redis to 1.3.0, deploy-pages and upload-pages-artifact to v5

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build the blog (sync snippets + zola build)
         run: just blog-build
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: blog/public
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
+checksum = "2fa6f8e4b491d7a8ef3a9550a4d71969bd0064f46e32b8dbbcc7fc60dad94fed"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -1349,7 +1349,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1638,7 +1638,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
Combines three passing dependabot PRs into one branch so the coverage gate (which needs a token unavailable to dependabot) can run.

## Combined PRs
- #285 build(deps): bump redis from 1.2.3 to 1.3.0 (Cargo.lock; transitive windows-sys 0.52.0 → 0.61.2)
- #284 build(deps): bump actions/upload-pages-artifact from 3.0.1 to 5.0.0
- #283 build(deps): bump actions/deploy-pages from 4.0.5 to 5.0.0

## Why combine
On the originals, every check is green except `coverage`, which fails only with `Token required because branch is protected` — dependabot forks cannot access `CODECOV_TOKEN`. From a regular branch the token is available and coverage passes.

## Validation
- `just ci` (fmt-check, clippy, build, doc, deny) green locally
- redis `1.3.0` satisfies the unchanged `redis = "1.2.2"` caret; minor, non-breaking
- pages.yml wiring intact; deploy-pages v5 / upload-pages-artifact v5 interoperate
- Rubber-duck review: no material issues

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the site publishing workflow to use newer supported deployment actions, helping keep releases compatible and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->