### PR TITLE
build(deps): bump codeql-action to 4.37.0 and regex to 1.13.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         languages: ${{ matrix.language }}
       env:
@@ -46,4 +46,4 @@ jobs:
         cargo build --all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#291](https://github.com/FalkorDB/falkordb-rs/pull/291) into one change so the `init` and
   `analyze` steps stay pinned to the same `github/codeql-action` version
   ([#292](https://github.com/FalkorDB/falkordb-rs/pull/292))
+- Bump the `github/codeql-action` (`init` and `analyze`, 4.36.3 → 4.37.0) GitHub Actions and the
+  `regex` crate (1.12.4 → 1.13.0), combining the Dependabot updates from
+  [#293](https://github.com/FalkorDB/falkordb-rs/pull/293),
+  [#294](https://github.com/FalkorDB/falkordb-rs/pull/294) and
+  [#295](https://github.com/FalkorDB/falkordb-rs/pull/295) into one change so the `init` and
+  `analyze` steps stay pinned to the same `github/codeql-action` version
+  ([#296](https://github.com/FalkorDB/falkordb-rs/pull/296))
 
 ## [0.10.2](https://github.com/FalkorDB/falkordb-rs/compare/v0.10.1...v0.10.2) - 2026-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
Combines three open Dependabot updates into a single PR so the `github/codeql-action` `init` and `analyze` steps stay pinned to the same version and the coverage job (which needs `CODECOV_TOKEN`, unavailable on Dependabot branches) can run.

## Bumps
- `github/codeql-action/init` 4.36.3 → 4.37.0 — supersedes #293
- `github/codeql-action/analyze` 4.36.3 → 4.37.0 — supersedes #295
- `regex` 1.12.4 → 1.13.0 (Cargo.lock only; satisfies the `^1.12.3` range in `Cargo.toml`) — supersedes #294

Both `codeql-action` steps use the identical SHA `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` (v4.37.0) to avoid the CodeQL "configuration error" that a version mismatch between `init` and `analyze` triggers.

Closes #293
Closes #294
Closes #295

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL analysis tooling to version 4.37.0 for improved security scanning maintenance.
  * Updated the regex package to version 1.13.0.

* **Documentation**
  * Added the dependency updates to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->