### PR TITLE
Fix spurious connection errors: override redis-rs 1.x default 500ms response timeout

### DIFF
--- a/src/client/asynchronous.rs
+++ b/src/client/asynchronous.rs
@@ -925,6 +925,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(FalkorAsyncClient::build_executor(
             &mut provider,
@@ -960,6 +961,7 @@ mod tests {
             sentinel_replica: Some(replica),
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(provider.has_sentinel_replica());
         assert!(FalkorAsyncClient::build_executor(
@@ -986,6 +988,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         let readonly_conn = provider
             .get_async_connection()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -639,6 +639,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(FalkorSyncClient::create_readonly_pool(&mut provider, 4).is_none());
     }
@@ -665,6 +666,7 @@ mod tests {
             sentinel_replica: Some(replica),
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(provider.has_sentinel_replica());
         assert!(FalkorSyncClient::create_readonly_pool(&mut provider, 4).is_none());

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -23,6 +23,7 @@ pub struct FalkorClientBuilder<const R: char> {
     retry_policy: RetryPolicy,
     query_logging: bool,
     read_preference: ReadPreference,
+    response_timeout: Option<Duration>,
 }
 
 impl<const R: char> FalkorClientBuilder<R> {
@@ -197,9 +198,36 @@ impl<const R: char> FalkorClientBuilder<R> {
         self.with_tcp_settings(settings)
     }
 
+    /// Set a client-side response timeout for async connections.
+    ///
+    /// By default no client-side timeout is applied (`None`), matching the other
+    /// FalkorDB clients (e.g. falkordb-py's `socket_timeout=None`): query duration is
+    /// governed by the server's own `TIMEOUT`/`TIMEOUT_DEFAULT` configuration. This
+    /// default deliberately overrides redis-rs 1.x's built-in 500ms response timeout,
+    /// which is far too short for typical graph workloads (`LOAD CSV`, deep
+    /// traversals) and would otherwise cut the connection while the server keeps
+    /// executing the query.
+    ///
+    /// # Arguments
+    /// * `response_timeout`: maximum time to wait for a server response, or `None` to
+    ///   wait indefinitely (the default).
+    ///
+    /// # Returns
+    /// The consumed and modified self.
+    pub fn with_response_timeout(
+        self,
+        response_timeout: Option<Duration>,
+    ) -> Self {
+        Self {
+            response_timeout,
+            ..self
+        }
+    }
+
     fn get_client<E: ToString, T: TryInto<FalkorConnectionInfo, Error = E>>(
         connection_info: T,
         tcp_settings: Option<&redis::io::tcp::TcpSettings>,
+        response_timeout: Option<Duration>,
     ) -> FalkorResult<(FalkorClientProvider, FalkorConnectionInfo)> {
         let connection_info = connection_info
             .try_into()
@@ -227,6 +255,7 @@ impl<const R: char> FalkorClientBuilder<R> {
                     sentinel: None,
                     sentinel_replica: None,
                     embedded_server: Some(embedded_server),
+                    response_timeout,
                 },
                 FalkorConnectionInfo::Redis(redis_connection_info),
             ));
@@ -250,6 +279,7 @@ impl<const R: char> FalkorClientBuilder<R> {
                         sentinel_replica: None,
                         #[cfg(feature = "embedded-core")]
                         embedded_server: None,
+                        response_timeout,
                     }
                 }
                 #[cfg(feature = "embedded-core")]
@@ -277,6 +307,7 @@ impl FalkorClientBuilder<'S'> {
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
             read_preference: ReadPreference::Primary,
+            response_timeout: None,
         }
     }
 
@@ -289,8 +320,11 @@ impl FalkorClientBuilder<'S'> {
             .connection_info
             .unwrap_or("falkor://127.0.0.1:6379".try_into()?);
 
-        let (mut client, actual_connection_info) =
-            Self::get_client(connection_info, self.tcp_settings.as_ref())?;
+        let (mut client, actual_connection_info) = Self::get_client(
+            connection_info,
+            self.tcp_settings.as_ref(),
+            self.response_timeout,
+        )?;
 
         #[allow(irrefutable_let_patterns)]
         if let FalkorConnectionInfo::Redis(redis_conn_info) = &actual_connection_info {
@@ -329,6 +363,7 @@ impl FalkorClientBuilder<'A'> {
             retry_policy: RetryPolicy::disabled(),
             query_logging: false,
             read_preference: ReadPreference::Primary,
+            response_timeout: None,
         }
     }
 
@@ -407,8 +442,11 @@ impl FalkorClientBuilder<'A'> {
             .connection_info
             .unwrap_or("falkor://127.0.0.1:6379".try_into()?);
 
-        let (mut client, actual_connection_info) =
-            Self::get_client(connection_info, self.tcp_settings.as_ref())?;
+        let (mut client, actual_connection_info) = Self::get_client(
+            connection_info,
+            self.tcp_settings.as_ref(),
+            self.response_timeout,
+        )?;
 
         #[allow(irrefutable_let_patterns)]
         if let FalkorConnectionInfo::Redis(redis_conn_info) = &actual_connection_info {
@@ -456,6 +494,22 @@ mod tests {
         assert!(client.is_ok());
 
         assert_eq!(client.unwrap().connection_pool_size(), 16);
+    }
+
+    #[test]
+    fn test_builder_response_timeout_defaults_to_none() {
+        let builder = FalkorClientBuilder::new();
+        assert!(builder.response_timeout.is_none());
+    }
+
+    #[test]
+    fn test_builder_with_response_timeout() {
+        let builder =
+            FalkorClientBuilder::new().with_response_timeout(Some(Duration::from_secs(30)));
+        assert_eq!(builder.response_timeout, Some(Duration::from_secs(30)));
+
+        let builder = builder.with_response_timeout(None);
+        assert!(builder.response_timeout.is_none());
     }
 
     #[test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -142,6 +142,14 @@ pub(crate) enum FalkorClientProvider {
         #[cfg(feature = "embedded-core")]
         #[allow(dead_code)]
         embedded_server: Option<std::sync::Arc<crate::embedded::EmbeddedServer>>,
+        /// Client-side response timeout applied to async connections. `None` (the
+        /// default) disables the client-side deadline entirely, letting the server's
+        /// own `TIMEOUT`/`TIMEOUT_DEFAULT` configuration govern query duration. This
+        /// overrides redis-rs 1.x's default 500ms response timeout, which is far too
+        /// short for typical graph queries (e.g. `LOAD CSV`, deep traversals) and
+        /// would otherwise surface as spurious connection errors while the server
+        /// keeps executing the query.
+        response_timeout: Option<std::time::Duration>,
     },
 }
 
@@ -167,21 +175,40 @@ impl FalkorClientProvider {
         })
     }
 
+    /// Async connection config carrying the provider's response timeout. Always set
+    /// explicitly (even when `None`) so redis-rs 1.x's default 500ms response timeout
+    /// never applies.
+    #[cfg(feature = "tokio")]
+    fn async_connection_config(
+        response_timeout: Option<std::time::Duration>
+    ) -> redis::AsyncConnectionConfig {
+        redis::AsyncConnectionConfig::new().set_response_timeout(response_timeout)
+    }
+
     #[cfg(feature = "tokio")]
     pub(crate) async fn get_async_connection(&mut self) -> FalkorResult<FalkorAsyncConnection> {
         Ok(match self {
             FalkorClientProvider::Redis {
                 sentinel: Some(sentinel),
+                response_timeout,
                 ..
             } => FalkorAsyncConnection::Redis(
                 sentinel
-                    .get_async_connection()
+                    .get_async_connection_with_config(&Self::async_connection_config(
+                        *response_timeout,
+                    ))
                     .await
                     .map_err(|err| FalkorDBError::RedisError(err.to_string()))?,
             ),
-            FalkorClientProvider::Redis { client, .. } => FalkorAsyncConnection::Redis(
+            FalkorClientProvider::Redis {
+                client,
+                response_timeout,
+                ..
+            } => FalkorAsyncConnection::Redis(
                 client
-                    .get_multiplexed_async_connection()
+                    .get_multiplexed_async_connection_with_config(&Self::async_connection_config(
+                        *response_timeout,
+                    ))
                     .await
                     .map_err(|err| FalkorDBError::RedisError(err.to_string()))?,
             ),
@@ -216,10 +243,13 @@ impl FalkorClientProvider {
         match self {
             FalkorClientProvider::Redis {
                 sentinel_replica: Some(replica),
+                response_timeout,
                 ..
             } => Ok(FalkorAsyncConnection::Redis(
                 replica
-                    .get_async_connection()
+                    .get_async_connection_with_config(&Self::async_connection_config(
+                        *response_timeout,
+                    ))
                     .await
                     .map_err(|err| FalkorDBError::RedisError(err.to_string()))?,
             )),
@@ -262,6 +292,7 @@ impl FalkorClientProvider {
         &mut self,
         max_inflight: Option<NonZeroUsize>,
     ) -> FalkorResult<FalkorAsyncConnection> {
+        let response_timeout = self.response_timeout();
         let client = match self {
             FalkorClientProvider::Redis {
                 sentinel: Some(sentinel),
@@ -274,7 +305,7 @@ impl FalkorClientProvider {
             #[cfg(test)]
             FalkorClientProvider::None => return Err(FalkorDBError::UnavailableProvider),
         };
-        Self::manager_from_client(client, max_inflight).await
+        Self::manager_from_client(client, max_inflight, response_timeout).await
     }
 
     /// Replica-routed counterpart of
@@ -285,6 +316,7 @@ impl FalkorClientProvider {
         &mut self,
         max_inflight: Option<NonZeroUsize>,
     ) -> FalkorResult<FalkorAsyncConnection> {
+        let response_timeout = self.response_timeout();
         match self {
             FalkorClientProvider::Redis {
                 sentinel_replica: Some(replica),
@@ -294,9 +326,21 @@ impl FalkorClientProvider {
                     .async_get_client()
                     .await
                     .map_err(|err| FalkorDBError::RedisError(err.to_string()))?;
-                Self::manager_from_client(client, max_inflight).await
+                Self::manager_from_client(client, max_inflight, response_timeout).await
             }
             _ => Err(FalkorDBError::UnavailableProvider),
+        }
+    }
+
+    /// The configured client-side response timeout (`None` disables it).
+    #[cfg(feature = "tokio")]
+    fn response_timeout(&self) -> Option<std::time::Duration> {
+        match self {
+            FalkorClientProvider::Redis {
+                response_timeout, ..
+            } => *response_timeout,
+            #[cfg(test)]
+            FalkorClientProvider::None => None,
         }
     }
 
@@ -304,16 +348,19 @@ impl FalkorClientProvider {
     async fn manager_from_client(
         client: redis::Client,
         max_inflight: Option<NonZeroUsize>,
+        response_timeout: Option<std::time::Duration>,
     ) -> FalkorResult<FalkorAsyncConnection> {
-        let manager = match max_inflight {
-            Some(limit) => {
-                let config =
-                    redis::aio::ConnectionManagerConfig::new().set_concurrency_limit(limit.get());
-                redis::aio::ConnectionManager::new_with_config(client, config).await
-            }
-            None => redis::aio::ConnectionManager::new(client).await,
-        }
-        .map_err(|err| FalkorDBError::RedisError(err.to_string()))?;
+        // Always set the response timeout explicitly (even when `None`) so redis-rs
+        // 1.x's default 500ms response timeout never applies.
+        let config =
+            redis::aio::ConnectionManagerConfig::new().set_response_timeout(response_timeout);
+        let config = match max_inflight {
+            Some(limit) => config.set_concurrency_limit(limit.get()),
+            None => config,
+        };
+        let manager = redis::aio::ConnectionManager::new_with_config(client, config)
+            .await
+            .map_err(|err| FalkorDBError::RedisError(err.to_string()))?;
         Ok(FalkorAsyncConnection::Managed(manager))
     }
 
@@ -509,6 +556,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(!provider.has_sentinel_replica());
     }
@@ -655,6 +703,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         assert!(!provider.has_sentinel_replica());
         let connection_info = redis::ConnectionInfo::from_str("redis://127.0.0.1:26379").unwrap();
@@ -679,6 +728,7 @@ mod tests {
             sentinel: None,
             sentinel_replica: None,
             embedded_server: None,
+            response_timeout: None,
         };
         // Just verify the structure can be created
     }
@@ -693,6 +743,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         // Just verify the structure can be created
     }
@@ -718,6 +769,7 @@ mod tests {
             sentinel_replica: Some(replica),
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         // The replica connection fails and the error must surface as a replica-path
         // RedisError; the call must not fall back to the primary.
@@ -749,6 +801,7 @@ mod tests {
                 sentinel_replica: Some(replica),
                 #[cfg(feature = "embedded-core")]
                 embedded_server: None,
+                response_timeout: None,
             };
             let result = provider.get_async_replica_connection().await;
             assert!(
@@ -770,6 +823,7 @@ mod tests {
             sentinel_replica: None,
             #[cfg(feature = "embedded-core")]
             embedded_server: None,
+            response_timeout: None,
         };
         let result = provider.get_replica_connection();
         assert!(matches!(result, Err(FalkorDBError::UnavailableProvider)));
@@ -788,6 +842,7 @@ mod tests {
                 sentinel_replica: None,
                 #[cfg(feature = "embedded-core")]
                 embedded_server: None,
+                response_timeout: None,
             };
             let result = provider.get_async_replica_connection().await;
             assert!(matches!(result, Err(FalkorDBError::UnavailableProvider)));
@@ -827,6 +882,7 @@ mod tests {
                 sentinel_replica: None,
                 #[cfg(feature = "embedded-core")]
                 embedded_server: None,
+                response_timeout: None,
             };
             // The sentinel arm resolves the master through an unreachable sentinel, which
             // fails fast with a RedisError rather than bypassing it.
@@ -859,6 +915,7 @@ mod tests {
                 sentinel_replica: Some(replica),
                 #[cfg(feature = "embedded-core")]
                 embedded_server: None,
+                response_timeout: None,
             };
             let result = provider.get_async_replica_connection_manager(None).await;
             assert!(
@@ -881,6 +938,7 @@ mod tests {
                 sentinel_replica: None,
                 #[cfg(feature = "embedded-core")]
                 embedded_server: None,
+                response_timeout: None,
             };
             let result = provider.get_async_replica_connection_manager(None).await;
             assert!(matches!(result, Err(FalkorDBError::UnavailableProvider)));


### PR DESCRIPTION
## Problem

Since the redis dependency was bumped to 1.x (falkordb-rs 0.3.0), every async connection inherits redis-rs's built-in **default response timeout of 500ms** (`DEFAULT_RESPONSE_TIMEOUT` in `redis/src/client.rs`). falkordb-rs never overrides it.

Graph queries routinely take longer than 500ms (`LOAD CSV`, deep traversals, heavy aggregations). When they do, the client cuts the connection and surfaces:

> This requested returned a connection error, however, we may be able to create a new connection to the server, this operation should probably be retried in a bit.

while the server keeps executing the query. For writes this is data-corrupting: the caller sees an error, retries, and the write is applied multiple times (observed in the FalkorDB Snowflake Native App, where a CSV load was duplicated 5x).

Reproduced against FalkorDB 4.18.10, 4.18.11, 4.20.0 and 4.20.1: any query >500ms fails client-side on falkordb-rs 0.3.0+, and works on the pre-1.x redis stack.

## Fix

Follow the convention of the other FalkorDB clients (falkordb-py uses `socket_timeout=None`):

- **Default: no client-side response timeout.** Query duration is governed by the server's own `TIMEOUT`/`TIMEOUT_DEFAULT` configuration.
- The timeout is now set **explicitly on every async connection path** (multiplexed, sentinel, replica, and `ConnectionManager`), so the redis-rs default can never leak in.
- New `FalkorClientBuilder::with_response_timeout(Option<Duration>)` for users who do want a client-side deadline.

## Validation

- `cargo test --all-features --lib`: 577 passed, 0 failed
- `cargo clippy --all-features --all-targets`: no new warnings
- End-to-end: a 428k-row `LOAD CSV` (~1.1s) and a ~1.2s read query both fail on current main and succeed with this patch, with the data loaded exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable response timeouts for asynchronous Redis connections.
  * Builders can now set an optional timeout that applies consistently to direct, embedded, replica, and managed connections.
  * By default, no custom response timeout is applied, preserving existing behavior.
* **Tests**
  * Added coverage confirming default timeout settings and custom timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->