### PR TITLE
ci: validate pull-request titles are Conventional Commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ Key recipes:
 | `just proptest` | `serde` property tests (no server). |
 | `just spellcheck` | Spellcheck the Markdown docs. |
 | `just spellcheck-pr-title` | Spellcheck a PR title (`PR_TITLE='…' just spellcheck-pr-title`). |
+| `just check-pr-title` | Validate a PR title is a Conventional Commit (`PR_TITLE='…' just check-pr-title`). |
 
 Tests need a running server; prefer the `*-local` wrappers, which manage Docker and the fixture.
 
@@ -89,6 +90,14 @@ don't pile up.
   history) and their Conventional-Commit prefix drives the release, so keep them clean at the
   source. **`CHANGELOG.md` entries are hand-written and spellchecked too** — an unknown word there
   fails the `spellcheck` gate, so backtick code/type names or add them to the wordlist.
+- **PR titles must be a valid Conventional Commit** — the `PR title format` CI gate
+  (`just check-pr-title`, in `spellcheck.yml`) rejects any title that isn't
+  `<type>[(scope)][!]: <subject>` with a recognized `<type>`. It guards against titles like
+  `Fix spurious connection errors: …` (PR #297): that isn't a Conventional Commit, so it matched
+  none of release-plz's `release_commits` and silently cut **no** release. The release-triggering
+  types are `feat` / `fix` / `docs` (mirroring `release_commits` in `release-plz.toml`);
+  `ci` / `chore` / `refactor` / `perf` / `test` / `build` / `style` / `revert` are accepted too but
+  ride along with the next release. Run it locally with `PR_TITLE='fix: …' just check-pr-title`.
 - When you add or rename a **public type / term**, add its name to **`.github/wordlist.txt`**.
 - In Markdown/docs, **backtick** code and type names (`` `ConnectionDown` ``) — backticked spans
   are ignored by the spellchecker.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    # Conventional-Commit prefix so the PR title passes the `PR title format` gate (a bare
+    # "Bump ..." title would fail it); `build` rides along with the next release.
+    commit-message:
+      prefix: "build"
 
   # This is actually for cargo crates
   - package-ecosystem: cargo
@@ -13,3 +17,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
+    # Conventional-Commit prefix so the PR title passes the `PR title format` gate (a bare
+    # "Bump ..." title would fail it); `build` rides along with the next release.
+    commit-message:
+      prefix: "build"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` so fixing a PR title re-runs the title checks (spelling + Conventional-Commit format).
+    types: [opened, synchronize, reopened, edited]
 jobs:
   spellcheck:
     runs-on: ubuntu-latest
@@ -57,3 +59,26 @@ jobs:
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: PRTitle
+
+  # Validate that the pull-request title is a Conventional Commit whose type release-plz
+  # recognizes. The title becomes the squash-merge subject and its prefix drives the release
+  # (release_commits in release-plz.toml), so a malformed title silently skips the release — as
+  # PR #297's "Fix spurious connection errors: ..." did. Runs the same `just check-pr-title`
+  # recipe developers run locally, so CI and local stay identical.
+  pr-title-format:
+    name: PR title format
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@88ada01c46e65c47040a0ae865537cc76fcd0e1c # just
+        with:
+          tool: just
+      - name: Check PR title is a Conventional Commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: just check-pr-title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#295](https://github.com/FalkorDB/falkordb-rs/pull/295) into one change so the `init` and
   `analyze` steps stay pinned to the same `github/codeql-action` version
   ([#296](https://github.com/FalkorDB/falkordb-rs/pull/296))
+- Add a `PR title format` CI gate (`just check-pr-title`, in `spellcheck.yml`) that rejects a
+  pull-request title which isn't a Conventional Commit, so a `fix` / `feat` / `docs` change is
+  titled to match `release-plz`'s `release_commits` and actually cuts a release (PR #297's
+  non-conventional title matched nothing and released nothing). Also sets a Conventional-Commit
+  `commit-message` prefix for Dependabot and documents the rule in
+  `.github/copilot-instructions.md` ([#298](https://github.com/FalkorDB/falkordb-rs/pull/298))
 
 ## [0.10.2](https://github.com/FalkorDB/falkordb-rs/compare/v0.10.1...v0.10.2) - 2026-07-05
 

--- a/Justfile
+++ b/Justfile
@@ -228,7 +228,7 @@ spellcheck-pr-title:
 # Conventional-Commit types accepted in a PR title. The release-triggering subset
 # `feat|fix|docs` mirrors release-plz's `release_commits` in release-plz.toml (so a fix/feat/docs
 # PR actually cuts a release); the remaining types are valid but ride along with the next release.
-pr_title_pattern := '^(feat|fix|docs|ci|chore|refactor|perf|test|build|style|revert)(\(.+\))?!?: .+'
+pr_title_pattern := '^(feat|fix|docs|ci|chore|refactor|perf|test|build|style|revert)(\([^()[:space:]][^()]*\))?!?: .+'
 
 # Validate a PR title as a Conventional Commit, exactly as the `PR title format` CI gate does.
 # The title becomes the squash-merge subject and its prefix drives the release, so a malformed
@@ -270,6 +270,8 @@ test-pr-title:
         "update the readme"
         "fix:no space after the colon"
         "feature: not a recognized type"
+        "fix( ): whitespace-only scope"
+        "fix(): empty scope"
     )
     rc=0
     for t in "${good[@]}"; do

--- a/Justfile
+++ b/Justfile
@@ -223,6 +223,64 @@ spellcheck-blog:
 spellcheck-pr-title:
     printf '# %s\n' "${PR_TITLE:?set PR_TITLE to the pull-request title}" > .pr-title.md && pyspelling -c .github/spellcheck-settings.yml -n PRTitle && rm -f .pr-title.md || { rm -f .pr-title.md; exit 1; }
 
+# === PR title (Conventional Commits) =========================================
+
+# Conventional-Commit types accepted in a PR title. The release-triggering subset
+# `feat|fix|docs` mirrors release-plz's `release_commits` in release-plz.toml (so a fix/feat/docs
+# PR actually cuts a release); the remaining types are valid but ride along with the next release.
+pr_title_pattern := '^(feat|fix|docs|ci|chore|refactor|perf|test|build|style|revert)(\(.+\))?!?: .+'
+
+# Validate a PR title as a Conventional Commit, exactly as the `PR title format` CI gate does.
+# The title becomes the squash-merge subject and its prefix drives the release, so a malformed
+# title silently skips it — as happened with PR #297's "Fix spurious connection errors: ...",
+# which matched none of release-plz's release_commits and cut no release. Set PR_TITLE first,
+# e.g. `PR_TITLE='fix: handle ConnectionDown' just check-pr-title`.
+check-pr-title: test-pr-title
+    #!/usr/bin/env bash
+    set -euo pipefail
+    title="${PR_TITLE:?set PR_TITLE to the pull-request title}"
+    if ! grep -Eq '{{pr_title_pattern}}' <<<"$title"; then
+        printf '::error::PR title is not a Conventional Commit: %s\n' "$title" >&2
+        printf 'Expected "<type>[(scope)][!]: <subject>", where <type> is one of:\n' >&2
+        printf '  feat, fix, docs                                       (trigger a release via release-plz)\n' >&2
+        printf '  ci, chore, refactor, perf, test, build, style, revert (ride along with the next release)\n' >&2
+        printf 'e.g. "fix: override redis-rs default response timeout"\n' >&2
+        exit 1
+    fi
+    printf 'PR title OK: %s\n' "$title"
+
+# Self-test the check-pr-title pattern against known-good/known-bad titles (incl. PR #297's subject
+# that slipped through and skipped a release). Needs no PR_TITLE; runs as part of check-pr-title.
+test-pr-title:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pattern='{{pr_title_pattern}}'
+    good=(
+        "fix: derive Clone for FalkorAsyncClient"
+        "feat!: make replica routing for read-only queries opt-in"
+        "feat(blog): add diagram zoom, a livelier theme"
+        "docs: generate README from crate docs via cargo-rdme"
+        "ci: compile README doctests and examples in CI"
+        "build(deps): bump codeql-action to 4.37.0 and regex to 1.13.0"
+        "chore: release v0.10.2"
+    )
+    bad=(
+        "Fix spurious connection errors: override redis-rs 1.x default 500ms response timeout"
+        "Bump redis from 1.2.0 to 1.3.0"
+        "update the readme"
+        "fix:no space after the colon"
+        "feature: not a recognized type"
+    )
+    rc=0
+    for t in "${good[@]}"; do
+        if ! grep -Eq "$pattern" <<<"$t"; then printf 'want PASS, got FAIL: %s\n' "$t" >&2; rc=1; fi
+    done
+    for t in "${bad[@]}"; do
+        if grep -Eq "$pattern" <<<"$t"; then printf 'want FAIL, got PASS: %s\n' "$t" >&2; rc=1; fi
+    done
+    if [ "$rc" -ne 0 ]; then exit 1; fi
+    printf 'test-pr-title: all %d cases passed\n' "$(( ${#good[@]} + ${#bad[@]} ))"
+
 # === llms.txt (AI-readable API surface) ======================================
 
 # Regenerate the repo-root llms.txt from docs/llms.template.md + the public API parsed

--- a/Justfile
+++ b/Justfile
@@ -228,7 +228,7 @@ spellcheck-pr-title:
 # Conventional-Commit types accepted in a PR title. The release-triggering subset
 # `feat|fix|docs` mirrors release-plz's `release_commits` in release-plz.toml (so a fix/feat/docs
 # PR actually cuts a release); the remaining types are valid but ride along with the next release.
-pr_title_pattern := '^(feat|fix|docs|ci|chore|refactor|perf|test|build|style|revert)(\([^()[:space:]][^()]*\))?!?: .+'
+pr_title_pattern := '^(feat|fix|docs|ci|chore|refactor|perf|test|build|style|revert)(\([^()[:space:]]+\))?!?: .*[^[:space:]]'
 
 # Validate a PR title as a Conventional Commit, exactly as the `PR title format` CI gate does.
 # The title becomes the squash-merge subject and its prefix drives the release, so a malformed
@@ -272,6 +272,8 @@ test-pr-title:
         "feature: not a recognized type"
         "fix( ): whitespace-only scope"
         "fix(): empty scope"
+        "feat(a b): whitespace inside the scope"
+        "fix:   "
     )
     rc=0
     for t in "${good[@]}"; do

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,11 @@ semver_check = false # disable API breaking changes checks, I suggest this becom
 # temporarily relax this filter.
 release_commits = '^(feat|fix|docs)(\(.+?\))?!?:'
 
+# The `PR title format` CI gate (`just check-pr-title`, in .github/workflows/spellcheck.yml)
+# enforces that every PR title is a Conventional Commit, so a fix/feat/docs change is titled to
+# match the regex above and actually cuts a release. PR #297's non-conventional
+# "Fix spurious connection errors: …" title matched nothing here and released nothing.
+
 [changelog]
 # Changelog entries are hand-written under "## [Unreleased]" in CHANGELOG.md (see the
 # "CHANGELOG & releases" section of .github/copilot-instructions.md). On release, release-plz


### PR DESCRIPTION
## Problem

PR #297 ("Fix spurious connection errors: override redis-rs 1.x default 500ms response timeout") was squash-merged with a **non-Conventional-Commit** subject. release-plz's `release_commits` filter is `^(feat|fix|docs)(\(.+?\))?!?:`, so that title — and the only other commits since v0.10.2 (two `build(deps):` bumps) — matched nothing. release-plz opened **no release PR** and the fix went unreleased.

## Fix

Add a `PR title format` CI gate so a malformed title can't silently skip a release again:

- **`Justfile`** — `check-pr-title` validates the title is `<type>[(scope)][!]: <subject>`, with a `test-pr-title` self-test (runs as a dependency) covering known-good/known-bad titles, including #297's exact subject (must fail). The release-triggering subset `feat|fix|docs` mirrors `release_commits`; `ci|chore|refactor|perf|test|build|style|revert` are accepted but ride along with the next release.
- **`.github/workflows/spellcheck.yml`** — a `pr-title-format` job runs the same `just check-pr-title` recipe (CI and local stay identical, per the repo's golden rule), and `edited` is added to the `pull_request` types so fixing a title re-runs the checks.
- **`.github/dependabot.yml`** — a Conventional-Commit `commit-message` prefix so bot PR titles pass the new gate.
- **`.github/copilot-instructions.md`** + **`release-plz.toml`** — document the rule and cross-link it to `release_commits`.

## Validation

```
$ PR_TITLE="Fix spurious connection errors: override redis-rs 1.x default 500ms response timeout" just check-pr-title
::error::PR title is not a Conventional Commit: ...   # exit 1

$ PR_TITLE="fix: derive Clone for FalkorAsyncClient" just check-pr-title
PR title OK: ...                                       # exit 0

$ just test-pr-title
test-pr-title: all 12 cases passed
```

This PR's own title passes the new gate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
