### PR TITLE
build: combine Dependabot updates (redis, spellcheck action, codeql action)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
       with:
         languages: ${{ matrix.language }}
       env:
@@ -46,4 +46,4 @@ jobs:
         cargo build --all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
+        uses: rojopolis/spellcheck-github-actions@b1a70f135d603e77d2828ef5ac7557de26657d3f # 0.63.1
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spellcheck blog posts
-        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
+        uses: rojopolis/spellcheck-github-actions@b1a70f135d603e77d2828ef5ac7557de26657d3f # 0.63.1
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Blog
@@ -55,7 +55,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: printf '# %s\n' "$PR_TITLE" > .pr-title.md
       - name: Spellcheck PR title
-        uses: rojopolis/spellcheck-github-actions@e619e00ca22f01ade9d73048dcd6518bedc552f2 # 0.63.0
+        uses: rojopolis/spellcheck-github-actions@b1a70f135d603e77d2828ef5ac7557de26657d3f # 0.63.1
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: PRTitle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#324](https://github.com/FalkorDB/falkordb-rs/pull/324),
   [#325](https://github.com/FalkorDB/falkordb-rs/pull/325) and
   [#326](https://github.com/FalkorDB/falkordb-rs/pull/326) into one change
+  ([#327](https://github.com/FalkorDB/falkordb-rs/pull/327))
 
 - Bump the `tokio` crate (1.53.0 → 1.53.1), the `libc` crate (0.2.186 → 0.2.189), the
   `thiserror` crate (2.0.18 → 2.0.19), the `serde_json` crate (1.0.150 → 1.0.151), the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- Bump the `redis` crate (1.4.1 → 1.5.0), the `rojopolis/spellcheck-github-actions` GitHub
+  Action (0.63.0 → 0.63.1, pinned SHA `e619e00` → `b1a70f1`) and the `github/codeql-action`
+  (`init` and `analyze`) GitHub Action (4.37.3 → 4.37.4, pinned SHA `e4fba86` → `f205ea1`),
+  combining the Dependabot updates from
+  [#323](https://github.com/FalkorDB/falkordb-rs/pull/323),
+  [#324](https://github.com/FalkorDB/falkordb-rs/pull/324),
+  [#325](https://github.com/FalkorDB/falkordb-rs/pull/325) and
+  [#326](https://github.com/FalkorDB/falkordb-rs/pull/326) into one change
+
 - Bump the `tokio` crate (1.53.0 → 1.53.1), the `libc` crate (0.2.186 → 0.2.189), the
   `thiserror` crate (2.0.18 → 2.0.19), the `serde_json` crate (1.0.150 → 1.0.151), the
   `actions/checkout` GitHub Action (7.0.0 → 7.0.1, pinned SHA `9c091bb` → `3d3c42e`) and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "arc-swap",
  "arcstr",
@@ -1646,7 +1646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
Combines the following Dependabot updates into one PR, on an in-repo branch so `coverage` has access to `CODECOV_TOKEN`:

- Bump `redis` from 1.4.1 to 1.5.0 (#324)
- Bump `rojopolis/spellcheck-github-actions` from 0.63.0 to 0.63.1 (#323)
- Bump `github/codeql-action` `init` from 4.37.3 to 4.37.4 (#325)
- Bump `github/codeql-action` `analyze` from 4.37.3 to 4.37.4 (#326)

Closes #323, #324, #325, #326.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security analysis and spellcheck automation to newer approved versions.
  * Refreshed pinned workflow references for improved maintenance and reliability.

* **Documentation**
  * Added the latest automation updates to the Unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->