### PR TITLE
fix: derive Clone for FalkorAsyncClient

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -50,6 +50,7 @@ cleans
 FalkorResult
 FalkorClientBuilder
 FalkorConnectionInfo
+FalkorAsyncClient
 EntityType
 IndexType
 EmbeddedServer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Derive `Clone` for `FalkorAsyncClient`, matching `FalkorSyncClient` and its own thread-safety
+  documentation, which already stated the client can be cloned and shared across threads
+  ([#287](https://github.com/FalkorDB/falkordb-rs/pull/287))
+
 ## [0.10.1](https://github.com/FalkorDB/falkordb-rs/compare/v0.10.0...v0.10.1) - 2026-06-29
 
 ### Other

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -672,6 +672,14 @@ mod tests {
     };
     use tokio::sync::mpsc::error::TryRecvError;
 
+    #[test]
+    fn falkor_async_client_is_clone_send_sync() {
+        // The struct's doc comment promises the client can be cloned and shared across threads.
+        // Assert those bounds at compile time so the impls (notably `Clone`) cannot silently regress.
+        fn assert_clone_send_sync<T: Clone + Send + Sync>() {}
+        assert_clone_send_sync::<FalkorAsyncClient>();
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_multiplexed_strategy_with_max_inflight() {
         // An explicit multiplexed strategy combined with a bounded in-flight limit

--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -252,6 +252,7 @@ impl ProvidesSyncConnections for FalkorAsyncClientInner {
 /// # Thread Safety
 /// This struct is fully thread safe, it can be cloned and passed between threads without constraints,
 /// Its API uses only immutable references
+#[derive(Clone)]
 pub struct FalkorAsyncClient {
     inner: Arc<FalkorAsyncClientInner>,
     _connection_info: FalkorConnectionInfo,


### PR DESCRIPTION
The docs says that FalkorAsyncClient can be cloned, it however does not impl Clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling for the asynchronous client so it can be duplicated more easily.
- **Tests**
  - Added a compile-time check to ensure the asynchronous client is `Clone + Send + Sync`.
- **Documentation**
  - Updated the changelog under **[Unreleased] → Fixed** to reflect the new `Clone` support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->