### PR TITLE
ci: run the library tests on the daily edge job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -110,6 +110,12 @@ jobs:
           cache-targets: "false"
           cache-bin: "false"
 
+      # The library tests query the shared `imdb` fixture, so it has to exist
+      # before they run. Only the coverage job populated it until now, which is
+      # part of why these tests were never run here.
+      - name: Populate test graph
+        run: pip install falkordb && just db-populate
+
       - name: Run integration tests
         run: just integration
 
@@ -176,6 +182,12 @@ jobs:
           # prevents the crates.io refetch that flaked, with no stale-artifact risk.
           cache-targets: "false"
           cache-bin: "false"
+
+      # The library tests query the shared `imdb` fixture, so it has to exist
+      # before they run. Only the coverage job populated it until now, which is
+      # part of why these tests were never run here.
+      - name: Populate test graph
+        run: pip install falkordb && just db-populate
 
       - name: Run async integration tests
         run: just integration --features tokio

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,6 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: falkordb-version
 
+    # Without this the job inherits the six hour default, so a hung suite
+    # holds a runner all morning and then reports `cancelled`, not `failure`.
+    timeout-minutes: 30
+
     services:
       falkordb:
         # Tag resolved by the `falkordb-version` job above.
@@ -115,6 +119,10 @@ jobs:
   integration-tests-tokio:
     runs-on: ubuntu-latest
     needs: falkordb-version
+
+    # Without this the job inherits the six hour default, so a hung suite
+    # holds a runner all morning and then reports `cancelled`, not `failure`.
+    timeout-minutes: 30
 
     services:
       falkordb:
@@ -180,7 +188,10 @@ jobs:
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [falkordb-version, integration-tests, integration-tests-tokio]
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    # `cancelled` as well as `failure`: a job stopped by its own timeout, or by
+    # GitHub's six hour ceiling, reports `cancelled`, and a nightly that hangs is
+    # exactly the case this alert exists for.
+    if: ${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: write
     # Pinned, and only the one secret it declares is passed: a mutable ref

--- a/Justfile
+++ b/Justfile
@@ -113,12 +113,16 @@ check-embedded-bundle:
     cargo build --features embedded-bundle --example embedded_usage
     cargo test --features embedded-bundle --lib embedded::bundle
 
-# Run the integration_tests binary with the given cargo args, exactly as the
-# integration CI jobs do. Examples: `just integration`,
+# Run the library and integration tests with the given cargo args, exactly as
+# the integration CI jobs do. Examples: `just integration`,
 # `just integration --features tokio`, `just integration --all-features`.
+#
+# --lib matters: a large share of the tests that talk to a live server live in
+# the library itself (src/graph/blocking.rs, src/graph/asynchronous.rs), so
+# selecting only --test integration_tests silently skipped them in CI.
 integration *args:
     FALKORDB_HOST={{host}} FALKORDB_PORT={{port}} \
-        cargo test --test integration_tests {{args}} --verbose
+        cargo test --lib --test integration_tests {{args}} --verbose
 
 # Run a single test by name filter, e.g. `just test-one test_borrow_connection`.
 test-one filter:


### PR DESCRIPTION
The daily `edge` job runs 32 tests out of 410.

`just integration` selects only the integration binary:

```
cargo test --test integration_tests {{args}} --verbose
```

Most of the tests that talk to a live server live in the library itself,
under `src/client/` and `src/graph/`, and `--test` excludes them. So the job
has been green while real failures sat behind the target selection.

Two changes make it run for real:

**1. `--lib` in the `integration` recipe**, so the library tests run too.

**2. `just db-populate` before the tests.** The library tests query the
shared `imdb` fixture, and only the coverage job was loading it. Without
this, 12 tests fail on a missing fixture rather than on anything real —
which is a good part of why they were excluded in the first place.

Verified locally against both images, with the fixture loaded:

```
latest:  409 passed;  0 failed
edge:    407 passed;  2 failed   (test_explain, test_profile)
```

So PRs, which run `latest`, stay green. The daily `edge` run will go red on
`graph::blocking::tests::test_explain` and `test_profile` — the plan shape
drift that the job exists to surface. Worth its own PR; the job is
non-blocking and does not gate merges.

Also in here, same as the sibling PRs in the other clients:

- `report-scheduled-failure` now fires on `cancelled` as well as `failure`.
  A job stopped by a timeout, or by GitHub's six hour ceiling, reports
  `cancelled`, so the alert was skipped whenever a nightly hung.
- `timeout-minutes: 30` on both integration jobs, so a hang fails the same
  morning instead of holding a runner until the six hour ceiling.
