### PR TITLE
docs: document the redis-rs response timeout fix and new builder option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `FalkorClientBuilder::with_response_timeout(Option<Duration>)` to configure an optional
+  client-side response timeout for async connections. It defaults to `None` (no client-side
+  deadline) — matching `falkordb-py`'s `socket_timeout` — so the server's `TIMEOUT` /
+  `TIMEOUT_DEFAULT` configuration governs how long a query may run
+  ([#297](https://github.com/FalkorDB/falkordb-rs/pull/297))
+
+### Fixed
+
+- Override the built-in 500ms default response timeout that `redis-rs 1.x` applies to every async
+  connection path (multiplexed, sentinel, replica, and `ConnectionManager`). Queries that took
+  longer than 500ms (for example `LOAD CSV`, deep traversals, or heavy aggregations) previously
+  failed client-side with a spurious connection error while the server kept executing them, and
+  the ensuing retries could duplicate writes. The response timeout is now unset by default
+  ([#297](https://github.com/FalkorDB/falkordb-rs/pull/297))
+
 ### Other
 
 - Bump the `github/codeql-action` (`init` and `analyze`, 4.36.2 → 4.36.3) and


### PR DESCRIPTION
## Why

`v0.10.2` is the latest release, but PR #297 — which fixed the redis-rs 500ms response-timeout that caused spurious connection errors, and added `FalkorClientBuilder::with_response_timeout` — was squash-merged with a **non-Conventional-Commit** subject ("Fix spurious connection errors: ...") **and no CHANGELOG entry**. release-plz's `release_commits` (`^(feat|fix|docs)(\(.+?\))?!?:`) therefore matched none of the commits since v0.10.2, so **no release PR was opened** and the fix is still unreleased.

## What

This records #297's user-facing changes under `## [Unreleased]`:

- **Added** — `FalkorClientBuilder::with_response_timeout(Option<Duration>)`.
- **Fixed** — the `redis-rs 1.x` 500ms default response timeout is now overridden (unset by default) on every async connection path.

Because this is a `docs:` Conventional Commit, merging it lets **release-plz open the release PR itself** (a patch bump → **v0.10.3**), stamping the version header above these hand-written entries — no version is hardcoded here.

## Follow-up

The root-cause guard (a `PR title format` CI gate that rejects non-Conventional-Commit titles) is in #298.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
