### PR TITLE
test: tolerate FalkorDB dropping the `Results` plan root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- Make the `test_explain` and `test_profile` tests tolerate FalkorDB dropping the `Results`
+  root operation from `GRAPH.EXPLAIN` / `GRAPH.PROFILE` output. The nightly `edge` coverage
+  run had been failing on this since the planner change landed; the tests now assert on the
+  operations below that root, so they pass against both current releases and `edge`. The
+  client itself needed no change — plan parsing already handles either shape
+  (PR_LINK_PLACEHOLDER)
+
 - Bump the `redis` crate (1.4.1 → 1.5.0), the `rojopolis/spellcheck-github-actions` GitHub
   Action (0.63.0 → 0.63.1, pinned SHA `e619e00` → `b1a70f1`) and the `github/codeql-action`
   (`init` and `analyze`) GitHub Action (4.37.3 → 4.37.4, pinned SHA `e4fba86` → `f205ea1`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run had been failing on this since the planner change landed; the tests now assert on the
   operations below that root, so they pass against both current releases and `edge`. The
   client itself needed no change — plan parsing already handles either shape
-  (PR_LINK_PLACEHOLDER)
+  ([#343](https://github.com/FalkorDB/falkordb-rs/pull/343))
 
 - Bump the `redis` crate (1.4.1 → 1.5.0), the `rojopolis/spellcheck-github-actions` GitHub
   Action (0.63.0 → 0.63.1, pinned SHA `e619e00` → `b1a70f1`) and the `github/codeql-action`

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -476,7 +476,7 @@ mod tests {
     use crate::{
         test_utils::{
             create_async_test_client, imdb_async_test_client, open_empty_async_test_graph,
-            plan_root, plan_steps, retry_until_async,
+            retry_until_async, skip_results_root, skip_results_root_op,
         },
         ConstraintType, FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -1027,11 +1027,17 @@ mod tests {
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
-        let steps = plan_steps(&execution_plan);
-        assert_eq!(steps.len(), 6);
+        let steps = skip_results_root(execution_plan.plan());
         assert_eq!(
-            steps.join("\n"),
-            "Limit\n    Aggregate\n        Filter\n            Node By Index Scan | (b:actor)\n                Project\n                    Node By Label Scan | (a:actor)"
+            steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
+            [
+                "Limit",
+                "Aggregate",
+                "Filter",
+                "Node By Index Scan | (b:actor)",
+                "Project",
+                "Node By Label Scan | (a:actor)",
+            ]
         );
     }
 
@@ -1046,10 +1052,10 @@ mod tests {
             .await
             .expect("Could not generate the query");
 
-        assert_eq!(plan_steps(&execution_plan).len(), 2);
+        assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
         let expected = vec!["Project", "Unwind"];
-        let mut current_rc = plan_root(&execution_plan);
+        let mut current_rc = skip_results_root_op(execution_plan.operation_tree()).clone();
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -476,7 +476,7 @@ mod tests {
     use crate::{
         test_utils::{
             create_async_test_client, imdb_async_test_client, open_empty_async_test_graph,
-            retry_until_async, skip_results_root, skip_results_root_op,
+            retry_until_async, skip_results_root,
         },
         ConstraintType, FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -1054,8 +1054,12 @@ mod tests {
 
         assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
+        let mut current_rc = execution_plan.operation_tree().clone();
+        if current_rc.name == "Results" {
+            current_rc = current_rc.children[0].clone();
+        }
+
         let expected = vec!["Project", "Unwind"];
-        let mut current_rc = skip_results_root_op(execution_plan.operation_tree()).clone();
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -476,7 +476,7 @@ mod tests {
     use crate::{
         test_utils::{
             create_async_test_client, imdb_async_test_client, open_empty_async_test_graph,
-            retry_until_async,
+            plan_root, plan_steps, retry_until_async,
         },
         ConstraintType, FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -1024,13 +1024,14 @@ mod tests {
         let mut graph = imdb_async_test_client().await.select_graph("imdb");
 
         let execution_plan = graph.explain("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().await.expect("Could not create execution plan");
-        assert_eq!(execution_plan.plan().len(), 7);
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
+        let steps = plan_steps(&execution_plan);
+        assert_eq!(steps.len(), 6);
         assert_eq!(
-            execution_plan.string_representation(),
-            "\nResults\n    Limit\n        Aggregate\n            Filter\n                Node By Index Scan | (b:actor)\n                    Project\n                        Node By Label Scan | (a:actor)"
+            steps.join("\n"),
+            "Limit\n    Aggregate\n        Filter\n            Node By Index Scan | (b:actor)\n                Project\n                    Node By Label Scan | (a:actor)"
         );
     }
 
@@ -1045,10 +1046,10 @@ mod tests {
             .await
             .expect("Could not generate the query");
 
-        assert_eq!(execution_plan.plan().len(), 3);
+        assert_eq!(plan_steps(&execution_plan).len(), 2);
 
-        let expected = vec!["Results", "Project", "Unwind"];
-        let mut current_rc = execution_plan.operation_tree().clone();
+        let expected = vec!["Project", "Unwind"];
+        let mut current_rc = plan_root(&execution_plan);
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/graph/asynchronous.rs
+++ b/src/graph/asynchronous.rs
@@ -474,9 +474,10 @@ impl AsyncGraph {
 mod tests {
     use super::*;
     use crate::{
+        response::execution_plan::skip_results_root,
         test_utils::{
             create_async_test_client, imdb_async_test_client, open_empty_async_test_graph,
-            retry_until_async, skip_results_root,
+            retry_until_async,
         },
         ConstraintType, FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -1027,6 +1028,8 @@ mod tests {
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
+        // FalkorDB up to 4.2 roots the plan in a `Results` operation that newer servers no
+        // longer plan, so assert on the operations below it to pass on both generations.
         let steps = skip_results_root(execution_plan.plan());
         assert_eq!(
             steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
@@ -1052,6 +1055,7 @@ mod tests {
             .await
             .expect("Could not generate the query");
 
+        // As in `test_explain`, ignore the legacy `Results` root the server may still plan.
         assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
         let mut current_rc = execution_plan.operation_tree().clone();

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -464,10 +464,8 @@ impl HasGraphSchema for SyncGraph {
 mod tests {
     use super::*;
     use crate::{
-        test_utils::{
-            create_test_client, imdb_test_client, open_empty_test_graph, retry_until,
-            skip_results_root,
-        },
+        response::execution_plan::skip_results_root,
+        test_utils::{create_test_client, imdb_test_client, open_empty_test_graph, retry_until},
         FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
 
@@ -958,6 +956,8 @@ mod tests {
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
+        // FalkorDB up to 4.2 roots the plan in a `Results` operation that newer servers no
+        // longer plan, so assert on the operations below it to pass on both generations.
         let steps = skip_results_root(execution_plan.plan());
         assert_eq!(
             steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
@@ -982,6 +982,7 @@ mod tests {
             .execute()
             .expect("Could not generate the query");
 
+        // As in `test_explain`, ignore the legacy `Results` root the server may still plan.
         assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
         let mut current_rc = execution_plan.operation_tree().clone();

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -465,8 +465,8 @@ mod tests {
     use super::*;
     use crate::{
         test_utils::{
-            create_test_client, imdb_test_client, open_empty_test_graph, plan_root, plan_steps,
-            retry_until,
+            create_test_client, imdb_test_client, open_empty_test_graph, retry_until,
+            skip_results_root, skip_results_root_op,
         },
         FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -958,11 +958,17 @@ mod tests {
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
-        let steps = plan_steps(&execution_plan);
-        assert_eq!(steps.len(), 6);
+        let steps = skip_results_root(execution_plan.plan());
         assert_eq!(
-            steps.join("\n"),
-            "Limit\n    Aggregate\n        Filter\n            Node By Index Scan | (b:actor)\n                Project\n                    Node By Label Scan | (a:actor)"
+            steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
+            [
+                "Limit",
+                "Aggregate",
+                "Filter",
+                "Node By Index Scan | (b:actor)",
+                "Project",
+                "Node By Label Scan | (a:actor)",
+            ]
         );
     }
 
@@ -976,10 +982,10 @@ mod tests {
             .execute()
             .expect("Could not generate the query");
 
-        assert_eq!(plan_steps(&execution_plan).len(), 2);
+        assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
         let expected = vec!["Project", "Unwind"];
-        let mut current_rc = plan_root(&execution_plan);
+        let mut current_rc = skip_results_root_op(execution_plan.operation_tree()).clone();
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -466,7 +466,7 @@ mod tests {
     use crate::{
         test_utils::{
             create_test_client, imdb_test_client, open_empty_test_graph, retry_until,
-            skip_results_root, skip_results_root_op,
+            skip_results_root,
         },
         FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
@@ -984,8 +984,12 @@ mod tests {
 
         assert_eq!(skip_results_root(execution_plan.plan()).len(), 2);
 
+        let mut current_rc = execution_plan.operation_tree().clone();
+        if current_rc.name == "Results" {
+            current_rc = current_rc.children[0].clone();
+        }
+
         let expected = vec!["Project", "Unwind"];
-        let mut current_rc = skip_results_root_op(execution_plan.operation_tree()).clone();
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/graph/blocking.rs
+++ b/src/graph/blocking.rs
@@ -464,7 +464,10 @@ impl HasGraphSchema for SyncGraph {
 mod tests {
     use super::*;
     use crate::{
-        test_utils::{create_test_client, imdb_test_client, open_empty_test_graph, retry_until},
+        test_utils::{
+            create_test_client, imdb_test_client, open_empty_test_graph, plan_root, plan_steps,
+            retry_until,
+        },
         FalkorDBError, IndexStatus, IndexType, WaitOptions,
     };
 
@@ -952,13 +955,14 @@ mod tests {
         let mut graph = imdb_test_client().select_graph("imdb");
 
         let execution_plan = graph.explain("MATCH (a:actor) WITH a MATCH (b:actor) WHERE a.age = b.age AND a <> b RETURN a, collect(b) LIMIT 100").execute().expect("Could not create execution plan");
-        assert_eq!(execution_plan.plan().len(), 7);
         assert!(execution_plan.operations().get("Aggregate").is_some());
         assert_eq!(execution_plan.operations()["Aggregate"].len(), 1);
 
+        let steps = plan_steps(&execution_plan);
+        assert_eq!(steps.len(), 6);
         assert_eq!(
-            execution_plan.string_representation(),
-            "\nResults\n    Limit\n        Aggregate\n            Filter\n                Node By Index Scan | (b:actor)\n                    Project\n                        Node By Label Scan | (a:actor)"
+            steps.join("\n"),
+            "Limit\n    Aggregate\n        Filter\n            Node By Index Scan | (b:actor)\n                Project\n                    Node By Label Scan | (a:actor)"
         );
     }
 
@@ -972,10 +976,10 @@ mod tests {
             .execute()
             .expect("Could not generate the query");
 
-        assert_eq!(execution_plan.plan().len(), 3);
+        assert_eq!(plan_steps(&execution_plan).len(), 2);
 
-        let expected = vec!["Results", "Project", "Unwind"];
-        let mut current_rc = execution_plan.operation_tree().clone();
+        let expected = vec!["Project", "Unwind"];
+        let mut current_rc = plan_root(&execution_plan);
         for step in expected {
             assert_eq!(current_rc.name, step);
             if step != "Unwind" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,6 +1164,44 @@ pub(crate) mod test_utils {
         client
     }
 
+    /// Root operation FalkorDB up to 4.2 puts at the top of every execution plan. Newer
+    /// servers no longer plan it, so tests that assert on plan shape normalize it away via
+    /// [`plan_steps`] and [`plan_root`] and pass on both server generations.
+    const LEGACY_RESULTS_ROOT: &str = "Results";
+
+    /// Execution-plan steps with the legacy `Results` root removed and the remaining steps
+    /// de-indented by the level it added, leaving only the operations the server planned.
+    /// A step is `<name>[ | <args or profile stats>]`, so only the leading name is matched.
+    pub(crate) fn plan_steps(plan: &ExecutionPlan) -> Vec<String> {
+        let steps = plan.plan();
+        let has_results_root = steps
+            .first()
+            .and_then(|step| step.split('|').next())
+            .is_some_and(|name| name.trim() == LEGACY_RESULTS_ROOT);
+        match has_results_root {
+            true => steps[1..]
+                .iter()
+                .map(|step| step.strip_prefix("    ").unwrap_or(step).to_string())
+                .collect(),
+            false => steps.to_vec(),
+        }
+    }
+
+    /// Root of the operation tree, skipping the legacy `Results` root when the server
+    /// still emits it.
+    pub(crate) fn plan_root(
+        plan: &ExecutionPlan
+    ) -> std::rc::Rc<crate::response::execution_plan::Operation> {
+        let root = plan.operation_tree();
+        match root.name == LEGACY_RESULTS_ROOT {
+            true => root
+                .children
+                .first()
+                .map_or_else(|| std::rc::Rc::clone(root), std::rc::Rc::clone),
+            false => std::rc::Rc::clone(root),
+        }
+    }
+
     pub(crate) fn open_empty_test_graph(graph_name: &str) -> TestSyncGraphHandle {
         let client = create_test_client();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,16 +1164,6 @@ pub(crate) mod test_utils {
         client
     }
 
-    /// Execution-plan steps without the `Results` root operation that FalkorDB up to 4.2 puts
-    /// above every plan and newer servers no longer plan. `GRAPH.PROFILE` appends per-operation
-    /// statistics to the step, hence the second form.
-    pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
-        match steps.first() {
-            Some(root) if root == "Results" || root.starts_with("Results |") => &steps[1..],
-            _ => steps,
-        }
-    }
-
     pub(crate) fn open_empty_test_graph(graph_name: &str) -> TestSyncGraphHandle {
         let client = create_test_client();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1169,10 +1169,11 @@ pub(crate) mod test_utils {
     const LEGACY_RESULTS_ROOT: &str = "Results";
 
     /// Execution-plan steps without the legacy `Results` root. A step is
-    /// `<name>[ | <args or profile stats>]`, so only the leading name is matched.
+    /// `<name>[ | <args or profile stats>]`, so it is split on `|` — as `ExecutionPlan::parse`
+    /// does — and only the operation name is matched.
     pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
-        match steps.first().map(|step| step.trim_start()) {
-            Some(first) if first.starts_with(LEGACY_RESULTS_ROOT) => &steps[1..],
+        match steps.first().and_then(|step| step.split('|').next()) {
+            Some(name) if name.trim() == LEGACY_RESULTS_ROOT => &steps[1..],
             _ => steps,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,41 +1164,26 @@ pub(crate) mod test_utils {
         client
     }
 
-    /// Root operation FalkorDB up to 4.2 puts at the top of every execution plan. Newer
-    /// servers no longer plan it, so tests that assert on plan shape normalize it away via
-    /// [`plan_steps`] and [`plan_root`] and pass on both server generations.
+    /// Root operation FalkorDB up to 4.2 puts at the top of every execution plan, which newer
+    /// servers no longer plan. Tests skip it so their assertions hold on both generations.
     const LEGACY_RESULTS_ROOT: &str = "Results";
 
-    /// Execution-plan steps with the legacy `Results` root removed and the remaining steps
-    /// de-indented by the level it added, leaving only the operations the server planned.
-    /// A step is `<name>[ | <args or profile stats>]`, so only the leading name is matched.
-    pub(crate) fn plan_steps(plan: &ExecutionPlan) -> Vec<String> {
-        let steps = plan.plan();
-        let has_results_root = steps
-            .first()
-            .and_then(|step| step.split('|').next())
-            .is_some_and(|name| name.trim() == LEGACY_RESULTS_ROOT);
-        match has_results_root {
-            true => steps[1..]
-                .iter()
-                .map(|step| step.strip_prefix("    ").unwrap_or(step).to_string())
-                .collect(),
-            false => steps.to_vec(),
+    /// Execution-plan steps without the legacy `Results` root. A step is
+    /// `<name>[ | <args or profile stats>]`, so only the leading name is matched.
+    pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
+        match steps.first().map(|step| step.trim_start()) {
+            Some(first) if first.starts_with(LEGACY_RESULTS_ROOT) => &steps[1..],
+            _ => steps,
         }
     }
 
-    /// Root of the operation tree, skipping the legacy `Results` root when the server
-    /// still emits it.
-    pub(crate) fn plan_root(
-        plan: &ExecutionPlan
-    ) -> std::rc::Rc<crate::response::execution_plan::Operation> {
-        let root = plan.operation_tree();
-        match root.name == LEGACY_RESULTS_ROOT {
-            true => root
-                .children
-                .first()
-                .map_or_else(|| std::rc::Rc::clone(root), std::rc::Rc::clone),
-            false => std::rc::Rc::clone(root),
+    /// Operation tree without the legacy `Results` root.
+    pub(crate) fn skip_results_root_op(
+        tree: &std::rc::Rc<crate::response::execution_plan::Operation>
+    ) -> &std::rc::Rc<crate::response::execution_plan::Operation> {
+        match tree.name == LEGACY_RESULTS_ROOT {
+            true => tree.children.first().unwrap_or(tree),
+            false => tree,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,27 +1164,13 @@ pub(crate) mod test_utils {
         client
     }
 
-    /// Root operation FalkorDB up to 4.2 puts at the top of every execution plan, which newer
-    /// servers no longer plan. Tests skip it so their assertions hold on both generations.
-    const LEGACY_RESULTS_ROOT: &str = "Results";
-
-    /// Execution-plan steps without the legacy `Results` root. A step is
-    /// `<name>[ | <args or profile stats>]`, so it is split on `|` — as `ExecutionPlan::parse`
-    /// does — and only the operation name is matched.
+    /// Execution-plan steps without the `Results` root operation that FalkorDB up to 4.2 puts
+    /// above every plan and newer servers no longer plan. `GRAPH.PROFILE` appends per-operation
+    /// statistics to the step, hence the second form.
     pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
-        match steps.first().and_then(|step| step.split('|').next()) {
-            Some(name) if name.trim() == LEGACY_RESULTS_ROOT => &steps[1..],
+        match steps.first() {
+            Some(root) if root == "Results" || root.starts_with("Results |") => &steps[1..],
             _ => steps,
-        }
-    }
-
-    /// Operation tree without the legacy `Results` root.
-    pub(crate) fn skip_results_root_op(
-        tree: &std::rc::Rc<crate::response::execution_plan::Operation>
-    ) -> &std::rc::Rc<crate::response::execution_plan::Operation> {
-        match tree.name == LEGACY_RESULTS_ROOT {
-            true => tree.children.first().unwrap_or(tree),
-            false => tree,
         }
     }
 

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -426,4 +426,52 @@ mod tests {
         assert!(plan.operations().contains_key("Scan"));
         assert!(plan.operations().contains_key("Filter"));
     }
+
+    fn parse_plan(steps: &[&str]) -> ExecutionPlan {
+        ExecutionPlan::parse(redis::Value::Array(
+            steps
+                .iter()
+                .map(|step| redis::Value::BulkString(step.as_bytes().to_vec()))
+                .collect(),
+        ))
+        .expect("Could not parse execution plan")
+    }
+
+    /// FalkorDB up to 4.2 roots every plan in a `Results` operation that newer servers no
+    /// longer plan, so the shared test helpers must normalize both shapes identically.
+    #[test]
+    fn test_plan_helpers_normalize_legacy_results_root() {
+        let legacy = parse_plan(&["Results", "    Project", "        Unwind"]);
+        let current = parse_plan(&["Project", "    Unwind"]);
+        let expected = vec!["Project".to_string(), "    Unwind".to_string()];
+
+        assert_eq!(crate::test_utils::plan_steps(&legacy), expected);
+        assert_eq!(crate::test_utils::plan_steps(&current), expected);
+        assert_eq!(crate::test_utils::plan_root(&legacy).name, "Project");
+        assert_eq!(crate::test_utils::plan_root(&current).name, "Project");
+    }
+
+    /// `GRAPH.PROFILE` appends per-operation statistics to every step, so the root is matched
+    /// on its operation name rather than the whole line.
+    #[test]
+    fn test_plan_helpers_normalize_profiled_results_root() {
+        let profiled = parse_plan(&[
+            "Results | Records produced: 1001, Execution time: 0.084527 ms",
+            "    Project | Records produced: 1001, Execution time: 0.104004 ms",
+            "        Unwind | Records produced: 1001, Execution time: 0.062085 ms",
+        ]);
+
+        assert_eq!(crate::test_utils::plan_steps(&profiled).len(), 2);
+        assert_eq!(crate::test_utils::plan_root(&profiled).name, "Project");
+    }
+
+    /// A `Results` root with no children cannot be skipped, so it is returned as-is rather
+    /// than panicking.
+    #[test]
+    fn test_plan_root_keeps_childless_results_root() {
+        let plan = parse_plan(&["Results"]);
+
+        assert_eq!(crate::test_utils::plan_root(&plan).name, "Results");
+        assert!(crate::test_utils::plan_steps(&plan).is_empty());
+    }
 }

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -440,38 +440,53 @@ mod tests {
     /// FalkorDB up to 4.2 roots every plan in a `Results` operation that newer servers no
     /// longer plan, so the shared test helpers must normalize both shapes identically.
     #[test]
-    fn test_plan_helpers_normalize_legacy_results_root() {
+    fn test_skip_results_root_normalizes_both_plan_shapes() {
         let legacy = parse_plan(&["Results", "    Project", "        Unwind"]);
         let current = parse_plan(&["Project", "    Unwind"]);
-        let expected = vec!["Project".to_string(), "    Unwind".to_string()];
 
-        assert_eq!(crate::test_utils::plan_steps(&legacy), expected);
-        assert_eq!(crate::test_utils::plan_steps(&current), expected);
-        assert_eq!(crate::test_utils::plan_root(&legacy).name, "Project");
-        assert_eq!(crate::test_utils::plan_root(&current).name, "Project");
+        for plan in [&legacy, &current] {
+            let steps = crate::test_utils::skip_results_root(plan.plan());
+            assert_eq!(
+                steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
+                ["Project", "Unwind"]
+            );
+            assert_eq!(
+                crate::test_utils::skip_results_root_op(plan.operation_tree()).name,
+                "Project"
+            );
+        }
     }
 
     /// `GRAPH.PROFILE` appends per-operation statistics to every step, so the root is matched
-    /// on its operation name rather than the whole line.
+    /// on its leading operation name rather than the whole line.
     #[test]
-    fn test_plan_helpers_normalize_profiled_results_root() {
+    fn test_skip_results_root_matches_profiled_root() {
         let profiled = parse_plan(&[
             "Results | Records produced: 1001, Execution time: 0.084527 ms",
             "    Project | Records produced: 1001, Execution time: 0.104004 ms",
             "        Unwind | Records produced: 1001, Execution time: 0.062085 ms",
         ]);
 
-        assert_eq!(crate::test_utils::plan_steps(&profiled).len(), 2);
-        assert_eq!(crate::test_utils::plan_root(&profiled).name, "Project");
+        assert_eq!(
+            crate::test_utils::skip_results_root(profiled.plan()).len(),
+            2
+        );
+        assert_eq!(
+            crate::test_utils::skip_results_root_op(profiled.operation_tree()).name,
+            "Project"
+        );
     }
 
-    /// A `Results` root with no children cannot be skipped, so it is returned as-is rather
-    /// than panicking.
+    /// A childless `Results` root has nothing to skip to, so it is returned as-is rather than
+    /// panicking.
     #[test]
-    fn test_plan_root_keeps_childless_results_root() {
+    fn test_skip_results_root_keeps_childless_root() {
         let plan = parse_plan(&["Results"]);
 
-        assert_eq!(crate::test_utils::plan_root(&plan).name, "Results");
-        assert!(crate::test_utils::plan_steps(&plan).is_empty());
+        assert!(crate::test_utils::skip_results_root(plan.plan()).is_empty());
+        assert_eq!(
+            crate::test_utils::skip_results_root_op(plan.operation_tree()).name,
+            "Results"
+        );
     }
 }

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -438,55 +438,25 @@ mod tests {
     }
 
     /// FalkorDB up to 4.2 roots every plan in a `Results` operation that newer servers no
-    /// longer plan, so the shared test helpers must normalize both shapes identically.
+    /// longer plan, and `GRAPH.PROFILE` appends statistics to that step, so all three forms
+    /// must normalize to the same operations.
     #[test]
-    fn test_skip_results_root_normalizes_both_plan_shapes() {
-        let legacy = parse_plan(&["Results", "    Project", "        Unwind"]);
-        let current = parse_plan(&["Project", "    Unwind"]);
+    fn test_skip_results_root() {
+        let plans = [
+            parse_plan(&["Results", "    Project", "        Unwind"]),
+            parse_plan(&["Project", "    Unwind"]),
+            parse_plan(&[
+                "Results | Records produced: 1001, Execution time: 0.084527 ms",
+                "    Project | Records produced: 1001, Execution time: 0.104004 ms",
+                "        Unwind | Records produced: 1001, Execution time: 0.062085 ms",
+            ]),
+        ];
 
-        for plan in [&legacy, &current] {
+        for plan in &plans {
             let steps = crate::test_utils::skip_results_root(plan.plan());
-            assert_eq!(
-                steps.iter().map(|step| step.trim()).collect::<Vec<_>>(),
-                ["Project", "Unwind"]
-            );
-            assert_eq!(
-                crate::test_utils::skip_results_root_op(plan.operation_tree()).name,
-                "Project"
-            );
+            assert_eq!(steps.len(), 2);
+            assert!(steps[0].trim_start().starts_with("Project"));
+            assert!(steps[1].trim_start().starts_with("Unwind"));
         }
-    }
-
-    /// `GRAPH.PROFILE` appends per-operation statistics to every step, so the root is matched
-    /// on its leading operation name rather than the whole line.
-    #[test]
-    fn test_skip_results_root_matches_profiled_root() {
-        let profiled = parse_plan(&[
-            "Results | Records produced: 1001, Execution time: 0.084527 ms",
-            "    Project | Records produced: 1001, Execution time: 0.104004 ms",
-            "        Unwind | Records produced: 1001, Execution time: 0.062085 ms",
-        ]);
-
-        assert_eq!(
-            crate::test_utils::skip_results_root(profiled.plan()).len(),
-            2
-        );
-        assert_eq!(
-            crate::test_utils::skip_results_root_op(profiled.operation_tree()).name,
-            "Project"
-        );
-    }
-
-    /// A childless `Results` root leaves no steps behind, and nothing for the tree helper to
-    /// skip to — so the tree root is returned as-is rather than panicking.
-    #[test]
-    fn test_skip_results_root_keeps_childless_root() {
-        let plan = parse_plan(&["Results"]);
-
-        assert!(crate::test_utils::skip_results_root(plan.plan()).is_empty());
-        assert_eq!(
-            crate::test_utils::skip_results_root_op(plan.operation_tree()).name,
-            "Results"
-        );
     }
 }

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -477,8 +477,8 @@ mod tests {
         );
     }
 
-    /// A childless `Results` root has nothing to skip to, so it is returned as-is rather than
-    /// panicking.
+    /// A childless `Results` root leaves no steps behind, and nothing for the tree helper to
+    /// skip to — so the tree root is returned as-is rather than panicking.
     #[test]
     fn test_skip_results_root_keeps_childless_root() {
         let plan = parse_plan(&["Results"]);

--- a/src/response/execution_plan.rs
+++ b/src/response/execution_plan.rs
@@ -269,6 +269,18 @@ impl ExecutionPlan {
     }
 }
 
+/// Execution-plan steps without the `Results` root operation that FalkorDB up to 4.2 puts above
+/// every plan and newer servers no longer plan. `GRAPH.PROFILE` appends per-operation statistics
+/// to the step, hence the second form. Test-only: the client is indifferent to the root, only
+/// assertions on a plan's shape have to be.
+#[cfg(test)]
+pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
+    match steps.first() {
+        Some(root) if root == "Results" || root.starts_with("Results |") => &steps[1..],
+        _ => steps,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,36 +439,30 @@ mod tests {
         assert!(plan.operations().contains_key("Filter"));
     }
 
-    fn parse_plan(steps: &[&str]) -> ExecutionPlan {
-        ExecutionPlan::parse(redis::Value::Array(
-            steps
-                .iter()
-                .map(|step| redis::Value::BulkString(step.as_bytes().to_vec()))
-                .collect(),
-        ))
-        .expect("Could not parse execution plan")
-    }
-
-    /// FalkorDB up to 4.2 roots every plan in a `Results` operation that newer servers no
-    /// longer plan, and `GRAPH.PROFILE` appends statistics to that step, so all three forms
-    /// must normalize to the same operations.
+    /// FalkorDB up to 4.2 roots every plan in a `Results` operation that newer servers no longer
+    /// plan, and `GRAPH.PROFILE` appends statistics to that step. Only one of those forms can be
+    /// produced by the server a given test run targets, so both are asserted here directly.
     #[test]
     fn test_skip_results_root() {
-        let plans = [
-            parse_plan(&["Results", "    Project", "        Unwind"]),
-            parse_plan(&["Project", "    Unwind"]),
-            parse_plan(&[
+        let steps = |steps: &[&str]| steps.iter().map(ToString::to_string).collect::<Vec<_>>();
+
+        assert_eq!(
+            skip_results_root(&steps(&["Results", "    Project"])),
+            ["    Project"]
+        );
+        assert_eq!(
+            skip_results_root(&steps(&[
                 "Results | Records produced: 1001, Execution time: 0.084527 ms",
                 "    Project | Records produced: 1001, Execution time: 0.104004 ms",
-                "        Unwind | Records produced: 1001, Execution time: 0.062085 ms",
-            ]),
-        ];
+            ])),
+            ["    Project | Records produced: 1001, Execution time: 0.104004 ms"]
+        );
 
-        for plan in &plans {
-            let steps = crate::test_utils::skip_results_root(plan.plan());
-            assert_eq!(steps.len(), 2);
-            assert!(steps[0].trim_start().starts_with("Project"));
-            assert!(steps[1].trim_start().starts_with("Unwind"));
-        }
+        // Already rootless, and an operation merely starting with `Results`: both kept whole.
+        assert_eq!(
+            skip_results_root(&steps(&["Project", "    Unwind"])),
+            ["Project", "    Unwind"]
+        );
+        assert_eq!(skip_results_root(&steps(&["ResultsFoo"])), ["ResultsFoo"]);
     }
 }


### PR DESCRIPTION
## Summary

The nightly `Code Coverage` run (which tests against `falkordb/falkordb:edge`, unlike PR runs
which use `latest`) has been failing since 14 Aug with
`assertion left == right failed, left: 6, right: 7` in `test_explain`
([run 31916597492](https://github.com/FalkorDB/falkordb-rs/actions/runs/31916597492)).

Root cause: FalkorDB's planner no longer emits the `Results` root operation at the top of
`GRAPH.EXPLAIN` / `GRAPH.PROFILE` output. Verified locally against both images:

```
# falkordb/falkordb:latest (module ver 42003)     # falkordb/falkordb:edge (unreleased)
Results                                            Limit
    Limit                                              Aggregate
        Aggregate                                          Filter
            Filter                                             Node By Index Scan | (b:actor)
                Node By Index Scan | (b:actor)                     Project
                    Project                                            Node By Label Scan | (a:actor)
                        Node By Label Scan | (a:actor)
```

The failure is **still relevant and not fixed** — it reproduces on today's `edge` and will hit
PR CI too once the next FalkorDB release promotes this to `latest`. Because the nightly run
fail-fasts, it only reported `test_explain`; `test_profile` (which asserts the same root) fails
for the same reason, in both the sync and async modules — 4 tests total.

The client itself needs no change: `ExecutionPlan::parse` already handles either shape. Only the
test assertions hardcoded the old root.

## Changes

- Add one test helper, `test_utils::skip_results_root`, which drops the first plan step when it
  is the `Results` root (`GRAPH.PROFILE` appends stats to it, hence the second form):

  ```rust
  pub(crate) fn skip_results_root(steps: &[String]) -> &[String] {
      match steps.first() {
          Some(root) if root == "Results" || root.starts_with("Results |") => &steps[1..],
          _ => steps,
      }
  }
  ```

- `test_explain` (sync + async) asserts on the trimmed step names past that root, so it does not
  care which indentation level the server's plan starts at.
- `test_profile` (sync + async) skips the tree root with a plain `if current_rc.name == "Results"`
  — the parsed operation name is exactly `Results`, so no helper is needed there.
- One server-free unit test parses all three plan shapes (legacy, current and profiled) and
  asserts they normalize to the same operations.
- `CHANGELOG.md` entry.

## Testing

Full suite (`just test`, 680 tests) run against **both** images, populated with the IMDB fixture:

- `falkordb/falkordb:latest` — 680 passed, 3 skipped
- `falkordb/falkordb:edge` — 680 passed, 3 skipped (previously 4 failures)

Static gates: `just ci` green (`fmt-check`, `clippy`, `build`, `doc`, `doctest`,
`build-examples`, `deny`, `check-llms`, `check-readme`), plus `just spellcheck` and
`PR_TITLE=… just check-pr-title`.

> Note: `just clippy-all` fails on `main` too (pre-existing `dead_code` on
> `check_macos_libomp` under `--all-features` on Linux); it is not part of the CI gate set and is
> untouched by this PR.

## Memory / Performance Impact

N/A — test-only change.

## Related Issues

Fixes the recurring scheduled-run failure reported by
[run 31916597492](https://github.com/FalkorDB/falkordb-rs/actions/runs/31916597492)
(also failed 14 and 15 Aug for the same reason).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved execution-plan validation for graph explanation and profiling results.
  * Tests now support responses both with and without the legacy `Results` root operation.
  * Added coverage for profiled plans, rootless plans, and operation names beginning with “Results.”

* **Documentation**
  * Added an Unreleased changelog entry describing the updated compatibility coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
