### PR TITLE
build(deps): bump codeql-action and spellcheck-github-actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
       with:
         languages: ${{ matrix.language }}
       env:
@@ -46,4 +46,4 @@ jobs:
         cargo build --all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@390a08ee9c46943112f21d2ff671649a2bacd33f # 0.62.0
+        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spellcheck blog posts
-        uses: rojopolis/spellcheck-github-actions@390a08ee9c46943112f21d2ff671649a2bacd33f # 0.62.0
+        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Blog
@@ -53,7 +53,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: printf '# %s\n' "$PR_TITLE" > .pr-title.md
       - name: Spellcheck PR title
-        uses: rojopolis/spellcheck-github-actions@390a08ee9c46943112f21d2ff671649a2bacd33f # 0.62.0
+        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: PRTitle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- Bump the `github/codeql-action` (`init` and `analyze`, 4.36.2 → 4.36.3) and
+  `rojopolis/spellcheck-github-actions` (0.62.0 → 0.63.0) GitHub Actions, combining the Dependabot
+  updates from [#289](https://github.com/FalkorDB/falkordb-rs/pull/289),
+  [#290](https://github.com/FalkorDB/falkordb-rs/pull/290) and
+  [#291](https://github.com/FalkorDB/falkordb-rs/pull/291) into one change so the `init` and
+  `analyze` steps stay pinned to the same `github/codeql-action` version
+  ([#PR](https://github.com/FalkorDB/falkordb-rs/pull/PR))
+
 ## [0.10.2](https://github.com/FalkorDB/falkordb-rs/compare/v0.10.1...v0.10.2) - 2026-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#290](https://github.com/FalkorDB/falkordb-rs/pull/290) and
   [#291](https://github.com/FalkorDB/falkordb-rs/pull/291) into one change so the `init` and
   `analyze` steps stay pinned to the same `github/codeql-action` version
-  ([#PR](https://github.com/FalkorDB/falkordb-rs/pull/PR))
+  ([#292](https://github.com/FalkorDB/falkordb-rs/pull/292))
 
 ## [0.10.2](https://github.com/FalkorDB/falkordb-rs/compare/v0.10.1...v0.10.2) - 2026-07-05
 


### PR DESCRIPTION
Combines three open Dependabot GitHub Actions bumps into one PR:

| Source | Action | Bump |
| --- | --- | --- |
| #289 | `github/codeql-action/init` | 4.36.2 → 4.36.3 |
| #290 | `github/codeql-action/analyze` | 4.36.2 → 4.36.3 |
| #291 | `rojopolis/spellcheck-github-actions` | 0.62.0 → 0.63.0 |

### Why combine

- **CodeQL needs matching versions.** `init` (#289) and `analyze` (#290) live in the same
  `.github/workflows/codeql.yml` file. Split across two PRs, each PR bumps only one step, leaving
  `init` and `analyze` on different versions — the CodeQL run then fails with a *configuration
  error* and the warning *"Not all workflow steps that use `github/codeql-action` actions use the
  same version."* Bumping both together fixes it.
- **Coverage needs repo secrets.** The individual Dependabot PRs also fail the `coverage` job
  (`Token required because branch is protected`) because Dependabot runs have no access to
  `CODECOV_TOKEN`. This in-repo branch does, so `coverage` can pass.

### Verification

- Pinned SHAs verified against their upstream tags: `codeql-action` v4.36.3 →
  `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`; `spellcheck-github-actions` 0.63.0 →
  `e619e00ca22f01ade9d73048dcd6518bedc552f2`.
- Both `codeql-action` steps bumped to the same SHA; all three `rojopolis` occurrences bumped.
- `just spellcheck` and `just spellcheck-pr-title` pass locally; YAML parses.

Supersedes #289, #290 and #291.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>